### PR TITLE
Task/des 149

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Improvements:
 
 - Remove `nodeCount` parameter in front end.
 - Add email notification for new users.
+- Add user report for admins.
 
 Fixes:
 

--- a/designsafe/apps/accounts/tasks.py
+++ b/designsafe/apps/accounts/tasks.py
@@ -31,7 +31,7 @@ def create_report(username, list_name):
         )
         csv_file = StringIO.StringIO()
         writer = csv.writer(csv_file)
-        writer.writerow(["Last Name","First Name","Email","Phone Number","Institution ID",\
+        writer.writerow(["Last Name","First Name","Email","Phone Number","Institution",\
             "Title", "Professional Level","Bio","NH_interests","Research Activities","Username",\
             "Ethnicity","Gender","Country of residence","Citizenship","Date Account Created",\
             ])
@@ -52,10 +52,10 @@ def create_report(username, list_name):
 
                 # order of items as required by user
                 writer.writerow([user_profile.lastName.encode('utf-8') if user_profile.lastName else user_profile.lastName,
-                    user_profile.firstName.encode('utf-8') if user_profile.firstName else user_profile.firstName,
+                    user_profile.firstName.encode('utf-8') if user_profile.firstName else user_profile.firstName, # delete these if statements.
                     user_profile.email,
                     user_profile.phone,
-                    user_profile.institutionId,
+                    user_profile.institution.encode('ascii', 'ignore'),
                     user_profile.title,
                     designsafe_user.profile.professional_level,
                     designsafe_user.profile.bio.encode('utf-8') if designsafe_user.profile.bio else designsafe_user.profile.bio,

--- a/designsafe/apps/accounts/tasks.py
+++ b/designsafe/apps/accounts/tasks.py
@@ -32,15 +32,16 @@ def create_report(username, list_name):
         csv_file = StringIO.StringIO()
         writer = csv.writer(csv_file)
         writer.writerow(["Last Name","First Name","Email","Phone Number","Institution ID",\
-            "Professional Level","Bio","NH_interests","Research Activities","Username",\
+            "Title", "Professional Level","Bio","NH_interests","Research Activities","Username",\
             "Ethnicity","Gender","Country of residence","Citizenship","Date Account Created",\
             ])
 
         for user in notification_list:
             user_profile = TASUser(username=user)
             designsafe_user = get_user_model().objects.get(username=user)
+            
             if hasattr(designsafe_user, "profile"):
-                
+
                 #making nh_interests QuerySet into list
                 interests = designsafe_user.profile.nh_interests.all().values('description')
                 nh_interests = [interest['description'].encode('utf-8') for interest in interests]
@@ -55,6 +56,7 @@ def create_report(username, list_name):
                     user_profile.email,
                     user_profile.phone,
                     user_profile.institutionId,
+                    user_profile.title,
                     designsafe_user.profile.professional_level,
                     designsafe_user.profile.bio.encode('utf-8') if designsafe_user.profile.bio else designsafe_user.profile.bio,
                     nh_interests if nh_interests else None,
@@ -67,9 +69,8 @@ def create_report(username, list_name):
                     designsafe_user.date_joined.date()
                 ])
 
-        User = get_user_model()
-        u = User.objects.get(username=username)
-        client = u.agave_oauth.client
+        User = get_user_model().objects.get(username=username)
+        client = User.agave_oauth.client
 
         setattr(csv_file, 'name', 'user_report.csv')
         client.files.importData(

--- a/designsafe/apps/accounts/tasks.py
+++ b/designsafe/apps/accounts/tasks.py
@@ -1,0 +1,88 @@
+import csv
+import StringIO
+import logging
+from django.conf import settings
+from agavepy.agave import Agave, AgaveException
+from celery import shared_task
+from requests import HTTPError
+from django.contrib.auth import get_user_model
+from pytas.models import User as TASUser
+from django.db.models import Q
+from designsafe.apps.accounts.models import (DesignSafeProfile,
+                                             NotificationPreferences)
+
+
+logger = logging.getLogger(__name__)
+
+@shared_task(default_retry_delay=1*30, max_retries=3)
+def create_report(username, list_name):
+   
+    notification_list = get_user_model().objects.filter(
+            Q(notification_preferences__isnull=True) |
+            Q(**{"notification_preferences__{}".format(list_name): True}))
+
+    try:
+
+        logger.info(
+            "Creating user report for user=%s on "
+            "default storage systemId=%s",
+            username,
+            settings.AGAVE_STORAGE_SYSTEM
+        )
+        csv_file = StringIO.StringIO()
+        writer = csv.writer(csv_file)
+        writer.writerow(["Last Name","First Name","Email","Phone Number","Institution ID",\
+            "Professional Level","Bio","NH_interests","Research Activities","Username",\
+            "Ethnicity","Gender","Country of residence","Citizenship","Date Account Created",\
+            ])
+
+        for user in notification_list:
+            user_profile = TASUser(username=user)
+            designsafe_user = get_user_model().objects.get(username=user)
+            if hasattr(designsafe_user, "profile"):
+                
+                #making nh_interests QuerySet into list
+                interests = designsafe_user.profile.nh_interests.all().values('description')
+                nh_interests = [interest['description'].encode('utf-8') for interest in interests]
+                
+                #making research_activities QuerySet into list
+                activities = designsafe_user.profile.research_activities.all().values('description')
+                research_activities = [activity['description'].encode('utf-8') for activity in activities]
+
+                # order of items as required by user
+                writer.writerow([user_profile.lastName.encode('utf-8') if user_profile.lastName else user_profile.lastName,
+                    user_profile.firstName.encode('utf-8') if user_profile.firstName else user_profile.firstName,
+                    user_profile.email,
+                    user_profile.phone,
+                    user_profile.institutionId,
+                    designsafe_user.profile.professional_level,
+                    designsafe_user.profile.bio.encode('utf-8') if designsafe_user.profile.bio else designsafe_user.profile.bio,
+                    nh_interests if nh_interests else None,
+                    research_activities if research_activities else None,
+                    user_profile,
+                    designsafe_user.profile.ethnicity,
+                    designsafe_user.profile.gender,
+                    user_profile.country,
+                    user_profile.citizenship,
+                    designsafe_user.date_joined.date()
+                ])
+
+        User = get_user_model()
+        u = User.objects.get(username=username)
+        client = u.agave_oauth.client
+
+        setattr(csv_file, 'name', 'user_report.csv')
+        client.files.importData(
+           filePath=username,
+           fileName='user_report.csv',
+           systemId=settings.AGAVE_STORAGE_SYSTEM,
+           fileToUpload=csv_file
+           )
+       
+        csv_file.close()
+
+    except (HTTPError, AgaveException):
+        logger.exception('Failed to create user report.',
+                         extra={'user': username,
+                                'systemId': settings.AGAVE_STORAGE_SYSTEM})
+

--- a/designsafe/apps/accounts/tasks.py
+++ b/designsafe/apps/accounts/tasks.py
@@ -52,10 +52,10 @@ def create_report(username, list_name):
 
                 # order of items as required by user
                 writer.writerow([user_profile.lastName.encode('utf-8') if user_profile.lastName else user_profile.lastName,
-                    user_profile.firstName.encode('utf-8') if user_profile.firstName else user_profile.firstName, # delete these if statements.
+                    user_profile.firstName.encode('utf-8') if user_profile.firstName else user_profile.firstName, 
                     user_profile.email,
                     user_profile.phone,
-                    user_profile.institution.encode('ascii', 'ignore'),
+                    user_profile.institution.encode('utf-8'),
                     user_profile.title,
                     designsafe_user.profile.professional_level,
                     designsafe_user.profile.bio.encode('utf-8') if designsafe_user.profile.bio else designsafe_user.profile.bio,

--- a/designsafe/apps/accounts/templates/designsafe/apps/accounts/generating_user_report.html
+++ b/designsafe/apps/accounts/templates/designsafe/apps/accounts/generating_user_report.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% load bootstrap3 sekizai_tags staticfiles %}
+
+{% block title %}Generating User Report{% endblock %}
+
+{% block content %}
+<div class="container">
+    <h1>Generating User Report ...</h1>
+
+    <h3>The report will be available in your home directory in a few minutes</h3>
+
+</div>
+{% endblock %}

--- a/designsafe/apps/accounts/tests.py
+++ b/designsafe/apps/accounts/tests.py
@@ -84,6 +84,28 @@ class AccountsTests(TestCase):
         self.assertNotContains(
             resp, '"{0}","{1}"'.format(ds_user.get_full_name(), ds_user.email))
 
+    def test_user_report_access(self):
+        """
+        Access to user report restricted to users with view_notification_subscribers
+        permission.
+        :return:
+        """
+        url = reverse('designsafe_accounts:user_report',
+                      args=('announcements',))
+
+        self.client.login(username='ds_user', password='user/password')
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 403)
+        self.client.logout()
+        user = get_user_model().objects.get(pk=2)
+        perm = Permission.objects.get(codename='view_notification_subscribers')
+        user.user_permissions.add(perm)
+
+        self.client.login(username='ds_user', password='user/password')
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, 'Generating User Report')
+
     def test_professional_profile_manage(self):
         url = reverse('designsafe_accounts:manage_pro_profile')
         self.client.login(username='ds_admin', password='admin/password')

--- a/designsafe/apps/accounts/urls.py
+++ b/designsafe/apps/accounts/urls.py
@@ -24,6 +24,9 @@ urlpatterns = [
     url(r'^mailing-list/(?P<list_name>.*)/$', views.mailing_list_subscription,
         name='mailing_list_subscription'),
 
+    url(r'^user-report/(?P<list_name>.*)/$', views.user_report,
+        name='user_report'),
+
     url(r'^terms-conditions/$', views.termsandconditions, name="terms_conditions"),
 ]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8302,8 +8302,8 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
       "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
       "dev": true,
-      "requires": {
-        "lodash": "4.17.4"
+      "requires": {	
+        "lodash": "4.17.4"	
       }
     },
     "xmlhttprequest-ssl": {


### PR DESCRIPTION
This is a continuation and cleanup of the [PR for DES-149](https://github.com/DesignSafe-CI/portal/pull/269).

I have marked this with as the "Celery" branch, because it completes the task with a Celery job that writes the user_report to the user's Agave home directory.  Tim has expressed that while this is ok, he would prefer that the report is just downloaded straight to his computer.  

Since I wasn't involved with the decision, and @xirdneh (who was) is out, I would push both a branch that stores the user_report in Agave and a branch that saves the file directly to the user's local machine.