### PR TITLE
Show previews for files indexed with type other than 'file'

### DIFF
--- a/designsafe/static/scripts/data-depot/controllers/community.js
+++ b/designsafe/static/scripts/data-depot/controllers/community.js
@@ -53,7 +53,7 @@
       } else {
         filePath = file.path;
       }
-      if (file.type === 'file'){
+      if (typeof(file.type) !== 'undefined' && file.type !== 'dir' && file.type !== 'folder'){
         DataBrowserService.preview(file, $scope.browser.listing);
       } else {
         $state.go('communityData', {systemId: file.system, filePath: file.path});

--- a/designsafe/static/scripts/data-depot/controllers/external-data.js
+++ b/designsafe/static/scripts/data-depot/controllers/external-data.js
@@ -32,7 +32,7 @@
       $event.stopPropagation();
 
       var filePath = file.id;
-      if (file.type === 'file'){
+      if (typeof(file.type) !== 'undefined' && file.type !== 'dir' && file.type !== 'folder'){
         DataBrowserService.preview(file);
       } else {
         $state.go($state.current.name, {filePath: file.id});

--- a/designsafe/static/scripts/data-depot/controllers/my-data.js
+++ b/designsafe/static/scripts/data-depot/controllers/my-data.js
@@ -35,7 +35,7 @@
     $scope.onBrowse = function ($event, file) {
       $event.preventDefault();
       $event.stopPropagation();
-      if (file.type === 'file') {
+      if (typeof(file.type) !== 'undefined' && file.type !== 'dir' && file.type !== 'folder') {
         DataBrowserService.preview(file, $scope.browser.listing);
       } else {
         $state.go('myData', {systemId: file.system, filePath: file.path});

--- a/designsafe/static/scripts/data-depot/controllers/projects.js
+++ b/designsafe/static/scripts/data-depot/controllers/projects.js
@@ -721,7 +721,7 @@
     $scope.onBrowseData = function onBrowseData($event, file) {
       $event.preventDefault();
       DataBrowserService.showListing();
-      if (file.type === 'file') {
+      if (typeof(file.type) !== 'undefined' && file.type !== 'dir' && file.type !== 'folder') {
         DataBrowserService.preview(file, $scope.browser.listing);
       } else {
         $state.go('projects.view.data', {projectId: projectId,

--- a/designsafe/static/scripts/data-depot/controllers/publications.js
+++ b/designsafe/static/scripts/data-depot/controllers/publications.js
@@ -54,7 +54,7 @@
       } else {
         filePath = file.path;
       }
-      if (file.type === 'file'){
+      if (typeof(file.type) !== 'undefined' && file.type !== 'dir' && file.type !== 'folder'){
         DataBrowserService.preview(file, $scope.browser.listing);
       } else {
         if (file.system === 'nees.public'){

--- a/designsafe/static/scripts/data-depot/controllers/published.js
+++ b/designsafe/static/scripts/data-depot/controllers/published.js
@@ -126,7 +126,7 @@
       } else {
         filePath = file.path;
       }
-      if (file.type === 'file'){
+      if (typeof(file.type) !== 'undefined' && file.type !== 'dir' && file.type !== 'folder'){
         DataBrowserService.preview(file, $scope.browser.listing);
       } else {
         if (file.system === 'nees.public'){

--- a/designsafe/static/scripts/data-depot/controllers/shared-data.js
+++ b/designsafe/static/scripts/data-depot/controllers/shared-data.js
@@ -38,7 +38,7 @@
       } else {
         filePath = file.path;
       }
-      if (file.type === 'file'){
+      if (typeof(file.type) !== 'undefined' && file.type !== 'dir' && file.type !== 'folder'){
         DataBrowserService.preview(file, $scope.browser.listing);
       } else {
         $state.go('sharedData', {systemId: file.system, filePath: file.path});


### PR DESCRIPTION
Previous behavior: Files indexed with a `type` other than `"file"` in elasticsearch would be treated as empty folders in the data depot.

Change made: Instead of looking specifically for the `"file"` type, any document other than a folder/directory is now considered previewable.