### PR TITLE
Opt in users to email subscriptions by default

### DIFF
--- a/designsafe/apps/accounts/migrations/0015_create_notification_preferences.py
+++ b/designsafe/apps/accounts/migrations/0015_create_notification_preferences.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+from django.conf import settings
+from django.apps import apps
+from django.db.models import Q
+
+
+def set_default_notification_prefs(apps, schema_editor):
+    # Find users with no prefs set
+    User = apps.get_model(settings.AUTH_USER_MODEL)
+    NotificationPreferences = apps.get_model(
+        "designsafe_accounts", "NotificationPreferences")
+    users = User.objects.filter(Q(notification_preferences__isnull=True))
+    for user in users:
+        prefs = NotificationPreferences(user=user)
+        prefs.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('designsafe_accounts', '0014_auto_20170911_1503'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_default_notification_prefs),
+    ]

--- a/designsafe/apps/auth/backends.py
+++ b/designsafe/apps/auth/backends.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from django.contrib.auth.backends import ModelBackend
 from django.core.exceptions import ValidationError
 from django.dispatch import receiver
-from designsafe.apps.accounts.models import DesignSafeProfile
+from designsafe.apps.accounts.models import DesignSafeProfile, NotificationPreferences
 from pytas.http import TASClient
 import logging
 import re
@@ -90,6 +90,12 @@ class TASBackend(ModelBackend):
                     profile = DesignSafeProfile(user=user)
                     profile.save()
 
+                try:
+                    prefs = NotificationPreferences.objects.get(user=user)
+                except NotificationPreferences.DoesNotExist:
+                    prefs = NotificationPreferences(user=user)
+                    prefs.save()
+
         return user
 
 
@@ -142,6 +148,12 @@ class AgaveOAuthBackend(ModelBackend):
                 except DesignSafeProfile.DoesNotExist:
                     profile = DesignSafeProfile(user=user)
                     profile.save()
+
+                try:
+                    prefs = NotificationPreferences.objects.get(user=user)
+                except NotificationPreferences.DoesNotExist:
+                    prefs = NotificationPreferences(user=user)
+                    prefs.save()
 
                 self.logger.info('Login successful for user "%s"' % username)
             else:


### PR DESCRIPTION
- Adds notification preferences to a user's model when they sign in, or when they create an account for the first time.
- Runs a migration to add a notification_preferences model to all current users where that model is null, just to be safe.