### PR TITLE
Task/des 509

### DIFF
--- a/designsafe/apps/api/agave/filemanager/public_search_index.py
+++ b/designsafe/apps/api/agave/filemanager/public_search_index.py
@@ -550,9 +550,15 @@ class PublicElasticFileManager(BaseFileManager):
                 projects_limit = projects_res.hits.total
                 files_limit = limit - projects_limit
         
+        des_published_query = Q('bool', must=[Q('simple_query_string', query=query_string)])
+        des_published_search = PublicationIndexed.search()\
+            .query(des_published_query)\
+            .extra(from_=offset, size=limit)
+
+        des_published_res = des_published_search.execute()
+        children = [Publication(res).to_file() for res in des_published_res]
+
         # TODO: This is rather SLOW
-        children = []
-  
         project_paths = [p.projectPath for p in projects_res]
         for project in projects_search[projects_offset:projects_limit]:
             logger.debug(project)

--- a/designsafe/apps/api/agave/filemanager/public_search_index.py
+++ b/designsafe/apps/api/agave/filemanager/public_search_index.py
@@ -508,20 +508,9 @@ class PublicElasticFileManager(BaseFileManager):
         else:
             projects_search = projects_search.sort('name._exact')
 
-        """
-        query = Q('bool', must=[Q('simple_query_string', query=query_string)])
-
-
-        projects_search = Search(index="des-publications_legacy,des-publications")\
-            .query(query)\
-            .extra(from_=offset, size=limit)
-        """
         t1 = datetime.datetime.now()
-        
         projects_res = projects_search.execute()
         logger.debug(datetime.datetime.now() - t1)
-
-        logger.debug(projects_res.hits.total)
 
         """
         files_search = PublicObjectIndexed.search()
@@ -539,6 +528,7 @@ class PublicElasticFileManager(BaseFileManager):
         files_res = files_search.execute()
         logger.debug(datetime.datetime.now() - t1)
         """
+
         if projects_res.hits.total:
             if projects_res.hits.total - offset > limit:
                 files_offset = 0
@@ -571,7 +561,7 @@ class PublicElasticFileManager(BaseFileManager):
             res = search.execute()
             if res.hits.total:
                 children.append(PublicObject(res[0]).to_dict())
-        # print children
+
         # search = PublicObjectIndexed.search()
         # search.query = Q('bool',
         #     must=[
@@ -584,6 +574,7 @@ class PublicElasticFileManager(BaseFileManager):
 
         # for r in res[projects_offset:projects_limit]:
         #     children.append(PublicObject(r).to_dict())
+        
         """
         for file_doc in files_search[files_offset:files_limit]:
             logger.debug(file_doc)

--- a/designsafe/static/scripts/data-depot/app.js
+++ b/designsafe/static/scripts/data-depot/app.js
@@ -289,7 +289,7 @@
       .state('publicDataSearch',{
         url: '/public-search/?query_string&offset&limit',
         controller: 'PublicationDataCtrl',
-        templateUrl: '/static/scripts/data-depot/templates/search-public-data-listing.html',
+        templateUrl: '/static/scripts/data-depot/templates/agave-public-data-listing.html',
         params: {
           systemId: 'nees.public',
           filePath: '$SEARCH'

--- a/designsafe/static/scripts/data-depot/app.js
+++ b/designsafe/static/scripts/data-depot/app.js
@@ -289,7 +289,7 @@
       .state('publicDataSearch',{
         url: '/public-search/?query_string&offset&limit',
         controller: 'PublicationDataCtrl',
-        templateUrl: '/static/scripts/data-depot/templates/agave-public-data-listing.html',
+        templateUrl: '/static/scripts/data-depot/templates/search-public-data-listing.html',
         params: {
           systemId: 'nees.public',
           filePath: '$SEARCH'
@@ -317,7 +317,7 @@
       .state('communityDataSearch',{
         url: '/community-search/?query_string&offset&limit',
         controller: 'CommunityDataCtrl',
-        templateUrl: '/static/scripts/data-depot/templates/search-public-data-listing.html',
+        templateUrl: '/static/scripts/data-depot/templates/agave-search-data-listing.html',
         params: {
           systemId: 'nees.public',
           filePath: '$SEARCH'

--- a/designsafe/static/scripts/data-depot/templates/search-public-data-listing.html
+++ b/designsafe/static/scripts/data-depot/templates/search-public-data-listing.html
@@ -1,8 +1,8 @@
 <dd-breadcrumb listing="browser.listing" skip-root="true" custom-root="data.customRoot" on-browse="onBrowse" item-href="resolveBreadcrumbHref"></dd-breadcrumb>
-<dd-public-search-listing browser="browser"
+<dd-public-listing browser="browser"
             on-browse="onBrowse"
             on-select="onSelect"
             on-detail="onDetail"
             render-path="renderPath"
             render-name="renderName">
-</dd-public-search-listing>
+</dd-public-listing>

--- a/designsafe/static/scripts/data-depot/templates/search-public-data-listing.html
+++ b/designsafe/static/scripts/data-depot/templates/search-public-data-listing.html
@@ -3,6 +3,7 @@
             on-browse="onBrowse"
             on-select="onSelect"
             on-detail="onDetail"
+            on-metadata="onMetadata"
             render-path="renderPath"
             render-name="renderName">
 </dd-public-listing>


### PR DESCRIPTION
Performing a search in the `Publications` section of the data depot now return a list of projects (both recent and legacy) displayed using the same template as in the main `Publications` view.

Old style:
![image](https://user-images.githubusercontent.com/12601812/39779003-7e42a22e-52cd-11e8-8ff3-e8dfa59a37fb.png)

New style (includes non-NEES publications):
![image](https://user-images.githubusercontent.com/12601812/39779041-988ea1fa-52cd-11e8-92e6-eb4dfd30fc89.png)

