### PR TITLE
WIP: Setup for RAMP verification

### DIFF
--- a/conf/RAMP/google136a59fe45020610.html
+++ b/conf/RAMP/google136a59fe45020610.html
@@ -1,0 +1,1 @@
+google-site-verification: google136a59fe45020610.html

--- a/conf/docker/docker-compose-dev.all.debug.yml
+++ b/conf/docker/docker-compose-dev.all.debug.yml
@@ -62,6 +62,7 @@ services:
     image: nginx
     volumes:
       - ../nginx/nginx.debug.conf:/etc/nginx/nginx.conf
+      - ../RAMP/google136a59fe45020610.html:/var/www/designsafe-ci.org/static/google136a59fe45020610.html
       - ../nginx/gzip.conf:/etc/nginx/gzip.conf
       - ../nginx/certificates/designsafe.dev.crt:/etc/ssl/designsafe.dev.crt
       - ../nginx/certificates/designsafe.dev.key:/etc/ssl/designsafe.dev.key

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -77,6 +77,10 @@ http {
             alias /corral-repl/tacc/NHERI/;
         }
 
+        location /data/browser/public/nees.public/google136a59fe45020610.html {
+            alias /var/www/designsafe-ci.org/static/google136a59fe45020610.html;
+        }
+
         location / {
             proxy_pass  http://django:8000/;
             proxy_set_header Host $host;

--- a/conf/nginx/nginx.debug.conf
+++ b/conf/nginx/nginx.debug.conf
@@ -71,6 +71,10 @@ http {
             alias /var/www/designsafe-ci.org/robots.txt;
         }
 
+        location /google136a59fe45020610.html {
+            alias /var/www/designsafe-ci.org/static/google136a59fe45020610.html;
+        }
+
         location /internal-resource {
             internal;
             alias /corral-repl/tacc/NHERI/;

--- a/conf/nginx/nginx.debug.conf
+++ b/conf/nginx/nginx.debug.conf
@@ -71,7 +71,7 @@ http {
             alias /var/www/designsafe-ci.org/robots.txt;
         }
 
-        location /google136a59fe45020610.html {
+        location /data/browser/public/nees.public/google136a59fe45020610.html {
             alias /var/www/designsafe-ci.org/static/google136a59fe45020610.html;
         }
 


### PR DESCRIPTION
Set up Nginx to serve a RAMP verification file. In staging/prod we'll need to define the following new volume in the Nginx service:

`../RAMP/google136a59fe45020610.html:/var/www/designsafe-ci.org/static/google136a59fe45020610.html`