### PR TITLE
Task/des 520

### DIFF
--- a/designsafe/apps/api/agave/filemanager/public_search_index.py
+++ b/designsafe/apps/api/agave/filemanager/public_search_index.py
@@ -417,15 +417,11 @@ class PublicElasticFileManager(BaseFileManager):
         projects_offset = offset
 
 
-        nees_published_query = Q('bool', must=[Q('simple_query_string', query=query_string)])
+        nees_published_query = Q('bool', must=[Q('query_string', query=query_string)])
         nees_published_search = LegacyPublicationIndexed.search()\
             .query(nees_published_query)\
             .extra(from_=offset, size=limit)
-
-        des_published_query = Q('bool', must=[
-            Q('simple_query_string', query=query_string),
-            Q({'term': {'status': status}}) 
-            ])
+        des_published_query = Q('bool', must=[Q('query_string', query=query_string)])
         des_published_search = PublicationIndexed.search()\
             .query(des_published_query)\
             .extra(from_=offset, size=limit)

--- a/designsafe/apps/api/agave/filemanager/search_index.py
+++ b/designsafe/apps/api/agave/filemanager/search_index.py
@@ -337,8 +337,9 @@ class ElasticFileManager(BaseFileManager):
         search = IndexedFile.search()
         search = search.filter("nested", path="permissions", query=Q("term", permissions__username=username))
         
-        search = search.filter(Q('bool', must=[Q({'prefix': {'path._exact': username}})]))
+        search = search.query(Q('bool', must=[Q({'prefix': {'path._exact': username}})]))
         search = search.filter("term", system=system)
+        search = search.query(Q('bool', must_not=[Q({'prefix': {'path._exact': '{}/.Trash'.format(username)}})]))
         search = search.query("query_string", query=query_string, fields=["name", "name._exact", "keywords"])
         res = search.execute()
         children = []
@@ -421,7 +422,7 @@ class ElasticFileManager(BaseFileManager):
         search.query = query
         res = search.execute()
         """
-        
+
         split_query = query_string.split(" ")
         for i, c in enumerate(split_query):
             if c.upper() not in ["AND", "OR"]:

--- a/designsafe/apps/api/agave/filemanager/search_index.py
+++ b/designsafe/apps/api/agave/filemanager/search_index.py
@@ -327,7 +327,7 @@ class ElasticFileManager(BaseFileManager):
         """
         split_query = query_string.split(" ")
         for i, c in enumerate(split_query):
-            if c.upper() not in ["AND", "OR"]:
+            if c.upper() not in ["AND", "OR", "NOT"]:
                 split_query[i] = "*" + c + "*"
         
         query_string = " ".join(split_query)
@@ -373,7 +373,7 @@ class ElasticFileManager(BaseFileManager):
         
         split_query = query_string.split(" ")
         for i, c in enumerate(split_query):
-            if c.upper() not in ["AND", "OR"]:
+            if c.upper() not in ["AND", "OR", "NOT"]:
                 split_query[i] = "*" + c + "*"
         
         query_string = " ".join(split_query)
@@ -425,7 +425,7 @@ class ElasticFileManager(BaseFileManager):
 
         split_query = query_string.split(" ")
         for i, c in enumerate(split_query):
-            if c.upper() not in ["AND", "OR"]:
+            if c.upper() not in ["AND", "OR", "NOT"]:
                 split_query[i] = "*" + c + "*"
         
         query_string = " ".join(split_query)

--- a/designsafe/apps/api/search/views.py
+++ b/designsafe/apps/api/search/views.py
@@ -89,7 +89,7 @@ class SearchView(BaseApiView):
 
         split_query = q.split(" ")
         for i, c in enumerate(split_query):
-            if c.upper() not in ["AND", "OR"]:
+            if c.upper() not in ["AND", "OR", "NOT"]:
                 split_query[i] = "*" + c + "*"
         
         q = " ".join(split_query)
@@ -118,7 +118,7 @@ class SearchView(BaseApiView):
 
         split_query = q.split(" ")
         for i, c in enumerate(split_query):
-            if c.upper() not in ["AND", "OR"]:
+            if c.upper() not in ["AND", "OR", "NOT"]:
                 split_query[i] = "*" + c + "*"
         
         q = " ".join(split_query)

--- a/designsafe/static/scripts/data-depot/app.js
+++ b/designsafe/static/scripts/data-depot/app.js
@@ -78,9 +78,9 @@
             DataBrowserService.apiParams.baseUrl = '/api/agave/files';
             DataBrowserService.apiParams.searchState = 'dataSearch';
             var queryString = $stateParams.query_string;
-            if (/[^A-Za-z0-9]/.test(queryString)){
-              queryString = '"' + queryString + '"';
-            }
+            //if (/[^A-Za-z0-9]/.test(queryString)){
+            //  queryString = '"' + queryString + '"';
+            //}
             var options = {system: $stateParams.systemId, query_string: queryString, offset: $stateParams.offset, limit: $stateParams.limit};
             return DataBrowserService.search(options);
           }],
@@ -143,9 +143,9 @@
             DataBrowserService.apiParams.baseUrl = '/api/agave/files';
             DataBrowserService.apiParams.searchState = 'sharedDataSearch';
             var queryString = $stateParams.query_string;
-            if (/[^A-Za-z0-9]/.test(queryString)){
-              queryString = '"' + queryString + '"';
-            }
+            //if (/[^A-Za-z0-9]/.test(queryString)){
+            //  queryString = '"' + queryString + '"';
+            //}
             var options = {system: $stateParams.systemId, query_string: queryString, offset: $stateParams.offset, limit: $stateParams.limit, shared: $stateParams.shared};
             return DataBrowserService.search(options);
           }],
@@ -302,9 +302,9 @@
             DataBrowserService.apiParams.baseUrl = '/api/public/files';
             DataBrowserService.apiParams.searchState = 'publicDataSearch';
             var queryString = $stateParams.query_string;
-            if (/[^A-Za-z0-9]/.test(queryString)){
-              queryString = '"' + queryString + '"';
-            }
+            //if (/[^A-Za-z0-9]/.test(queryString)){
+            //  queryString = '"' + queryString + '"';
+            //}
             var options = {system: $stateParams.systemId, query_string: queryString, offset: $stateParams.offset, limit: $stateParams.limit};
             return DataBrowserService.search(options);
           }],
@@ -330,11 +330,10 @@
             DataBrowserService.apiParams.baseUrl = '/api/public/files';
             DataBrowserService.apiParams.searchState = 'communityDataSearch';
             var queryString = $stateParams.query_string;
-            if (/[^A-Za-z0-9]/.test(queryString)){
-              queryString = '"' + queryString + '"';
-            }
+            //if (/[^A-Za-z0-9]/.test(queryString)){
+            //  queryString = '"' + queryString + '"';
+            //}
             var options = {system: $stateParams.systemId, query_string: queryString, offset: $stateParams.offset, limit: $stateParams.limit};
-            console.log(options);
             return DataBrowserService.search(options);
           }],
           'auth': function($q) {


### PR DESCRIPTION
Enable search for multiple terms separated by `AND`/`OR`/`NOT`. Both the data depot and site-wide search are affected.

To get this to work, query strings are no longer wrapped in quotation marks if they contain spaces/special characters. For files, any term in the search that isn't `AND`/`OR`/`NOT` is wrapped in wildcard characters. If the user enters:

`irma OR nate OR maria`

the query string that Elasticsearch sees is: 

`*irma* OR *nate* OR *maria*`

This allows search hits on partial matches.

![image](https://user-images.githubusercontent.com/12601812/40145659-66dba264-5928-11e8-89fe-acb9789aa43f.png)
![image](https://user-images.githubusercontent.com/12601812/40145705-860e6400-5928-11e8-92a6-604a571ad059.png)
![image](https://user-images.githubusercontent.com/12601812/40145714-8d70efe2-5928-11e8-9adb-a27d6a2ff01e.png)
![image](https://user-images.githubusercontent.com/12601812/40146027-a42991d4-5929-11e8-99ac-8b0b0082943b.png)


