### PR TITLE
DES-562: add RAMP verification through django urls

### DIFF
--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -527,6 +527,11 @@ GOOGLE_ANALYTICS_PROPERTY_ID = os.environ.get('GOOGLE_ANALYTICS_PROPERTY_ID', Fa
 # Google Site Verification
 #
 GOOGLE_SITE_VERIFICATION_ID = os.environ.get('GOOGLE_SITE_VERIFICATION_ID', False)
+
+# RAMP Verification
+#
+RAMP_VERIFICATION_ID = os.environ.get('RAMP_VERIFICATION_ID', False)
+
 ###
 # Agave Integration
 #

--- a/designsafe/templates/ramp_verification.html
+++ b/designsafe/templates/ramp_verification.html
@@ -1,0 +1,1 @@
+google-site-verification: google136a59fe45020610.html

--- a/designsafe/urls.py
+++ b/designsafe/urls.py
@@ -66,6 +66,9 @@ urlpatterns = [
 
     url(r'^api/', include('designsafe.apps.api.urls', namespace='designsafe_api')),
 
+    # RAMP verification
+    url(r'^data/browser/public/nees.public/{}.html$'.format(settings.RAMP_VERIFICATION_ID), TemplateView.as_view(template_name='ramp_verification.html')),
+    
     # api urls, just for the samples.
     url(r'^applications/', include('designsafe.apps.applications.urls',
                                 namespace='designsafe_applications')),


### PR DESCRIPTION
Serve a RAMP verification file. We need to add the following line to `designsafe.env`:

`RAMP_VERIFICATION_ID=google136a59fe45020610`