### PR TITLE
task/DES-663 move and copy toolbar button fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Improvements:
 Fixes:
 
 - Licenses names for publication.
+- File toolbar pems checking.
 
 ## v2.7.1-20180805
 

--- a/designsafe/static/scripts/ng-designsafe/services/data-browser-service.js
+++ b/designsafe/static/scripts/ng-designsafe/services/data-browser-service.js
@@ -171,15 +171,14 @@
 
       var tests = {};
       tests.canDownload = files.length >= 1 && hasPermission('READ', files) && (!(containsFolder(files)));
-      tests.canPreview = files.length === 1 && hasPermission('READ', files);
-      tests.canPreviewImages = files.length >= 1 && hasPermission('READ', files) && !['dropboxData', 'boxData', 'googledriveData'].includes($state.current.name);
-      tests.canViewMetadata = files.length >= 1 && hasPermission('READ', files);
+      tests.canPreview = files.length === 1 && hasPermission('READ', files) && !['publicData'].includes($state.current.name);
+      tests.canPreviewImages = files.length >= 1 && hasPermission('READ', files) && !['dropboxData', 'boxData', 'googledriveData', 'publicData'].includes($state.current.name);
+      tests.canViewMetadata = files.length >= 1 && hasPermission('READ', files) && !['publicData', 'publishedData', 'communityData'].includes($state.current.name);
       tests.canViewCitation = files.length >= 1 && hasPermission('READ', files);
       tests.canShare = files.length === 1 && $state.current.name === 'myData';
-      tests.canCopy = files.length >= 1 && hasPermission('READ', files);
-      // following two tests do not work...
-      // tests.canMove = files.length >= 1 && hasPermission('WRITE', [currentState.listing].concat(files)) && !['dropboxData', 'boxData', 'googledriveData'].includes($state.current.name);
-      // tests.canRename = files.length === 1 && hasPermission('WRITE', [currentState.listing].concat(files)) && !['dropboxData', 'boxData', 'googledriveData'].includes($state.current.name);
+      tests.canCopy = files.length >= 1 && hasPermission('READ', files) && !['publicData'].includes($state.current.name);
+      tests.canMove = files.length >= 1 && hasPermission('WRITE', files) && !['dropboxData', 'boxData', 'googledriveData', 'publicData', 'publishedData', 'communityData'].includes($state.current.name);
+      tests.canRename = files.length === 1 && hasPermission('WRITE', files) && !['dropboxData', 'boxData', 'googledriveData', 'publicData', 'publishedData', 'communityData'].includes($state.current.name);
       tests.canViewCategories = true;
 
       var trashPath = _trashPath();


### PR DESCRIPTION
Fixed tests for the toolbar buttons and disabled the tag, move, and rename buttons in Community and Published areas of the Data Depot