### PR TITLE
Task/des 194

### DIFF
--- a/designsafe/LoginTest.py
+++ b/designsafe/LoginTest.py
@@ -3,6 +3,7 @@ from django.test import TestCase, RequestFactory
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 import mock
+import json
 from designsafe.apps.auth.models import AgaveOAuthToken
 from designsafe.apps.auth.tasks import check_or_create_agave_home_dir
 from designsafe.apps.auth.views import agave_oauth_callback
@@ -40,56 +41,32 @@ class LoginTestClass(TestCase):
   def tearDown(self):
     return
     
-  """ @mock.patch('designsafe.apps.auth.models.AgaveOAuthToken.client')
+  @mock.patch('designsafe.apps.auth.models.AgaveOAuthToken.client')
   @mock.patch('agavepy.agave.Agave')
-  @mock.patch('designsafe.apps.auth.views.agave_oauth_callback')
-  def test_has_agave_file_listing(self, agave_client, agave, agave_oauth_callback):
+  def test_has_agave_file_listing(self, agave_client, agave):
     #agaveclient.return_value.files.list.return_value = [] // whatever the listing should look like
     #request.post.return_value = {} // some object that looks like a requests response
     
     self.client.login(username='test_with_agave', password='test')
 
     agave_client.files.list.return_value = {
-        "name": ".",
-        "path": "test",
-        "lastModified": "2018-06-14T10:44:03.000-05:00",
-        "length": 4096,
-        "permissions": "ALL",
-        "format": "folder",
-        "mimeType": "text/directory",
-        "type": "dir",
+        "name": "test",
         "system": "designsafe.storage.default",
-        "_links": {
-            "self": {
-                "href": "https://agave.designsafe-ci.org/files/v2/media/system/designsafe.storage.default/test"
-            },
-            "system": {
-                "href": "https://agave.designsafe-ci.org/systems/v2/designsafe.storage.default"
-            },
-            "metadata": {
-                "href": "https://agave.designsafe-ci.org/meta/v2/data?q=%7B%22associationIds%22%3A%11111111111111111111111-11111111-0001-001%22%7D"
-            },
-            "history": {
-                "href": "https://agave.designsafe-ci.org/files/v2/history/system/designsafe.storage.default//test"
-            }
-        }
-    } 
-    
-    request_with_agave = self.rf.get(
-        reverse('designsafe_auth:agave_oauth_callback'))
-    request_with_agave.POST.return_value = {
-        'state': 'test',
-        'session': {'auth_state': 'test'},
-        'code': 'test'
-        }
+        "trail": [{"path": "/", "name": "/", "system": "designsafe.storage.default"}, 
+                  {"path": "/test", "name": "test", "system": "designsafe.storage.default"}],
+        "path": "test",
+        "type": "dir",
+        "children": [],
+        "permissions": "READ"
+      } 
 
-    agave_oauth_callback(request_with_agave.POST)
+    resp = self.client.get('/api/agave/files/listing/agave/designsafe.storage.default/test', follow=True)
 
-    resp = self.client.get('https://agave.designsafe-ci.org/files/v2/listings/designsafe.storage.default/test')
-    print resp 
-    self.assertEqual(resp.status_code, 200) """
+    self.assertEqual(resp.status_code, 200)
+    self.assertJSONEqual(resp.content, agave_client.files.list.return_value, msg='Agave homedir listing has unexpected values')
 
-  @mock.patch('designsafe.apps.auth.models.AgaveOAuthToken.client')
+
+  '''@mock.patch('designsafe.apps.auth.models.AgaveOAuthToken.client')
   @mock.patch('agavepy.agave.Agave')
   def test_no_agave_file_listing(self, agave_client, agave):
       self.client.login(username='test_without_agave', password='test')
@@ -110,10 +87,12 @@ class LoginTestClass(TestCase):
 
       resp = agave_oauth_callback(request_without_agave.POST)
       print resp
-      self.assertEqual(resp.status_code, 200)
+      self.assertEqual(resp.status_code, 200)'''
 
   """ def test_user_without_agave_homedir_gets_redirected(self, mock_client, mock_Agave):
 
     pass """
     
-  
+  """ def test_agave_callbak(self):
+
+      resp = self.client.post("/auth/agave/callback?code=code&state=test", data=data) """

--- a/designsafe/LoginTest.py
+++ b/designsafe/LoginTest.py
@@ -1,0 +1,69 @@
+from django.test import TestCase, RequestFactory
+from django.contrib.auth import get_user_model
+import mock
+from designsafe.apps.auth.models import AgaveOAuthToken
+from designsafe.apps.auth.tasks import check_or_create_agave_home_dir
+from designsafe.apps.auth.views import agave_oauth_callback
+
+
+class LoginTestClass(TestCase):
+  def setUp (self):
+    User = get_user_model()
+    user = User.objects.create_user('test', 'test@test.com', 'test')
+    token = AgaveOAuthToken(
+        token_type="bearer",
+        scope="default",
+        access_token="1234abcd",
+        refresh_token="123123123",
+        expires_in=14400,
+        created=1523633447)
+    token.user = user
+    token.save()
+    
+  
+  def tearDown(self):
+    return
+    
+  @mock.patch('designsafe.apps.auth.models.AgaveOAuthToken.client')
+  @mock.patch('agavepy.agave.Agave')
+  def test_agave_file_listing(self, agave_client, agave):
+    #agaveclient.return_value.files.list.return_value = [] // whatever the listing should look like
+    #request.post.return_value = {} // some object that looks like a requests response
+    
+    self.client.login(username='test', password='test')
+
+    agave_client.files.list.return_value = {
+        "name": ".",
+        "path": "test",
+        "lastModified": "2018-06-14T10:44:03.000-05:00",
+        "length": 4096,
+        "permissions": "ALL",
+        "format": "folder",
+        "mimeType": "text/directory",
+        "type": "dir",
+        "system": "designsafe.storage.default",
+        "_links": {
+            "self": {
+                "href": "https://agave.designsafe-ci.org/files/v2/media/system/designsafe.storage.default/test"
+            },
+            "system": {
+                "href": "https://agave.designsafe-ci.org/systems/v2/designsafe.storage.default"
+            },
+            "metadata": {
+                "href": "https://agave.designsafe-ci.org/meta/v2/data?q=%7B%22associationIds%22%3A%11111111111111111111111-11111111-0001-001%22%7D"
+            },
+            "history": {
+                "href": "https://agave.designsafe-ci.org/files/v2/history/system/designsafe.storage.default//test"
+            }
+        }
+    } 
+    
+    resp = self.client.get('https://agave.designsafe-ci.org/files/v2/listings/designsafe.storage.default/test')
+    print resp 
+    self.assertEqual(resp.status_code, 200)
+
+  """ def test_user_without_agave_homedir_gets_redirected(self, mock_client, mock_Agave):
+
+    pass """
+    
+  

--- a/designsafe/LoginTest.py
+++ b/designsafe/LoginTest.py
@@ -1,5 +1,7 @@
+#python manage.py test designsafe.LoginTest --settings=designsafe.settings.test_settings
 from django.test import TestCase, RequestFactory
 from django.contrib.auth import get_user_model
+from django.core.urlresolvers import reverse
 import mock
 from designsafe.apps.auth.models import AgaveOAuthToken
 from designsafe.apps.auth.tasks import check_or_create_agave_home_dir
@@ -18,20 +20,21 @@ class LoginTestClass(TestCase):
         refresh_token="123123123",
         expires_in=14400,
         created=1523633447)
-    token.user = user
+    token.user = user_with_agave
     token.save()
+    self.rf = RequestFactory()
 
     user_without_agave = User.objects.create_user(
-        'test_without_agave', 'test@test.com', 'test')
-    token = AgaveOAuthToken(
+        'test_without_agave', 'test2@test.com', 'test')
+    """ token = AgaveOAuthToken(
         token_type="bearer",
         scope="default",
-        access_token="1234abcd",
-        refresh_token="123123123",
+        access_token="5555abcd",
+        refresh_token="5555555",
         expires_in=14400,
         created=1523633447)
-    token.user = user
-    token.save()
+    token.user = user_without_agave
+    token.save() """
     
   
   def tearDown(self):
@@ -39,7 +42,8 @@ class LoginTestClass(TestCase):
     
   """ @mock.patch('designsafe.apps.auth.models.AgaveOAuthToken.client')
   @mock.patch('agavepy.agave.Agave')
-  def test_has_agave_file_listing(self, agave_client, agave):
+  @mock.patch('designsafe.apps.auth.views.agave_oauth_callback')
+  def test_has_agave_file_listing(self, agave_client, agave, agave_oauth_callback):
     #agaveclient.return_value.files.list.return_value = [] // whatever the listing should look like
     #request.post.return_value = {} // some object that looks like a requests response
     
@@ -71,6 +75,16 @@ class LoginTestClass(TestCase):
         }
     } 
     
+    request_with_agave = self.rf.get(
+        reverse('designsafe_auth:agave_oauth_callback'))
+    request_with_agave.POST.return_value = {
+        'state': 'test',
+        'session': {'auth_state': 'test'},
+        'code': 'test'
+        }
+
+    agave_oauth_callback(request_with_agave.POST)
+
     resp = self.client.get('https://agave.designsafe-ci.org/files/v2/listings/designsafe.storage.default/test')
     print resp 
     self.assertEqual(resp.status_code, 200) """
@@ -85,9 +99,16 @@ class LoginTestClass(TestCase):
           "message": "File/folder does not exist", 
           "version": "test"
           }
+      
+      request_without_agave = self.rf.get(
+        reverse('designsafe_auth:agave_oauth_callback'))
+      request_without_agave.get.return_value = {
+        'state': 'test',
+        'session': {'auth_state': 'test'},
+        'code': 'test'
+        }
 
-      resp = self.client.get(
-          'https://agave.designsafe-ci.org/files/v2/listings/designsafe.storage.default//test')
+      resp = agave_oauth_callback(request_without_agave.POST)
       print resp
       self.assertEqual(resp.status_code, 200)
 

--- a/designsafe/LoginTest.py
+++ b/designsafe/LoginTest.py
@@ -3,7 +3,6 @@ from django.test import TestCase, RequestFactory
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 import mock
-import json
 from designsafe.apps.auth.models import AgaveOAuthToken
 from designsafe.apps.auth.tasks import check_or_create_agave_home_dir
 from designsafe.apps.auth.views import agave_oauth_callback
@@ -25,9 +24,8 @@ class LoginTestClass(TestCase):
     token.save()
     self.rf = RequestFactory()
 
-    user_without_agave = User.objects.create_user(
-        'test_without_agave', 'test2@test.com', 'test')
-    """ token = AgaveOAuthToken(
+    user_without_agave = User.objects.create_user('test_without_agave', 'test2@test.com', 'test')
+    token = AgaveOAuthToken(
         token_type="bearer",
         scope="default",
         access_token="5555abcd",
@@ -35,13 +33,13 @@ class LoginTestClass(TestCase):
         expires_in=14400,
         created=1523633447)
     token.user = user_without_agave
-    token.save() """
+    token.save()
     
   
   def tearDown(self):
     return
     
-  @mock.patch('designsafe.apps.auth.models.AgaveOAuthToken.client')
+  """ @mock.patch('designsafe.apps.auth.models.AgaveOAuthToken.client')
   @mock.patch('agavepy.agave.Agave')
   def test_has_agave_file_listing(self, agave_client, agave):
     #agaveclient.return_value.files.list.return_value = [] // whatever the listing should look like
@@ -63,31 +61,33 @@ class LoginTestClass(TestCase):
     resp = self.client.get('/api/agave/files/listing/agave/designsafe.storage.default/test', follow=True)
 
     self.assertEqual(resp.status_code, 200)
-    self.assertJSONEqual(resp.content, agave_client.files.list.return_value, msg='Agave homedir listing has unexpected values')
+    self.assertJSONEqual(resp.content, agave_client.files.list.return_value, msg='Agave homedir listing has unexpected values') """
 
-
-  '''@mock.patch('designsafe.apps.auth.models.AgaveOAuthToken.client')
+  @mock.patch('designsafe.apps.auth.models.AgaveOAuthToken.client')
   @mock.patch('agavepy.agave.Agave')
   def test_no_agave_file_listing(self, agave_client, agave):
-      self.client.login(username='test_without_agave', password='test')
-
-      agave_client.files.list.return_value = {
-          "status": "error", 
-          "message": "File/folder does not exist", 
-          "version": "test"
-          }
-      
-      request_without_agave = self.rf.get(
-        reverse('designsafe_auth:agave_oauth_callback'))
-      request_without_agave.get.return_value = {
-        'state': 'test',
-        'session': {'auth_state': 'test'},
-        'code': 'test'
-        }
-
-      resp = agave_oauth_callback(request_without_agave.POST)
-      print resp
-      self.assertEqual(resp.status_code, 200)'''
+    self.client.login(username='test_without_agave', password='test')
+    session = self.client.session
+    session['auth_state'] = 'test'
+    session.save()
+    
+    request_without_agave = self.client.post("/auth/agave/callback/?state=test&code=test", follow = True)
+    print 'Initial Query Status: ' + str(request_without_agave.status_code)
+    """ request_without_agave.get.return_value = {
+      'state': 'test',
+      'session': {'auth_state': 'test'},
+      'code': 'test'
+      } """
+    
+    """ agave_client.files.list.return_value = {
+        "status": "error", 
+        "message": "File/folder does not exist", 
+        "version": "test"
+        } """
+        
+    resp = agave_oauth_callback(request_without_agave)
+    print 'Oauth Callback Status: ' + str(resp)
+    self.assertEqual(resp.status_code, 200)
 
   """ def test_user_without_agave_homedir_gets_redirected(self, mock_client, mock_Agave):
 

--- a/designsafe/apps/accounts/views.py
+++ b/designsafe/apps/accounts/views.py
@@ -499,7 +499,7 @@ def email_confirmation(request, code=None):
                 user = tas.get_user(username=username)
                 if tas.verify_user(user['id'], code, password=password):
                     check_or_create_agave_home_dir.apply(args=(user["username"],))
-                    
+                    return HttpResponseRedirect(reverse('designsafe_accounts:manage_profile'))
                 else:
                     messages.error(request,
                                    'We were unable to activate your account. Please try '

--- a/designsafe/apps/accounts/views.py
+++ b/designsafe/apps/accounts/views.py
@@ -8,7 +8,6 @@ from django.db.models import Q
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render_to_response
 from django.utils.translation import ugettext_lazy as _
-from django.conf import settings
 from designsafe.apps.accounts import forms, integrations
 from designsafe.apps.accounts.models import (NEESUser, DesignSafeProfile,
                                              NotificationPreferences)

--- a/designsafe/apps/accounts/views.py
+++ b/designsafe/apps/accounts/views.py
@@ -501,29 +501,6 @@ def email_confirmation(request, code=None):
                 if tas.verify_user(user['id'], code, password=password):
                     check_or_create_agave_home_dir.apply(args=(user["username"],))
                     
-                    ag = Agave(api_server=settings.AGAVE_TENANT_BASEURL,
-                               token=settings.AGAVE_SUPER_TOKEN)
-
-                    try:
-                        ag.files.list(
-                            systemId=settings.AGAVE_STORAGE_SYSTEM,
-                            filePath=username)
-
-                        messages.success(request,
-                                         'Congratulations, your account has been activated and home directory created! '
-                                         'You can now log in to DesignSafe.')
-
-                        return HttpResponseRedirect(
-                            reverse('designsafe_accounts:manage_profile'))
-
-                    except HTTPError:
-                        
-                        messages.error(request,
-                                       'We have not been able to create your home directory yet. Please try '
-                                       'again later. If this problem persists, please '
-                                       '<a href="/help">open a support ticket</a>.')
-                    
-                    
                 else:
                     messages.error(request,
                                    'We were unable to activate your account. Please try '

--- a/designsafe/apps/auth/signals.py
+++ b/designsafe/apps/auth/signals.py
@@ -1,8 +1,0 @@
-from django.contrib.auth.signals import user_logged_in
-from django.dispatch import receiver
-from .tasks import check_or_create_agave_home_dir
-
-
-@receiver(user_logged_in)
-def on_user_logged_in(sender, user, request, **kwargs):
-    check_or_create_agave_home_dir.apply_async(args=(user.username,), queue='files')

--- a/designsafe/apps/auth/tasks.py
+++ b/designsafe/apps/auth/tasks.py
@@ -26,43 +26,47 @@ def check_or_create_agave_home_dir(username):
         try:
             ag.files.list(
                 systemId=settings.AGAVE_STORAGE_SYSTEM,
-                filePath=username)
+                filePath=username)  
+                
         except HTTPError:
             body = {'action': 'mkdir', 'path': username}
-            ag.files.manage(systemId=settings.AGAVE_STORAGE_SYSTEM,
-                            filePath='', body=body)
+            ag.files.manage(systemId=settings.AGAVE_STORAGE_SYSTEM, 
+                            filePath='', 
+                            body=body)
 
-        ds_admin_client = Agave(
-            api_server=getattr(
-                settings,
-                'AGAVE_TENANT_BASEURL'
-            ),
-            token=getattr(
-                settings,
-                'AGAVE_SUPER_TOKEN'
+            ds_admin_client = Agave(
+                api_server=getattr(
+                    settings,
+                    'AGAVE_TENANT_BASEURL'
+                ),
+                token=getattr(
+                    settings,
+                    'AGAVE_SUPER_TOKEN'
+                ),
             )
-        )
-        job_body = {
-            'inputs': {
-                'username': username,
-                'directory': 'shared/{}'.format(username)
-            },
-            'name': 'setfacl',
-            'appId': 'setfacl_corral3-0.1'
-        }
+            job_body = {
+                'inputs': {
+                    'username': username,
+                    'directory': 'shared/{}'.format(username)
+                },
+                'name': 'setfacl',
+                'appId': 'setfacl_corral3-0.1'
+            }
 
-        ds_admin_client.jobs.submit(body=job_body)
-        # logger.debug('setfacl response: {}'.format(response))
+            ds_admin_client.jobs.submit(body=job_body)
+            # logger.debug('setfacl response: {}'.format(response))
 
-        # add dir to index
-        fm = FileManager(user)
-        fm.indexer.index(
-            settings.AGAVE_STORAGE_SYSTEM,
-            username, username,
-            levels=1
-        )
+            # add dir to index
+            fm = FileManager(user)
+            fm.indexer.index(
+                settings.AGAVE_STORAGE_SYSTEM,
+                username, username,
+                levels=1
+            )
+
 
     except (HTTPError, AgaveException):
         logger.exception('Failed to create home directory.',
                          extra={'user': username,
                                 'systemId': settings.AGAVE_STORAGE_SYSTEM})
+

--- a/designsafe/apps/auth/views.py
+++ b/designsafe/apps/auth/views.py
@@ -149,14 +149,8 @@ def agave_oauth_callback(request):
         token_data['created'] = int(time.time())
         # log user in
         user = authenticate(backend='agave', token=token_data['access_token'])
-        logger.info('******'*100)
-        logger.info(user)
+        
         if user:
-            #If the login() call doesn't get hit, DS falls apart because the browser gets redirected too many times.
-            #I commented login() out to test this.  So user is always true and those else statements are never hit.
-            #Proved this by using an incorrect pw and the failure messages below never came up. Instead, this seems to be
-            #controlled by the TAS/LDAP login page.
-
             try:
                 token = user.agave_oauth
                 token.update(**token_data)
@@ -165,58 +159,22 @@ def agave_oauth_callback(request):
                 token.user = user
             token.save()
 
-            """ check_or_create_agave_home_dir.apply(
-                args=(
-                    user.username,
-                ),
-                queue='files'
-            ) """            
+            check_or_create_agave_home_dir.apply(args=(user.username,),queue='files')            
 
-            hasFiles = []
-            ag = Agave(api_server=settings.AGAVE_TENANT_BASEURL,
-                       token=token_data['access_token'])
-            try:
-                #This is a rudimentary test to see if files come back from the homedir.  
-                #If they don't, the homedir must not exist
-                hasFiles = ag.files.list(
-                    systemId=settings.AGAVE_STORAGE_SYSTEM,
-                    filePath=user.username)
-                
-                #logger.info('filepath: ' +
-                            #str(settings.AGAVE_STORAGE_SYSTEM) + str(user.username))  # designsafe.storage.defaultfrankn
-                                                                                        # systems-delete $SYSTEM_ID
-            except (HTTPError, AgaveException):
-                messages.error(request,
-                              'We have not been able to create your home directory yet. Please try '
-                              'again later. If this problem persists, please '
-                              '<a href="/help">open a support ticket</a>.')
-                logger.info('************'*100)
-                logger.info('Redirect')
-                logger.info(reverse('designsafe_auth:login'))
-                return HttpResponseRedirect(reverse('designsafe_auth:login'))
-
-            if hasFiles:
-                #If user has no homedir, then we don't call login()
-                login(request, user)
-                if user.last_login is not None:
-                    msg_tmpl = 'Login successful. Welcome back, %s %s!'
-                else:
-                    msg_tmpl = 'Login successful. Welcome to DesignSafe, %s %s!'
-                messages.success(
-                    request,
-                    msg_tmpl % (
-                        user.first_name,
-                        user.last_name
-                    )
-                )
+            login(request, user)
+            if user.last_login is not None:
+                msg_tmpl = 'Login successful. Welcome back, %s %s!'
             else:
-                logger.info('************'*100)
-                logger.info('Redirect')
-                return HttpResponseRedirect(reverse('designsafe_auth:login'))
+                msg_tmpl = 'Login successful. Welcome to DesignSafe, %s %s!'
+            messages.success(
+                request,
+                msg_tmpl % (
+                    user.first_name,
+                    user.last_name
+                )
+            )
             
         else:
-            logger.info('************'*100)
-            logger.info('Redirect')
             messages.error(
                 request,
                 'Authentication failed. Please try again. If this problem '
@@ -227,22 +185,16 @@ def agave_oauth_callback(request):
         if 'error' in request.GET:
             error = request.GET['error']
             logger.warning('Authorization failed: %s' % error)
-        logger.info('************'*100)
-        logger.info('Redirect')
         messages.error(
             request, 'Authentication failed! Did you forget your password? '
                      '<a href="%s">Click here</a> to reset your password.' %
                      reverse('designsafe_accounts:password_reset'))
         return HttpResponseRedirect(reverse('designsafe_auth:login'))
     if 'next' in request.session:
-        logger.info('************'*100)
-        logger.info('Redirect')
         next_uri = request.session.pop('next')
         return HttpResponseRedirect(next_uri)
     else:
         # return HttpResponseRedirect(settings.LOGIN_REDIRECT_URL)
-        logger.info('************'*100)
-        logger.info('Redirect')
         return HttpResponseRedirect(reverse('designsafe_dashboard:index'))
 
 

--- a/designsafe/apps/auth/views.py
+++ b/designsafe/apps/auth/views.py
@@ -1,12 +1,12 @@
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth import authenticate, login, logout
+from django.contrib.auth import authenticate, login
 from django.core.urlresolvers import reverse
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.shortcuts import render
 from .models import AgaveOAuthToken, AgaveServiceStatus
-from agavepy.agave import Agave, AgaveException
+from agavepy.agave import Agave
 from designsafe.apps.auth.tasks import check_or_create_agave_home_dir
 import logging
 import os

--- a/designsafe/apps/auth/views.py
+++ b/designsafe/apps/auth/views.py
@@ -155,6 +155,13 @@ def agave_oauth_callback(request):
                 token.user = user
             token.save()
 
+            check_or_create_agave_home_dir.apply(
+                args=(
+                    user.username,
+                ),
+                queue='files'
+            )
+            
             login(request, user)
             if user.last_login is not None:
                 msg_tmpl = 'Login successful. Welcome back, %s %s!'
@@ -167,12 +174,7 @@ def agave_oauth_callback(request):
                     user.last_name
                 )
             )
-            check_or_create_agave_home_dir.apply_async(
-                args=(
-                    user.username,
-                ),
-                queue='files'
-            )
+            
         else:
             messages.error(
                 request,


### PR DESCRIPTION
When a user logs in, DesignSafe now checks if the user has an Agave home directory synchronously.  If the user has one, the directory is created synchronously.  Then, the normal check_or_create task is run asynchronously.

Removed signals.py from auth, because it was no longer useful.

Removed successful account creation and login messages, because they were not appearing consistently.  