### PR TITLE
update CMS search index erry 15 minutes

### DIFF
--- a/designsafe/apps/search/tasks.py
+++ b/designsafe/apps/search/tasks.py
@@ -1,0 +1,11 @@
+from celery import shared_task
+import datetime
+import logging
+from django.core.management import call_command
+
+logger = logging.getLogger(__name__)
+
+@shared_task()
+def update_search_index():
+    logger.info("Updating search index")
+    call_command("rebuild_index", interactive=False)

--- a/designsafe/celery.py
+++ b/designsafe/celery.py
@@ -21,14 +21,14 @@ app = Celery('designsafe')
 app.config_from_object('django.conf:settings')
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
-# app.conf.update(
-#     CELERYBEAT_SCHEDULE = {
-#         'update_user_storages': {
-#             'task': 'designsafe.apps.api.tasks.update_user_storages',
-#             'schedule': crontab(hour=0, minute=0),
-#         }
-#     }
-# )
+app.conf.update(
+    CELERYBEAT_SCHEDULE = {
+        'update_user_storages': {
+            'task': 'designsafe.apps.search.tasks.update_search_index',
+            'schedule': crontab(minute="*/15"),
+        }
+    }
+)
 
 @app.task(bind=True)
 def debug_task(self):


### PR DESCRIPTION
We might want to isolate the celerybeat container into its own, right now it is running in the workers container. If we were to spin up more workers, we would get more beat schedulers...