### PR TITLE
DES-262: moving some of the E.S. settings around

### DIFF
--- a/designsafe/common_settings.py
+++ b/designsafe/common_settings.py
@@ -199,24 +199,6 @@ else:
     }
 
 
-# Haystack cms indexing settings
-if os.environ.get('DS_LOCAL_DEV', 'False').lower() == 'true':
-    HAYSTACK_CONNECTIONS = {
-        'default': {
-            'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
-            'URL': 'elasticsearch:9200/',
-            'INDEX_NAME': 'cms',
-        }
-    }
-else:
-    HAYSTACK_CONNECTIONS = {
-        'default': {
-            'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
-            'URL': 'designsafe-es01.tacc.utexas.edu:9200/',
-            'INDEX_NAME': 'cms',
-        }
-    }
-
 HAYSTACK_ROUTERS = ['aldryn_search.router.LanguageRouter', ]
 ALDRYN_SEARCH_DEFAULT_LANGUAGE = 'en'
 ALDRYN_SEARCH_REGISTER_APPHOOK = True

--- a/designsafe/elasticsearch_settings.py
+++ b/designsafe/elasticsearch_settings.py
@@ -1,7 +1,7 @@
 import os
 
 """Elastic search connection configuration"""
-if not (os.environ.get('DJANGO_DEBUG', 'False').lower() == 'true'):
+if (os.environ.get('DESIGNSAFE_ENVIRONMENT', 'dev').lower() == 'prod'):
     ELASTIC_SEARCH = {
         'cluster': {
             'hosts': [
@@ -12,6 +12,32 @@ if not (os.environ.get('DJANGO_DEBUG', 'False').lower() == 'true'):
         'default_index': 'designsafe',
         'published_index': 'nees'
     }
+
+    HAYSTACK_CONNECTIONS = {
+        'default': {
+            'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
+            'URL': 'designsafe-es01.tacc.utexas.edu:9200/',
+            'INDEX_NAME': 'cms',
+        }
+    }
+elif (os.environ.get('DESIGNSAFE_ENVIRONMENT', 'dev').lower() == 'staging'):
+    ELASTIC_SEARCH = {
+        'cluster': {
+            'hosts': [
+                'designsafe-es01-dev.tacc.utexas.edu',
+            ]
+        },
+        'default_index': 'designsafe',
+        'published_index': 'nees'
+    }
+
+    HAYSTACK_CONNECTIONS = {
+        'default': {
+            'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
+            'URL': 'designsafe-es01-dev.tacc.utexas.edu:9200/',
+            'INDEX_NAME': 'cms',
+        }
+    }
 else:
     ELASTIC_SEARCH = {
         'cluster': {
@@ -21,4 +47,11 @@ else:
         },
         'default_index': 'designsafe',
         'published_index': 'nees'
+    }
+    HAYSTACK_CONNECTIONS = {
+        'default': {
+            'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
+            'URL': 'elasticsearch:9200/',
+            'INDEX_NAME': 'cms',
+        }
     }


### PR DESCRIPTION
We will have to add a new env variable DESIGNSAFE_ENVIRONMENT to flop the different setups around. 
DESIGNSAFE_ENVIRONMENT=Prod
DESIGNSAFE_ENVIRONMENT=Staging

Or it will default to dev config of local dockerized elasticsearch