### PR TITLE
Only show publications in search if status=published

### DIFF
--- a/designsafe/apps/api/agave/filemanager/public_search_index.py
+++ b/designsafe/apps/api/agave/filemanager/public_search_index.py
@@ -409,7 +409,7 @@ class PublicElasticFileManager(BaseFileManager):
         return listing
 
     def search(self, system, query_string,
-               file_path=None, offset=0, limit=100, sort=None):
+               file_path=None, offset=0, limit=100, sort=None, status='published'):
         files_limit = limit
         files_offset = offset
         projects_limit = limit
@@ -421,7 +421,10 @@ class PublicElasticFileManager(BaseFileManager):
             .query(nees_published_query)\
             .extra(from_=offset, size=limit)
 
-        des_published_query = Q('bool', must=[Q('simple_query_string', query=query_string)])
+        des_published_query = Q('bool', must=[
+            Q('simple_query_string', query=query_string),
+            Q({'term': {'status': status}}) 
+            ])
         des_published_search = PublicationIndexed.search()\
             .query(des_published_query)\
             .extra(from_=offset, size=limit)


### PR DESCRIPTION
Filter publication searches to make sure `status = 'published'`. Otherwise old tests/unviewable publications show up.