### PR TITLE
task/DES-589 "Show" link on reports does not display data

### DIFF
--- a/designsafe/static/scripts/ng-designsafe/html/directives/dd-listing.html
+++ b/designsafe/static/scripts/ng-designsafe/html/directives/dd-listing.html
@@ -2404,7 +2404,7 @@
                   <p style="overflow:hidden; display:block; height:20px;">
                     <span style="font-weight:bold;">Description: </span>{{report.value.description}}
                   </p>
-                  <button class="btn btn-link btn-sm" ng-click="publicationCtrl.showText(analysis.value.description)">
+                  <button class="btn btn-link btn-sm" ng-click="publicationCtrl.showText(report.value.description)">
                     <i class="fa fa-external-link"></i> Show
                   </button>
                 </div>


### PR DESCRIPTION
https://jira.tacc.utexas.edu/browse/DES-589

 "Show" link on reports now display data. 

Given most updated code on portal the "show" link is only currently available on experimental projects, but the change made should work for all sorts of projects when this link comes to be available in other sorts of projects such as simulation and hybrid.