### PR TITLE
Task/des 512

### DIFF
--- a/designsafe/apps/api/agave/filemanager/public_search_index.py
+++ b/designsafe/apps/api/agave/filemanager/public_search_index.py
@@ -550,9 +550,15 @@ class PublicElasticFileManager(BaseFileManager):
                 projects_limit = projects_res.hits.total
                 files_limit = limit - projects_limit
         
+        des_published_query = Q('bool', must=[Q('simple_query_string', query=query_string)])
+        des_published_search = PublicationIndexed.search()\
+            .query(des_published_query)\
+            .extra(from_=offset, size=limit)
+
+        des_published_res = des_published_search.execute()
+        children = [Publication(res).to_file() for res in des_published_res]
+
         # TODO: This is rather SLOW
-        children = []
-  
         project_paths = [p.projectPath for p in projects_res]
         for project in projects_search[projects_offset:projects_limit]:
             logger.debug(project)

--- a/designsafe/apps/api/agave/filemanager/public_search_index.py
+++ b/designsafe/apps/api/agave/filemanager/public_search_index.py
@@ -508,20 +508,9 @@ class PublicElasticFileManager(BaseFileManager):
         else:
             projects_search = projects_search.sort('name._exact')
 
-        """
-        query = Q('bool', must=[Q('simple_query_string', query=query_string)])
-
-
-        projects_search = Search(index="des-publications_legacy,des-publications")\
-            .query(query)\
-            .extra(from_=offset, size=limit)
-        """
         t1 = datetime.datetime.now()
-        
         projects_res = projects_search.execute()
         logger.debug(datetime.datetime.now() - t1)
-
-        logger.debug(projects_res.hits.total)
 
         """
         files_search = PublicObjectIndexed.search()
@@ -539,6 +528,7 @@ class PublicElasticFileManager(BaseFileManager):
         files_res = files_search.execute()
         logger.debug(datetime.datetime.now() - t1)
         """
+
         if projects_res.hits.total:
             if projects_res.hits.total - offset > limit:
                 files_offset = 0
@@ -571,7 +561,7 @@ class PublicElasticFileManager(BaseFileManager):
             res = search.execute()
             if res.hits.total:
                 children.append(PublicObject(res[0]).to_dict())
-        # print children
+
         # search = PublicObjectIndexed.search()
         # search.query = Q('bool',
         #     must=[
@@ -584,6 +574,7 @@ class PublicElasticFileManager(BaseFileManager):
 
         # for r in res[projects_offset:projects_limit]:
         #     children.append(PublicObject(r).to_dict())
+        
         """
         for file_doc in files_search[files_offset:files_limit]:
             logger.debug(file_doc)

--- a/designsafe/apps/api/public_data/views.py
+++ b/designsafe/apps/api/public_data/views.py
@@ -77,6 +77,7 @@ class PublicDataListView(BaseApiView):
         status = request.GET.get('status', 'published')
         listing = file_mgr.listing(system_id, file_path,
                                    offset=offset, limit=limit, status=status)
+        # logger.debug(listing.to_dict()['children'][0])
         return JsonResponse(listing.to_dict())
 
 class PublicMediaView(FileMediaView):

--- a/designsafe/static/scripts/data-depot/app.js
+++ b/designsafe/static/scripts/data-depot/app.js
@@ -289,7 +289,7 @@
       .state('publicDataSearch',{
         url: '/public-search/?query_string&offset&limit',
         controller: 'PublicationDataCtrl',
-        templateUrl: '/static/scripts/data-depot/templates/search-public-data-listing.html',
+        templateUrl: '/static/scripts/data-depot/templates/agave-public-data-listing.html',
         params: {
           systemId: 'nees.public',
           filePath: '$SEARCH'

--- a/designsafe/static/scripts/data-depot/app.js
+++ b/designsafe/static/scripts/data-depot/app.js
@@ -289,7 +289,7 @@
       .state('publicDataSearch',{
         url: '/public-search/?query_string&offset&limit',
         controller: 'PublicationDataCtrl',
-        templateUrl: '/static/scripts/data-depot/templates/agave-public-data-listing.html',
+        templateUrl: '/static/scripts/data-depot/templates/search-public-data-listing.html',
         params: {
           systemId: 'nees.public',
           filePath: '$SEARCH'
@@ -317,7 +317,7 @@
       .state('communityDataSearch',{
         url: '/community-search/?query_string&offset&limit',
         controller: 'CommunityDataCtrl',
-        templateUrl: '/static/scripts/data-depot/templates/search-public-data-listing.html',
+        templateUrl: '/static/scripts/data-depot/templates/agave-search-data-listing.html',
         params: {
           systemId: 'nees.public',
           filePath: '$SEARCH'

--- a/designsafe/static/scripts/data-depot/templates/agave-public-data-listing.html
+++ b/designsafe/static/scripts/data-depot/templates/agave-public-data-listing.html
@@ -1,5 +1,6 @@
 <dd-breadcrumb listing="browser.listing" skip-root="true" custom-root="data.customRoot" on-browse="onBrowse" item-href="resolveBreadcrumbHref"></dd-breadcrumb>
-<dd-public-listing browser="browser"
+<dd-public-listing ng-if="browser.listing.path==='/'"
+            browser="browser"
             on-browse="onBrowse"
             on-select="onSelect"
             on-detail="onDetail"
@@ -9,3 +10,12 @@
             scroll-to-bottom="scrollToBottom"
             scroll-to-top="scrollToTop">
 </dd-public-listing>
+
+<dd-listing ng-if="browser.listing.path !== '/'"
+            browser="browser"
+            on-browse="onBrowse"
+            on-select="onSelect"
+            on-detail="onDetail"
+            scroll-to-top="scrollToTop"
+            scroll-to-bottom="scrollToBottom">
+</dd-listing>

--- a/designsafe/static/scripts/data-depot/templates/search-public-data-listing.html
+++ b/designsafe/static/scripts/data-depot/templates/search-public-data-listing.html
@@ -1,8 +1,8 @@
 <dd-breadcrumb listing="browser.listing" skip-root="true" custom-root="data.customRoot" on-browse="onBrowse" item-href="resolveBreadcrumbHref"></dd-breadcrumb>
-<dd-public-search-listing browser="browser"
+<dd-public-listing browser="browser"
             on-browse="onBrowse"
             on-select="onSelect"
             on-detail="onDetail"
             render-path="renderPath"
             render-name="renderName">
-</dd-public-search-listing>
+</dd-public-listing>

--- a/designsafe/static/scripts/data-depot/templates/search-public-data-listing.html
+++ b/designsafe/static/scripts/data-depot/templates/search-public-data-listing.html
@@ -3,6 +3,7 @@
             on-browse="onBrowse"
             on-select="onSelect"
             on-detail="onDetail"
+            on-metadata="onMetadata"
             render-path="renderPath"
             render-name="renderName">
 </dd-public-listing>

--- a/designsafe/static/scripts/ng-designsafe/html/modals/data-browser-service-published-metadata.html
+++ b/designsafe/static/scripts/ng-designsafe/html/modals/data-browser-service-published-metadata.html
@@ -245,17 +245,17 @@
                                             </div>
                                         </td>
                                     </tr>
-                                    <tr ng-if="(experiment.systemId && experiment.experimentPath)">
+                                    <tr ng-if="experiment.path">
                                         <td>
                                             Files
                                         </td>
                                         <td>
-                                          <a fm-draggable data-agave-href = "agave://{{experiment.systemId}}/{{experiment.experimentPath}}"
-                                             href="/data/browser/public/{{experiment.systemId}}/{{experiment.experimentPath}}"
+                                          <a fm-draggable data-agave-href = "agave://nees.public/{{experiment.path}}"
+                                             href="/data/browser/public/nees.public/{{experiment.path}}"
                                              target="_blank"
                                              title="some title" class="file-folder">
                                              <i class="glyphicon glyphicon-folder-close"></i>
-                                              /{{experiment.experimentPath}}
+                                              /{{experiment.path}}
                                            </a>
                                         </td>
                                     </tr>


### PR DESCRIPTION
All operations using the deprecated 'nees' elasticsearch index now use 'des-publications_legacy'. 

- Added a new {{LegacyPublication}} class to replace `PublicObject` and `PublicExpermient`[sic]

- Added a `PublicDocumentListing` class to turn an iterator of {{Publication}} and `LegacyPublication` objects into a listing object that can be passed to the front end.

- New publications aren't repeated in the list when scrolling down in the main Published listing.

- Browsing files in an old NEES project uses the template for Agave files rather than publications.