### PR TITLE
Add functional 'nodeCount' field to job submission forms

### DIFF
--- a/designsafe/apps/workspace/static/designsafe/apps/workspace/scripts/controllers/application-form.js
+++ b/designsafe/apps/workspace/static/designsafe/apps/workspace/scripts/controllers/application-form.js
@@ -70,7 +70,6 @@
       });
 
       $scope.resetForm = function() {
-        console.log($scope.data.app);
         $scope.data.needsLicense = $scope.data.app.license.type && !$scope.data.app.license.enabled;
         $scope.form = {model: {}, readonly: $scope.data.needsLicense};
         $scope.form.schema = Apps.formSchema($scope.data.app);
@@ -98,9 +97,9 @@
         } else {
           items.push('maxRunTime', 'name', 'archivePath');
         }
-        // if ($scope.data.app.parallelism == "PARALLEL") {
-        //   items.push('nodeCount');
-        // }
+        if ($scope.data.app.parallelism == "PARALLEL") {
+          items.push('nodeCount');
+        }
         $scope.form.form.push({
           type: 'fieldset',
           readonly: $scope.data.needsLicense,
@@ -151,6 +150,11 @@
               }
             }
           });
+
+          // Calculate processorsPerNode if nodeCount parameter submitted
+          if (_.has(jobData, 'nodeCount')) {
+            jobData.processorsPerNode = jobData.nodeCount * ($scope.data.app.defaultProcessorsPerNode / $scope.data.app.defaultNodeCount);
+          }
 
           $scope.data.submitting = true;
           Jobs.submit(jobData).then(

--- a/designsafe/apps/workspace/static/designsafe/apps/workspace/scripts/services/apps-service.js
+++ b/designsafe/apps/workspace/static/designsafe/apps/workspace/scripts/services/apps-service.js
@@ -152,16 +152,16 @@
         required: true
       };
 
-      // schema.properties.nodeCount = {
-      //   title: 'Node Count (optional)',
-      //   description: `Number of requested process nodes for the job. Default number of nodes is ${app.defaultNodeCount}.`,
-      //   type: 'integer',
-      //   "minimum": 1,
-      //   "maximum": 12,
-      //   "format": "int64",
-      //   "validationMessage": "Must be an integer in the range 1 to 12.",
-      //   'x-schema-form': {placeholder: app.defaultNodeCount}
-      // };
+      schema.properties.nodeCount = {
+        title: 'Node Count (optional)',
+        description: `Number of requested process nodes for the job. Default number of nodes is ${app.defaultNodeCount}.`,
+        type: 'integer',
+        "minimum": 1,
+        "maximum": 12,
+        "format": "int64",
+        "validationMessage": "Must be an integer in the range 1 to 12.",
+        'x-schema-form': {placeholder: app.defaultNodeCount}
+      };
 
       schema.properties.archivePath = {
         title: 'Job output archive location (optional)',


### PR DESCRIPTION
- Reintroduces `nodeCount` as an available parameter for users to edit in job submissions for parallel apps. 
- Calculates `processorsPerNode` when `nodeCount != defaultNodeCount`, overwriting `defaultProcessorsPerNode` and allowing successful submission