### PR TITLE
fixes to data depot search

### DIFF
--- a/designsafe/apps/api/agave/filemanager/search_index.py
+++ b/designsafe/apps/api/agave/filemanager/search_index.py
@@ -144,7 +144,7 @@ class Object(object):
         self._wrap.save()
         return self
 
-    def user_pems(self, user_context):
+    def user_pems(self, user_context = None):
         """Converts from ES pems to user specific pems
 
         When doing an agave file listing the permissions returned
@@ -169,8 +169,14 @@ class Object(object):
               Agave file listing permissions:
             `` 'permissions': 'ALL' ``
         """
-        pems = [pem for pem in getattr(self._wrap, 'permissions', {'username': ''}) if \
-                pem['username'] == user_context]
+        logger.debug(getattr(self._wrap, 'permissions', {'username': ''}))
+        logger.debug(user_context)
+        if user_context:
+            pems = [pem for pem in getattr(self._wrap, 'permissions', {'username': ''}) if \
+                    pem['username'] == user_context]
+            logger.debug(pems)
+        else:
+            pems = [pem for pem in getattr(self._wrap, 'permissions', {'username': ''})] 
         if not pems:
             return 'NONE'
 
@@ -184,16 +190,19 @@ class Object(object):
             user_pem += 'EXECUTE_'
 
         user_pem = user_pem.strip('_')
-        if user_pem == 'RED_WRITE_EXECUTE':
+        if user_pem == 'READ_WRITE_EXECUTE':
             user_pem = 'ALL'
 
         return user_pem
 
     def to_dict(self, user_context=None):
         file_dict = self._wrap.to_dict()
-        if user_context:
-            file_dict['permissions'] = self.user_pems(user_context)
-
+        logger.debug(file_dict['name'])
+        logger.debug(file_dict['permissions'])
+        #if user_context:
+        file_dict['permissions'] = self.user_pems(user_context)
+        #elif file_dict['system'] == 'designsafe.storage.community':
+        #    file_dict['permissions'] = "ALL"
         file_dict['path'] = os.path.join(self._wrap.path, self._wrap.name)
         file_dict['system'] = self._wrap['system']
         return file_dict
@@ -267,7 +276,7 @@ class ElasticFileManager(BaseFileManager):
             res = search.execute()
 
         listing = merge_file_paths(system, user_context, file_path, search)
-
+        logger.debug(file_path)
         if file_path == '/':
             result = {
                 'trail': [{'name': '$SHARE', 'path': '/$SHARE'}],
@@ -299,6 +308,7 @@ class ElasticFileManager(BaseFileManager):
 
         for f in listing:
             result['children'].append(f.to_dict(user_context=user_context))
+        #logger.debug(result['permissions'])
         return result
 
     def search(self, system, username, query_string,
@@ -316,16 +326,12 @@ class ElasticFileManager(BaseFileManager):
 
         """
         search = IndexedFile.search()
-        query = Q('bool',
-                  filter=Q('bool',
-                           must=[Q({'term': {'systemId': system}}),
-                                 Q({'term': {'permissions.username': username}}),
-                                 Q({'prefix': {'path._exact': username}})],
-                           must_not=[Q({'prefix': {'path._exact': '{}/.Trash'.format(username)}})]),
-                   must=Q({'simple_query_string':{
-                            'query': query_string,
-                            'fields': ['name', 'name._exact', 'keywords']}}))
-        search.query = query
+        search = search.filter("nested", path="permissions", query=Q("term", permissions__username=username))
+        search = search.query("simple_query_string", query=query_string, fields=["name", "name._exact", "keywords"])
+        
+        search = search.query(Q('bool', must=[Q({'prefix': {'path._exact': username}})]))
+        search = search.filter("term", system=system)
+        search = search.query(Q('bool', must_not=[Q({'prefix': {'path._exact': '{}/.Trash'.format(username)}})]))
         res = search.execute()
         children = []
         if res.hits.total:
@@ -385,6 +391,7 @@ class ElasticFileManager(BaseFileManager):
 
     def search_shared(self, system, username, query_string,
                file_path=None, offset=0, limit=100):
+        """
         search = IndexedFile.search()
         query = Q('bool',
                   filter=Q('bool',
@@ -392,11 +399,24 @@ class ElasticFileManager(BaseFileManager):
                                  Q({'term': {'permissions.username': username}})],
                            must_not=[Q({'prefix': {'path._exact': '{}/.Trash'.format(username)}}),
                                      Q({'prefix': {'path._exact': username}})]),
-                   must=Q({'simple_query_string':{
+                   must=Q({'query_string':{
                             'query': query_string,
                             'fields': ['name', 'name._exact', 'keywords']}}))
         search.query = query
         res = search.execute()
+        """
+
+        search = IndexedFile.search()
+        search = search.filter("nested", path="permissions", query=Q("term", permissions__username=username))
+        search = search.query("query_string", query=query_string, fields=["name", "name._exact", "keywords"])
+        
+        search = search.query(Q('bool', must_not=[Q({'prefix': {'path._exact': username}})]))
+        search = search.filter("term", system=system)
+        search = search.query(Q('bool', must_not=[Q({'prefix': {'path._exact': '{}/.Trash'.format(username)}})]))
+        res = search.execute()
+
+        res = search.execute()
+
         children = []
         if res.hits.total:
             children = [Object(wrap=o).to_dict() for o in search[offset:limit]]

--- a/designsafe/apps/api/agave/views.py
+++ b/designsafe/apps/api/agave/views.py
@@ -563,14 +563,8 @@ class FileSearchView(View):
 
         fmgr = ElasticFileManager()
         if not request.GET.get('shared', False):
-
-            if system_id == 'designsafe.storage.default':
-                listing = fmgr.search(system_id, request.user.username, query_string,
-                                    offset=offset, limit=limit)
-            elif system_id == 'designsafe.storage.community':
-                logger.debug("searching community...")
-                listing = fmgr.search_community('designsafe.storage.community', query_string,
-                                    offset=offset, limit=limit) 
+            listing = fmgr.search(system_id, request.user.username, query_string,
+                                offset=offset, limit=limit)
         else:
             listing = fmgr.search_shared(system_id, request.user.username, query_string,
                                          offset=offset, limit=limit)

--- a/designsafe/apps/api/public_data/views.py
+++ b/designsafe/apps/api/public_data/views.py
@@ -30,6 +30,7 @@ from designsafe.apps.api.agave import get_service_account_client
 from designsafe.apps.data.models.agave.files import BaseFileResource
 from designsafe.apps.data.models.agave.util import AgaveJSONEncoder
 from designsafe.apps.api.agave.filemanager.public_search_index import PublicElasticFileManager
+from designsafe.apps.api.agave.filemanager.search_index import ElasticFileManager
 from designsafe.apps.api.agave.filemanager.community import CommunityFileManager
 from designsafe.apps.api.agave.filemanager.published import PublishedFileManager
 from designsafe.apps.api.agave.views import FileMediaView
@@ -109,6 +110,7 @@ class PublicSearchView(BaseApiView):
     def get(self, request, file_mgr_name,
             system_id=None, file_path=None):
         """GET handler"""
+        logger.debug(system_id)
         offset = int(request.GET.get('offset', 0))
         limit = int(request.GET.get('limit', 100))
         query_string = request.GET.get('query_string')
@@ -123,9 +125,17 @@ class PublicSearchView(BaseApiView):
             ag = get_user_model().objects.get(username='envision').agave_oauth.client
         else:
             ag = request.user.agave_oauth.client
-        file_mgr = PublicElasticFileManager(ag)
-        listing = file_mgr.search(system_id, query_string,
-                                  offset=offset, limit=limit)
+        
+
+        if system_id == "nees.public":
+            file_mgr = PublicElasticFileManager(ag)
+            listing = file_mgr.search(system_id, query_string,
+                                    offset=offset, limit=limit)
+
+        elif system_id == "designsafe.storage.community":
+            file_mgr = ElasticFileManager()
+            listing = file_mgr.search_community('designsafe.storage.community', query_string,
+                                    offset=offset, limit=limit) 
         # logger.info(listing)
         return JsonResponse(listing)
 

--- a/designsafe/static/scripts/data-depot/app.js
+++ b/designsafe/static/scripts/data-depot/app.js
@@ -313,6 +313,37 @@
           }
         }
       })
+
+      .state('communityDataSearch',{
+        url: '/community-search/?query_string&offset&limit',
+        controller: 'CommunityDataCtrl',
+        templateUrl: '/static/scripts/data-depot/templates/search-public-data-listing.html',
+        params: {
+          systemId: 'nees.public',
+          filePath: '$SEARCH'
+        },
+        resolve: {
+          'listing': ['$stateParams', 'DataBrowserService', function($stateParams, DataBrowserService) {
+            var systemId = $stateParams.systemId || 'nees.public';
+            var filePath = $stateParams.filePath || '/';
+            DataBrowserService.apiParams.fileMgr = 'public';
+            DataBrowserService.apiParams.baseUrl = '/api/public/files';
+            DataBrowserService.apiParams.searchState = 'communityDataSearch';
+            var queryString = $stateParams.query_string;
+            if (/[^A-Za-z0-9]/.test(queryString)){
+              queryString = '"' + queryString + '"';
+            }
+            var options = {system: $stateParams.systemId, query_string: queryString, offset: $stateParams.offset, limit: $stateParams.limit};
+            console.log(options);
+            return DataBrowserService.search(options);
+          }],
+          'auth': function($q) {
+              return true;
+          }
+        }
+      })
+
+
       .state('communityData', {
         // url: '/community/',
         // template: '<pre>local/communityData.html</pre>'
@@ -334,7 +365,7 @@
             // }
             DataBrowserService.apiParams.fileMgr = 'community';
             DataBrowserService.apiParams.baseUrl = '/api/public/files';
-            DataBrowserService.apiParams.searchState = 'dataSearch';
+            DataBrowserService.apiParams.searchState = 'communityDataSearch';
             return DataBrowserService.browse(options);
           }],
           'auth': function($q) {

--- a/designsafe/static/scripts/data-depot/templates/data-depot-toolbar.html
+++ b/designsafe/static/scripts/data-depot/templates/data-depot-toolbar.html
@@ -11,7 +11,7 @@
         -->
     </div>
     <div class="btn-toolbar btn-toolbar-right" role="toolbar" aria-label="Data Browser Toolbar">
-        <form class="navbar-form navbar-left" ng-submit="ops.search()" style="display:flex">
+        <form class="navbar-form navbar-left" ng-submit="ops.search()" style="display:flex" ng-hide="placeholder() === 'My Projects'">
             <input class="form-control" style="width:240px;" placeholder="Find in {{ placeholder() }}" ng-model="search.queryString">
             <button class="btn btn-default" style="clear: right;"> <i class="fa fa-search"></i> </button>
         </form>

--- a/designsafe/static/scripts/data-depot/templates/data-depot-toolbar.html
+++ b/designsafe/static/scripts/data-depot/templates/data-depot-toolbar.html
@@ -11,7 +11,8 @@
         -->
     </div>
     <div class="btn-toolbar btn-toolbar-right" role="toolbar" aria-label="Data Browser Toolbar">
-        <form class="navbar-form navbar-left" ng-submit="ops.search()" style="display:flex" ng-hide="placeholder() === 'My Projects'">
+        <form class="navbar-form navbar-left" ng-submit="ops.search()" style="display:flex" 
+            ng-hide="['Dropbox', 'My Projects', 'Box', 'Google Drive'].includes(placeholder())">
             <input class="form-control" style="width:240px;" placeholder="Find in {{ placeholder() }}" ng-model="search.queryString">
             <button class="btn btn-default" style="clear: right;"> <i class="fa fa-search"></i> </button>
         </form>


### PR DESCRIPTION
Various fixes to search within the Data Depot.

- Searches in Community Data executed from the data depot will no longer redirect to the login screen for logged-out users.
- Community Data searches now show the correct options in the preview window based on user permissions.
- Searches in My Data/Shared with Me should work correctly now.
- Don't show the search bar while in My Projects.

![apr-23-2018 11-15-27 des-community search](https://user-images.githubusercontent.com/12601812/39139516-c1177378-46e7-11e8-9537-9c2f795d9137.gif)

