### PR TITLE
DES-580: Search within projects in My Projects

### DIFF
--- a/designsafe/apps/api/agave/filemanager/search_index.py
+++ b/designsafe/apps/api/agave/filemanager/search_index.py
@@ -408,7 +408,6 @@ class ElasticFileManager(BaseFileManager):
         }
         return result
 
-
     def search_in_project(self, system, query_string, file_path=None, offset=0, limit=100):
         """
         Performs a search for files within a specific project.

--- a/designsafe/apps/api/agave/filemanager/search_index.py
+++ b/designsafe/apps/api/agave/filemanager/search_index.py
@@ -334,8 +334,6 @@ class ElasticFileManager(BaseFileManager):
         
         query_string = " ".join(split_query)
 
-        logger.debug(query_string)
-
         search = IndexedFile.search()
         search = search.filter("nested", path="permissions", query=Q("term", permissions__username=username))
         
@@ -380,7 +378,6 @@ class ElasticFileManager(BaseFileManager):
         
         query_string = " ".join(split_query)
 
-        logger.debug(query_string)
         filters = Q('term', system="designsafe.storage.community") #| \
                   #Q('term', system="designsafe.storage.published") | \
                   #Q('term', system="designsafe.storage.community")
@@ -420,7 +417,6 @@ class ElasticFileManager(BaseFileManager):
         
         query_string = " ".join(split_query)
 
-        logger.debug(query_string)
 
         search = IndexedFile.search()
         # search = search.filter("nested", path="permissions", query=Q("term", permissions__username=username))

--- a/designsafe/apps/api/agave/filemanager/search_index.py
+++ b/designsafe/apps/api/agave/filemanager/search_index.py
@@ -410,6 +410,10 @@ class ElasticFileManager(BaseFileManager):
 
 
     def search_in_project(self, system, query_string, file_path=None, offset=0, limit=100):
+        """
+        Performs a search for files within a specific project.
+        """
+        
         split_query = query_string.split(" ")
         for i, c in enumerate(split_query):
             if c.upper() not in ["AND", "OR", "NOT"]:

--- a/designsafe/apps/api/agave/filemanager/search_index.py
+++ b/designsafe/apps/api/agave/filemanager/search_index.py
@@ -340,7 +340,7 @@ class ElasticFileManager(BaseFileManager):
         search = search.filter("nested", path="permissions", query=Q("term", permissions__username=username))
         
         search = search.query(Q('bool', must=[Q({'prefix': {'path._exact': username}})]))
-        search = search.filter(Q({'term': {'system._exact': system}}))
+        search = search.filter("term", system=system)
         search = search.query(Q('bool', must_not=[Q({'prefix': {'path._exact': '{}/.Trash'.format(username)}})]))
         search = search.query("query_string", query=query_string, fields=["name", "name._exact", "keywords"])
         res = search.execute()
@@ -413,7 +413,7 @@ class ElasticFileManager(BaseFileManager):
         """
         Performs a search for files within a specific project.
         """
-        
+
         split_query = query_string.split(" ")
         for i, c in enumerate(split_query):
             if c.upper() not in ["AND", "OR", "NOT"]:

--- a/designsafe/apps/api/agave/views.py
+++ b/designsafe/apps/api/agave/views.py
@@ -82,11 +82,11 @@ class FileListingView(BaseApiView):
                                         offset=offset, limit=limit)
                 else:
                     query_string = request.GET.get('query_string')
+                    # Performing an Agave listing here prevents a race condition.
                     listing = fm.listing(system=system_id, file_path='/',
                                         offset=offset, limit=limit) 
-                    logger.debug(system_id)
-                    fmgr = ElasticFileManager()
-                    listing = fmgr.search_in_project(system_id, query_string,
+                    efmgr = ElasticFileManager()
+                    listing = efmgr.search_in_project(system_id, query_string,
                                 offset=offset, limit=limit)
                     logger.debug(listing)
                 return JsonResponse(listing,

--- a/designsafe/apps/api/agave/views.py
+++ b/designsafe/apps/api/agave/views.py
@@ -49,7 +49,7 @@ class FileListingView(BaseApiView):
     """Main File Listing View. Used to list agave resources."""
 
     @profile_fn
-    def get(self, request, file_mgr_name, system_id=None, file_path=None, query_string=None):
+    def get(self, request, file_mgr_name, system_id=None, file_path=None):
         if file_mgr_name == AgaveFileManager.NAME:
             if not request.user.is_authenticated:
                 return HttpResponseForbidden('Login required')

--- a/designsafe/apps/api/agave/views.py
+++ b/designsafe/apps/api/agave/views.py
@@ -69,14 +69,11 @@ class FileListingView(BaseApiView):
                                                      user_context=request.user.username)
                 return JsonResponse(listing)
             else:
-                try:
-                    searching = json.loads(request.GET.get('searching'))
-                except TypeError:
-                    searching = False
-                logger.debug(searching)
+                query_string = request.GET.get('query_string') 
+    
                 offset = int(request.GET.get('offset', 0))
                 limit = int(request.GET.get('limit', 100))
-                if not searching:
+                if (not query_string) or (query_string==""):
                     listing = fm.listing(system=system_id, file_path=file_path,
                                         offset=offset, limit=limit)
                 else:

--- a/designsafe/apps/api/agave/views.py
+++ b/designsafe/apps/api/agave/views.py
@@ -69,7 +69,6 @@ class FileListingView(BaseApiView):
                                                      user_context=request.user.username)
                 return JsonResponse(listing)
             else:
-                
                 try:
                     searching = json.loads(request.GET.get('searching'))
                 except TypeError:

--- a/designsafe/apps/api/agave/views.py
+++ b/designsafe/apps/api/agave/views.py
@@ -84,7 +84,6 @@ class FileListingView(BaseApiView):
                     efmgr = ElasticFileManager()
                     listing = efmgr.search_in_project(system_id, query_string,
                                 offset=offset, limit=limit)
-                    logger.debug(listing)
                 return JsonResponse(listing,
                                     encoder=AgaveJSONEncoder,
                                     safe=False)

--- a/designsafe/static/scripts/data-depot/app.js
+++ b/designsafe/static/scripts/data-depot/app.js
@@ -201,7 +201,7 @@
         }
       })
       .state('projects.view.data', {
-        url: '{filePath:any}?query_string&searching&offset&limit',
+        url: '{filePath:any}?query_string&offset&limit',
         controller: 'ProjectDataCtrl',
         templateUrl: '/static/scripts/data-depot/templates/project-data.html',
         params: {
@@ -213,7 +213,6 @@
           'projectId': function($stateParams) { return $stateParams.projectId; },
           'filePath': function($stateParams) { return $stateParams.filePath || '/'; },
           'projectTitle': function($stateParams) { return $stateParams.projectTitle; },
-          'searching': function($stateParams) { return $stateParams.query_string || ''; },
           'query_string': function($stateParams) { return $stateParams.query_string || ''; }
         }
       })

--- a/designsafe/static/scripts/data-depot/app.js
+++ b/designsafe/static/scripts/data-depot/app.js
@@ -201,16 +201,20 @@
         }
       })
       .state('projects.view.data', {
-        url: '{filePath:any}',
+        url: '{filePath:any}?query_string&searching&offset&limit',
         controller: 'ProjectDataCtrl',
         templateUrl: '/static/scripts/data-depot/templates/project-data.html',
         params: {
-          projectTitle: ''
+          projectTitle: '',
+          query_string: '',
+          filePath: '/'
         },
         resolve: {
           'projectId': function($stateParams) { return $stateParams.projectId; },
           'filePath': function($stateParams) { return $stateParams.filePath || '/'; },
-          'projectTitle': function($stateParams) { return $stateParams.projectTitle; }
+          'projectTitle': function($stateParams) { return $stateParams.projectTitle; },
+          'searching': function($stateParams) { return $stateParams.query_string || ''; },
+          'query_string': function($stateParams) { return $stateParams.query_string || ''; }
         }
       })
       .state('projects.search', {

--- a/designsafe/static/scripts/data-depot/controllers/data-depot-toolbar.js
+++ b/designsafe/static/scripts/data-depot/controllers/data-depot-toolbar.js
@@ -93,7 +93,7 @@
       },
       search: function(){
         var state = $scope.apiParams.searchState;
-        $state.go(state, {'query_string': $scope.search.queryString,
+        $state.go(state, {'query_string': $scope.search.queryString, 'searching': true,
                    'systemId': $scope.browser.listing.system,
                    'filePath': '$SEARCH'});
       }

--- a/designsafe/static/scripts/data-depot/controllers/data-depot-toolbar.js
+++ b/designsafe/static/scripts/data-depot/controllers/data-depot-toolbar.js
@@ -93,9 +93,9 @@
       },
       search: function(){
         var state = $scope.apiParams.searchState;
-        $state.go(state, {'query_string': $scope.search.queryString, 'searching': true,
+        $state.go(state, {'query_string': $scope.search.queryString,
                    'systemId': $scope.browser.listing.system,
-                   'filePath': '$SEARCH'});
+                   'filePath': '/'});
       }
     };
   }]);

--- a/designsafe/static/scripts/data-depot/controllers/projects.js
+++ b/designsafe/static/scripts/data-depot/controllers/projects.js
@@ -69,7 +69,6 @@
                 projectId: toStateParams.projectId,
                 filePath: filePath,
                 projectTitle: DataBrowserService.state().project.value.title,
-                searching: '',
                 query_string: ''
               })
             });
@@ -956,8 +955,7 @@
       $scope.browser.busy = true;
     }
     DataBrowserService.browse({system: 'project-' + projectId, path: filePath}, 
-                              {'query_string': $state.params.query_string,
-                              'searching': $state.params.searching})
+                              {'query_string': $state.params.query_string})
       .then(function () {
         $scope.browser = DataBrowserService.state();
         $scope.browser.busy = true;

--- a/designsafe/static/scripts/data-depot/controllers/projects.js
+++ b/designsafe/static/scripts/data-depot/controllers/projects.js
@@ -43,7 +43,7 @@
         }
       }
 
-    
+      
       if (toStateParams.filePath) {
         if (toStateParams.filePath === '/') {
           $scope.data.navItems.push({

--- a/designsafe/static/scripts/data-depot/controllers/projects.js
+++ b/designsafe/static/scripts/data-depot/controllers/projects.js
@@ -63,7 +63,6 @@
             if (e === '$SEARCH') {
               e = ''
             }
-            console.log(filePath)
             $scope.data.navItems.push({
               label: e || DataBrowserService.state().project.value.title,
               href: $state.href('projects.view.data', {
@@ -183,7 +182,6 @@
     }
 
     ProjectService.get({uuid: projectId}).then(function (project) {
-      console.log('ProjectViewCtrl has retrieved project metadata.')
       $scope.data.project = project;
       DataBrowserService.state().project = project;
       DataBrowserService.state().loadingEntities = true;
@@ -957,10 +955,6 @@
     if (typeof $scope.browser !== 'undefined'){
       $scope.browser.busy = true;
     }
-    //console.log(DataBrowserService.state())
-    //console.log($scope)
-    //console.log(DataBrowserService.state())
-    //console.log($scope.browser.project)
     DataBrowserService.browse({system: 'project-' + projectId, path: filePath}, 
                               {'query_string': $state.params.query_string,
                               'searching': $state.params.searching})
@@ -1000,8 +994,6 @@
           });
         }
       }).then(function(){
-        console.log('ProjectDataCtrl is about to use the project metadata to display the listing. Printing $scope.browser.project...');
-        console.log($scope.browser.project);
         $http.get('/api/projects/publication/' + $scope.browser.project.value.projectId)
           .then(function(resp){
               if (resp.data.project && resp.data.project.doi){

--- a/designsafe/static/scripts/data-depot/controllers/projects.js
+++ b/designsafe/static/scripts/data-depot/controllers/projects.js
@@ -43,7 +43,7 @@
         }
       }
 
-      
+
       if (toStateParams.filePath) {
         if (toStateParams.filePath === '/') {
           $scope.data.navItems.push({

--- a/designsafe/static/scripts/data-depot/templates/data-depot-toolbar.html
+++ b/designsafe/static/scripts/data-depot/templates/data-depot-toolbar.html
@@ -12,7 +12,7 @@
     </div>
     <div class="btn-toolbar btn-toolbar-right" role="toolbar" aria-label="Data Browser Toolbar">
         <form class="navbar-form navbar-left" ng-submit="ops.search()" style="display:flex" 
-            ng-hide="['Dropbox', 'Box', 'Google Drive', 'Project View', 'Project Data View'].includes(placeholder())">
+            ng-hide="['Dropbox', 'Box', 'Google Drive', 'Project View'].includes(placeholder())">
             <input class="form-control" style="width:240px;" placeholder="Find in {{ placeholder() }}" ng-model="search.queryString">
             <button class="btn btn-default" style="clear: right;"> <i class="fa fa-search"></i> </button>
         </form>

--- a/designsafe/static/scripts/ng-designsafe/services/data-browser-service.js
+++ b/designsafe/static/scripts/ng-designsafe/services/data-browser-service.js
@@ -204,7 +204,7 @@
      * @param options.system
      * @param options.path
      */
-    function browse (options) {
+    function browse (options, params) {
       // resolve any ongoing requests
       if(req){
         req.stopper.resolve();
@@ -219,7 +219,12 @@
       currentState.busyListingPage = false;
       currentState.page = 0;
 
-      req = FileListing.get(options, apiParams); // stopper is returned here...
+      if (params) {
+        req = FileListing.get(options, apiParams, params); // stopper is returned here...
+      }
+      else {
+        req = FileListing.get(options, apiParams); // stopper is returned here... 
+      }
 
       var currentReq = req.then(function (listing) {
         select([], true);


### PR DESCRIPTION
Implements a search within projects in My Projects (previously searches could only be run from the general projects listing).

This is done by adding a `query_string` argument to the `projects.view.data` router state and using it to display search results. An optional `params` argument was added to the `DataBrowserService.browse` method so that the query string can be passed to the backend without affecting file listings in other parts of the Data Depot.

![proj_search_big](https://user-images.githubusercontent.com/12601812/42002298-62bc643c-7a2c-11e8-8525-85e86b4f36ca.gif)

