### PR TITLE
fix file selection bug when navigating between My Data and My Projects

### DIFF
--- a/designsafe/static/scripts/data-depot/controllers/projects.js
+++ b/designsafe/static/scripts/data-depot/controllers/projects.js
@@ -8,6 +8,9 @@
     DataBrowserService.apiParams.baseUrl = '/api/agave/files';
     DataBrowserService.apiParams.searchState = undefined;
 
+    // release selected files
+    DataBrowserService.deselect(DataBrowserService.state().selected);
+
     $scope.data = {
       navItems: [],
       projects: []
@@ -54,6 +57,12 @@
     $scope.ui = {};
     $scope.ui.busy = true;
     $scope.data.projects = [];
+
+
+    // release selected files on load
+    DataBrowserService.deselect(DataBrowserService.state().selected);
+
+
     ProjectService.list().then(function(projects) {
       $scope.ui.busy = false;
       $scope.data.projects = _.map(projects, function(p) { p.href = $state.href('projects.view', {projectId: p.uuid}); return p; });

--- a/designsafe/static/scripts/ng-designsafe/services/data-browser-service.js
+++ b/designsafe/static/scripts/ng-designsafe/services/data-browser-service.js
@@ -2216,6 +2216,7 @@
    */
 
   function selectProjects(projects, reset) {
+    deselect(currentState.selected);
     if (!Array.isArray(projects)) {
       projects = [projects];
     }


### PR DESCRIPTION
This pull request fixes issues with the Data Depot Toolbar when navigating between the My Data and My Projects section of the Data Depot. The bug is that if you make a file selection inside My Data and then navigate to the My Projects section, the Data Depot Toolbar is still enabled and will allow you to operate on the selected files from My Data (even though they are not visible).

This fixes the bug by deselecting files when the My Projects area is selected.