### PR TITLE
Video functionality for data-depot

### DIFF
--- a/designsafe/apps/api/templates/designsafe/apps/api/agave/preview.html
+++ b/designsafe/apps/api/templates/designsafe/apps/api/agave/preview.html
@@ -73,8 +73,8 @@
             })(jQuery);
         </script>
     {% elif video_preview %}
-      <div>
-        <video width="400" controls preload="auto" autoplay>
+      <div align="center">
+        <video width="600" controls preload autoplay>
           <source src="{{video_preview}}" type="{{mimetype}}">
           Your browser is not capable of previewing this video. Please try downloading the file.
         </video>

--- a/designsafe/apps/api/templates/designsafe/apps/api/agave/preview.html
+++ b/designsafe/apps/api/templates/designsafe/apps/api/agave/preview.html
@@ -76,7 +76,7 @@
       <div>
         <video controls>
           <source src="{{video_preview}}" type="{{mimetype}}">
-          Your browser is not capable of previewing this video. Please try downloading the file.
+          <!-- Your browser is not capable of previewing this video. Please try downloading the file. -->
         </video>
       </div>
     {% else %}

--- a/designsafe/apps/api/templates/designsafe/apps/api/agave/preview.html
+++ b/designsafe/apps/api/templates/designsafe/apps/api/agave/preview.html
@@ -21,9 +21,9 @@
     {% if image_preview %}
         <div class="text-center">
             <img src="{{ image_preview }}" id="preview" style="max-width:100%;">
-            <div><i class="fa fa-spinner fa-spin" style="font-size: 150px" id="loading_ind"></i></div>
+            <!-- <div><i class="fa fa-spinner fa-spin" style="font-size: 150px" id="loading_ind"></i></div> -->
         </div>
-        {% addtoblock 'js' %}
+        <!-- {% addtoblock 'js' %}
         <script type="text/javascript">
         $('#preview').on('load', function() {
             $('#loading_ind').hide();
@@ -32,11 +32,11 @@
             $(this).hide().after('<p class="alert alert-danger">Unable to display preview.</p>');
         });
         </script>
-        {% endaddtoblock %}
+        {% endaddtoblock %} -->
     {% elif text_preview %}
         <div class="embed-responsive embed-responsive-4by3">
             <pre class="embed-responsive-item">{{ text_preview }}</pre>
-            <div><i class="fa fa-spinner fa-spin" style="font-size: 150px" id="loading_ind"></i></div>
+            <!-- <div><i class="fa fa-spinner fa-spin" style="font-size: 150px" id="loading_ind"></i></div> -->
         </div>
     {% elif object_preview %}
         <!--
@@ -44,7 +44,7 @@
             <object data="{{ object_preview }}" width="100%" height="100%"></object>
         </div>
         -->
-        <div><i class="fa fa-spinner fa-spin" style="font-size: 150px" id="loading_ind"></i></div>
+        <!-- <div><i class="fa fa-spinner fa-spin" style="font-size: 150px" id="loading_ind"></i></div> -->
         <iframe class="embed-responsive-item"
                 src="https://docs.google.com/gview?url={{object_preview}}&embedded=true"
                 frameborder="0"
@@ -59,7 +59,7 @@
             })(jQuery);
         </script>
     {% elif iframe_preview %}
-        <div><i class="fa fa-spinner fa-spin" style="font-size: 150px" id="loading_ind"></i></div>
+        <!-- <div><i class="fa fa-spinner fa-spin" style="font-size: 150px" id="loading_ind"></i></div> -->
         <iframe class="embed-responsive-item"
                 src="{{iframe_preview}}"
                 frameborder="0"

--- a/designsafe/apps/api/templates/designsafe/apps/api/agave/preview.html
+++ b/designsafe/apps/api/templates/designsafe/apps/api/agave/preview.html
@@ -74,9 +74,9 @@
         </script>
     {% elif video_preview %}
       <div>
-        <video controls>
+        <video width="400" controls preload="auto" autoplay>
           <source src="{{video_preview}}" type="{{mimetype}}">
-          <!-- Your browser is not capable of previewing this video. Please try downloading the file. -->
+          Your browser is not capable of previewing this video. Please try downloading the file.
         </video>
       </div>
     {% else %}

--- a/designsafe/apps/data/models/agave/files.py
+++ b/designsafe/apps/data/models/agave/files.py
@@ -166,7 +166,8 @@ class BaseFileResource(BaseAgaveResource):
     SUPPORTED_PREVIEW_EXTENSIONS = (SUPPORTED_IMAGE_PREVIEW_EXTS +
                                     SUPPORTED_TEXT_PREVIEW_EXTS +
                                     SUPPORTED_OBJECT_PREVIEW_EXTS + 
-                                    SUPPORTED_MS_OFFICE)
+                                    SUPPORTED_MS_OFFICE +
+                                    SUPPORTED_VIDEO_EXTS)
 
     def __init__(self, agave_client, system, path, **kwargs):
         super(BaseFileResource, self).__init__(agave_client, system=system, path=path,

--- a/designsafe/static/scripts/ng-designsafe/html/modals/data-browser-service-preview.html
+++ b/designsafe/static/scripts/ng-designsafe/html/modals/data-browser-service-preview.html
@@ -12,7 +12,16 @@
                 <i class="fa {{ file.icon() }}" style="font-size:150px"></i>
             </div>
             <div class="embed-responsive embed-responsive-4by3" ng-if="! busy && previewHref">
-                <iframe class="embed-responsive-item" ng-src="{{ previewHref }}"></iframe>
+                    <i class="fa fa-spinner fa-spin" style="font-size:150px;line-height:400px" id="loading_ind"></i>
+                <iframe class="embed-responsive-item" ng-src="{{ previewHref }}" id="framepreview"></iframe>
+                <script type="text/javascript">
+                    $('#framepreview').on('load', function() {
+                        $('#loading_ind').hide();
+                    }).on('error', function() {
+                        $('#loading_ind').hide();
+                        $(this).hide().after('<p class="alert alert-danger">Unable to display preview.</p>');
+                    });
+                </script>
             </div>
         </div>
         <div class="caption">


### PR DESCRIPTION
Videos should work in data-depot preview now, also fixed an issue where text files would continuously display a loading spinner even when fully rendered. Suggest moving spinner scripts from "preview.html" to "data-browser-service-preview.html" so that the loading spinner will constantly run through the multiple processes needed to retrieve files.