### PR TITLE
Remove nodeCount option for parallel apps - hotfix

### DIFF
--- a/designsafe/apps/workspace/static/designsafe/apps/workspace/scripts/controllers/application-form.js
+++ b/designsafe/apps/workspace/static/designsafe/apps/workspace/scripts/controllers/application-form.js
@@ -93,9 +93,9 @@
         /* job details */
         items = [];
         items.push('maxRunTime', 'name', 'archivePath');
-        if ($scope.data.app.parallelism == "PARALLEL") {
-          items.push('nodeCount');
-        }
+        // if ($scope.data.app.parallelism == "PARALLEL") {
+        //   items.push('nodeCount');
+        // }
         $scope.form.form.push({
           type: 'fieldset',
           readonly: $scope.data.needsLicense,

--- a/designsafe/apps/workspace/static/designsafe/apps/workspace/scripts/services/apps-service.js
+++ b/designsafe/apps/workspace/static/designsafe/apps/workspace/scripts/services/apps-service.js
@@ -152,16 +152,16 @@
         required: true
       };
 
-      schema.properties.nodeCount = {
-        title: 'Node Count (optional)',
-        description: `Number of requested process nodes for the job. Default number of nodes is ${app.defaultNodeCount}.`,
-        type: 'integer',
-        "minimum": 1,
-        "maximum": 12,
-        "format": "int64",
-        "validationMessage": "Must be an integer in the range 1 to 12.",
-        'x-schema-form': {placeholder: app.defaultNodeCount}
-      };
+      // schema.properties.nodeCount = {
+      //   title: 'Node Count (optional)',
+      //   description: `Number of requested process nodes for the job. Default number of nodes is ${app.defaultNodeCount}.`,
+      //   type: 'integer',
+      //   "minimum": 1,
+      //   "maximum": 12,
+      //   "format": "int64",
+      //   "validationMessage": "Must be an integer in the range 1 to 12.",
+      //   'x-schema-form': {placeholder: app.defaultNodeCount}
+      // };
 
       schema.properties.archivePath = {
         title: 'Job output archive location (optional)',


### PR DESCRIPTION
It appears that parallel apps have a hard defined Processors Per Node count (`defaultProcessorsPerNode`), and deviating from the `defaultNodeCount` can cause the job to fail. e.g. OpenSeesMP (Stampede 2) has a `defaultProcessorsPerNode` of 544, and a `defaultNodeCount` of 8, and allocates 544/8=68 processors per node. In order to work within this functionality we will need to add some logic to the job submission to calculate the correct `defaultProcessorsPerNode`, and test to make sure this process is correct.