### PR TITLE
Elasticsearch indexer works in local dev.

### DIFF
--- a/designsafe/apps/api/tasks.py
+++ b/designsafe/apps/api/tasks.py
@@ -22,9 +22,16 @@ def reindex_agave(self, username, file_id, full_indexing=True,
                   levels=1, pems_indexing=True, index_full_path=True):
     user = get_user_model().objects.get(username=username)
     #levels=1
-
+    
     from designsafe.apps.api.data import AgaveFileManager
+    from designsafe.apps.data.managers.indexer import AgaveIndexer as AgaveFileIndexer
     agave_fm = AgaveFileManager(user)
+    
+    if settings.DEBUG and username == 'ds_admin':
+        service_client = get_service_account_client()
+        agave_fm.agave_client = service_client
+        agave_fm.indexer = AgaveFileIndexer(agave_client=service_client)
+
     system_id, file_user, file_path = agave_fm.parse_file_id(file_id)
     if system_id != settings.AGAVE_STORAGE_SYSTEM:
         file_id_comps = file_id.strip('/').split('/')


### PR DESCRIPTION
Currently in local dev, running the `reindex_agave` task on file upload throws `401 Client Error: Unauthorized for url` because it's trying to use an expired access token for the `ds_admin` user. 

With this change we use the service account client to do these operations, since its access token doesn't expire.

The service account client is only used if Debug mode is active, so this change shouldn't affect staging/prod.