### PR TITLE
Task/des 479

### DIFF
--- a/designsafe/static/scripts/data-depot/app.js
+++ b/designsafe/static/scripts/data-depot/app.js
@@ -430,10 +430,7 @@
       .state('publicData', {
         url: '/public/nees.public/{filePath:any}',
         controller: 'PublicationDataCtrl',
-        // templateUrl: '/static/scripts/data-depot/templates/agave-public-data-listing.html',
-        templateUrl: '/static/scripts/data-depot/templates/nees-project-metadata.html',
-        // templateUrl: '/static/scripts/data-depot/templates/data-published-metadata-copy.html',
-
+        templateUrl: '/static/scripts/data-depot/templates/agave-public-data-listing.html',
         params: {
           systemId: 'nees.public',
           filePath: ''

--- a/designsafe/static/scripts/data-depot/app.js
+++ b/designsafe/static/scripts/data-depot/app.js
@@ -430,7 +430,10 @@
       .state('publicData', {
         url: '/public/nees.public/{filePath:any}',
         controller: 'PublicationDataCtrl',
-        templateUrl: '/static/scripts/data-depot/templates/agave-public-data-listing.html',
+        // templateUrl: '/static/scripts/data-depot/templates/agave-public-data-listing.html',
+        templateUrl: '/static/scripts/data-depot/templates/nees-project-metadata.html',
+        // templateUrl: '/static/scripts/data-depot/templates/data-published-metadata-copy.html',
+
         params: {
           systemId: 'nees.public',
           filePath: ''

--- a/designsafe/static/scripts/data-depot/app.js
+++ b/designsafe/static/scripts/data-depot/app.js
@@ -428,7 +428,7 @@
         }
       })
       .state('publicData', {
-        url: '/public/nees.public/{filePath:any}',
+        url: '/public/nees.public/',
         controller: 'PublicationDataCtrl',
         templateUrl: '/static/scripts/data-depot/templates/agave-public-data-listing.html',
         params: {
@@ -485,12 +485,40 @@
           }]
         }
       })
+      .state('publishedNeesData', {
+        url: '/public/nees.public/{filePath:any}',
+        controller: 'PublishedDataCtrl',
+        templateUrl: '/static/scripts/data-depot/templates/published-data-listing.html',
+        params: {
+          systemId: 'nees.public',
+          filePath: ''
+        },
+        resolve: {
+          'listing': ['$stateParams', 'DataBrowserService', function ($stateParams, DataBrowserService) {
+            var systemId = $stateParams.systemId || 'nees.public';
+            var filePath = $stateParams.filePath;
+            DataBrowserService.apiParams.fileMgr = 'published';
+            DataBrowserService.apiParams.baseUrl = '/api/public/files';
+            DataBrowserService.apiParams.searchState = 'publicDataSearch';
+            return DataBrowserService.browse({ system: systemId, path: filePath });
+          }],
+          'auth': function ($q) {
+            return true;
+          },
+          userAuth: ['UserService', function (UserService) {
+            return UserService.authenticate().then(function (resp) {
+              return true;
+            }, function (err) {
+              return false;
+            });
+          }]
+        }
+      })
       .state('trainingMaterials', {
         url: '/training/',
         template: '<pre>local/trainingMaterials.html</pre>'
       })
-    ;
-
+      ;
     $urlRouterProvider.otherwise(function($injector, $location) {
       var $state = $injector.get('$state');
 

--- a/designsafe/static/scripts/data-depot/controllers/publications.js
+++ b/designsafe/static/scripts/data-depot/controllers/publications.js
@@ -49,14 +49,11 @@
     };
 
     $scope.onBrowse = function($event, file) {
-      console.log('I am printing from on browser publications.js')
       $event.preventDefault();
       $event.stopPropagation();
 
       var systemId = file.system || file.systemId;
-      console.log (systemId)
       var filePath;
-      console.log(filePath)
       if (file.path == '/'){
         filePath = file.path + file.name;
       } else {
@@ -66,12 +63,14 @@
         DataBrowserService.preview(file, $scope.browser.listing);
       } else {
         if (file.system === 'nees.public'){
-          // DataBrowserService.viewMetadata([file], $scope.browser.listing);
-          $state.go('publicData', {systemId: file.system, filePath: file.path});
-          // designsafe.dev/data/browser/public/nees.public//NEES-2006-0202.groups
+          // $state.go('publicData', {systemId: file.system, filePath: file.path});
+          DataBrowserService.viewMetadata([file], $scope.browser.listing);
+          // by changing the $state.go of publicData for the DataBrowserService above
+          // when you click the name of a Ness project under published it redirects you the metadata we want. It loads however as a modal,
+          // we want take the content of this modal and pass it as a regular html. In order to do this you will most likely have to create a new controller.
+         
         } else {
           $state.go('publishedData', {systemId: file.system, filePath: file.path});
-          // designsafe.dev/data/browser/public/designsafe.storage.published//PRJ-2056
         }
       }
     };
@@ -123,7 +122,6 @@
     };
 
     $scope.renderName = function(file){
-      console.log('I am printing from publications.js')
       if (typeof file.metadata === 'undefined' ||
           file.metadata === null ||
           _.isEmpty(file.metadata)){

--- a/designsafe/static/scripts/data-depot/controllers/publications.js
+++ b/designsafe/static/scripts/data-depot/controllers/publications.js
@@ -49,11 +49,14 @@
     };
 
     $scope.onBrowse = function($event, file) {
+      console.log('I am printing from on browser publications.js')
       $event.preventDefault();
       $event.stopPropagation();
 
       var systemId = file.system || file.systemId;
+      console.log (systemId)
       var filePath;
+      console.log(filePath)
       if (file.path == '/'){
         filePath = file.path + file.name;
       } else {
@@ -63,9 +66,12 @@
         DataBrowserService.preview(file, $scope.browser.listing);
       } else {
         if (file.system === 'nees.public'){
+          // DataBrowserService.viewMetadata([file], $scope.browser.listing);
           $state.go('publicData', {systemId: file.system, filePath: file.path});
+          // designsafe.dev/data/browser/public/nees.public//NEES-2006-0202.groups
         } else {
           $state.go('publishedData', {systemId: file.system, filePath: file.path});
+          // designsafe.dev/data/browser/public/designsafe.storage.published//PRJ-2056
         }
       }
     };
@@ -117,6 +123,7 @@
     };
 
     $scope.renderName = function(file){
+      console.log('I am printing from publications.js')
       if (typeof file.metadata === 'undefined' ||
           file.metadata === null ||
           _.isEmpty(file.metadata)){

--- a/designsafe/static/scripts/data-depot/controllers/publications.js
+++ b/designsafe/static/scripts/data-depot/controllers/publications.js
@@ -63,12 +63,7 @@
         DataBrowserService.preview(file, $scope.browser.listing);
       } else {
         if (file.system === 'nees.public'){
-          // $state.go('publicData', {systemId: file.system, filePath: file.path});
-          DataBrowserService.viewMetadata([file], $scope.browser.listing);
-          // by changing the $state.go of publicData for the DataBrowserService above
-          // when you click the name of a Ness project under published it redirects you the metadata we want. It loads however as a modal,
-          // we want take the content of this modal and pass it as a regular html. In order to do this you will most likely have to create a new controller.
-         
+          $state.go('publishedNeesData', {systemId: file.system, filePath: file.path});
         } else {
           $state.go('publishedData', {systemId: file.system, filePath: file.path});
         }

--- a/designsafe/static/scripts/data-depot/templates/published-data-listing.html
+++ b/designsafe/static/scripts/data-depot/templates/published-data-listing.html
@@ -623,7 +623,7 @@
   </div>
 </div>
 
-<div ng-if="project.value.projectType == 'simulation' && filePathComps.length <= 1">  <!-- simulation publishe dview -->
+<div ng-if="project.value.projectType == 'simulation' && filePathComps.length <= 1">  <!-- simulation published view -->
 
   <div ng-repeat="simulation in browser.publication.simulations | orderBy: 'value.title'" style="#fff;">
     <div class="dropdown entity-preview-header" id="details-{{simulation.uuid}}">

--- a/designsafe/static/scripts/ng-designsafe/html/directives/dd-public-listing.html
+++ b/designsafe/static/scripts/ng-designsafe/html/directives/dd-public-listing.html
@@ -10,7 +10,7 @@
         <th style="width: 100px;">Date of Publication</th>
         <th style="width: 100px;">Project Type</th>
         <th style="width: 100px;">Project Number</th>
-        <th style="width: 100px;">NEES Project Metadata</th>
+        <!-- <th style="width: 100px;">NEES Project Metadata</th> -->
         </thead>
 
         <tbody>
@@ -49,14 +49,14 @@
             <td ng-if="!item.meta.projectId">
               N/A
             </td>
-            <td ng-if="item.system === 'nees.public'" ng-click="onMetadata()($event, item)">
+            <!-- <td ng-if="item.system === 'nees.public'" ng-click="onMetadata()($event, item)">
               <button class="btn btn-sm btn-default" ng-click="onMetadata()($event, item)">
                 <i class="fa fa-tags"></i>View Metadata
               </button>
             </td>
             <td ng-if="item.system !== 'nees.public'">
                 N/A
-            </td>
+            </td> -->
         </tr>
         <tr ng-if="browser.busyListingPage">
           <td>

--- a/designsafe/static/scripts/ng-designsafe/html/directives/dd-public-listing.html
+++ b/designsafe/static/scripts/ng-designsafe/html/directives/dd-public-listing.html
@@ -10,7 +10,7 @@
         <th style="width: 100px;">Date of Publication</th>
         <th style="width: 100px;">Project Type</th>
         <th style="width: 100px;">Project Number</th>
-        <!-- <th style="width: 100px;">NEES Project Metadata</th> -->
+        <th style="width: 100px;">NEES Project Metadata</th> <!--TODO: DELETE THIS LINE -->
         </thead>
 
         <tbody>
@@ -49,14 +49,16 @@
             <td ng-if="!item.meta.projectId">
               N/A
             </td>
-            <!-- <td ng-if="item.system === 'nees.public'" ng-click="onMetadata()($event, item)">
+            <!-- TODO: DELETE STUFF BELOW HERE -->
+            <td ng-if="item.system === 'nees.public'" ng-click="onMetadata()($event, item)">
               <button class="btn btn-sm btn-default" ng-click="onMetadata()($event, item)">
                 <i class="fa fa-tags"></i>View Metadata
               </button>
             </td>
             <td ng-if="item.system !== 'nees.public'">
                 N/A
-            </td> -->
+            </td>
+            <!-- TODO: DELETE STUFF ABOVE HERE -->
         </tr>
         <tr ng-if="browser.busyListingPage">
           <td>

--- a/designsafe/static/scripts/ng-designsafe/html/modals/data-browser-service-published-metadata.html
+++ b/designsafe/static/scripts/ng-designsafe/html/modals/data-browser-service-published-metadata.html
@@ -1,10 +1,10 @@
-<div class="modal-header">
+<!-- <div class="modal-header">
     <h3 class="modal-title">Metadata</h3>
 </div>
-<div class="modal-body">
+<div class="modal-body"> -->
 <h3>{{data.file.metadata.project.title}}</h3>
-<uib-tabset active="active">
-    <uib-tab index="0" heading="Project">
+<!-- <uib-tabset active="active">
+    <uib-tab index="0" heading="Project"> -->
         <div class="table-responsive">
             <table class="table">
                 <thead>
@@ -106,13 +106,13 @@
                 </tbody>
             </table>
         </div>
-    </uib-tab>
+    <!-- </uib-tab>
     <uib-tab index="$index + 1" ng-repeat="tab in tabs" heading="{{tab.title}}" active="tab.active" disable="tab.disabled">
         {{tab.content}}
     </uib-tab>
     <uib-tab index="3">
         <uib-tab-heading>Experiments
-        </uib-tab-heading>
+        </uib-tab-heading> -->
         <div class="table-responsive">
             <table class="table">
                 <thead>
@@ -121,6 +121,9 @@
                         <th class="col-lg-10"></th>
                     </tr>
                 </thead>
+                <div style="width:100%;">
+                    <p><strong>Experiment</strong></p>
+                </div>
                 <tbody ng-repeat="experiment in data.file.metadata.experiments | orderBy: nameOrder">
                     <tr>
                         <td class="col-lg-2">{{experiment.name}}</td>
@@ -267,6 +270,6 @@
                 </tbody>
             </table>
         </div>
-    </uib-tab>
-</uib-tabset>
+    <!-- </uib-tab>
+</uib-tabset> -->
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.4.tgz",
+      "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
       "dev": true,
       "requires": {
         "jsonparse": "1.3.1",
@@ -329,9 +329,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.215.1",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.215.1.tgz",
-      "integrity": "sha1-6YN91aDCatO+mcm0H09UWPWjC48=",
+      "version": "2.320.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.320.0.tgz",
+      "integrity": "sha512-qJBjZ0sIIy6AzBe0RkK5HDl3Kl1uAz01R4Nqy+RyflB//XWz+dPN8CFYtzrQNyfpLtPe/4uPrmxC4NwGW1MXBQ==",
       "dev": true,
       "requires": {
         "buffer": "4.9.1",
@@ -342,8 +342,7 @@
         "sax": "1.2.1",
         "url": "0.10.3",
         "uuid": "3.1.0",
-        "xml2js": "0.4.17",
-        "xmlbuilder": "4.2.1"
+        "xml2js": "0.4.19"
       },
       "dependencies": {
         "punycode": {
@@ -354,7 +353,7 @@
         },
         "sax": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
           "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
           "dev": true
         },
@@ -1865,6 +1864,12 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decimal.js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.0.1.tgz",
+      "integrity": "sha512-vklWB5C4Cj423xnaOtsUmAv0/7GqlXIgDv2ZKDyR64OV3OSzGHNx2mk4p/1EKnB5s70k73cIOOEcG9YzF0q4Lw==",
+      "dev": true
+    },
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
@@ -2035,25 +2040,27 @@
       "dev": true
     },
     "elasticdump": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/elasticdump/-/elasticdump-3.3.7.tgz",
-      "integrity": "sha512-caNMIhwlUssZ4WTP+Au6LdYez6xp0jGoHEjSO8LTb5lhwFmP3/YcwUjmWrb5HPhJDdoy0e17jXJZUPiWzbTtDg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/elasticdump/-/elasticdump-3.4.0.tgz",
+      "integrity": "sha512-DHK6WpqZf5VTW9PK2UjkRADDacT6c2fsHFCy0pQ8c1VYUWz/zI5OGzBBPg5HTZbvTgY+AXJ3JHUB3E7Esktlog==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
+        "JSONStream": "1.3.4",
         "async": "2.6.0",
-        "aws-sdk": "2.215.1",
+        "aws-sdk": "2.320.0",
         "aws4": "1.6.0",
+        "decimal.js": "10.0.1",
         "ini": "1.3.5",
-        "lodash": "4.17.5",
+        "lodash": "4.17.11",
+        "lossless-json": "1.0.3",
         "optimist": "0.6.1",
         "request": "2.79.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
         },
         "optimist": {
@@ -4740,6 +4747,12 @@
       "requires": {
         "js-tokens": "3.0.2"
       }
+    },
+    "lossless-json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-1.0.3.tgz",
+      "integrity": "sha512-r4w0WrhIHV1lOTVGbTg4Toqwso5x6C8pM7Q/Nto2vy4c7yUSdTYVYlj16uHVX3MT1StpSELDv8yrqGx41MBsDA==",
+      "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -7436,7 +7449,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -8288,23 +8301,20 @@
       "dev": true
     },
     "xml2js": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "dev": true,
       "requires": {
         "sax": "1.2.4",
-        "xmlbuilder": "4.2.1"
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4"
-      }
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-loader": "^7.1.2",
     "babel-preset-es2015": "^6.24.1",
     "css-loader": "^0.28.9",
-    "elasticdump": "^3.3.7",
+    "elasticdump": "^3.4.0",
     "extract-text-webpack-plugin": "^3.0.2",
     "html-webpack-plugin": "^2.30.1",
     "jasmine-core": "^2.4.1",


### PR DESCRIPTION
### **This is a work in progress**

This writes `NEES` metadata to the project page in the same way that `designsafe.storage.published` metadata is written on the page. 

I've written a new state, called `publishedNeesData`, that calls the same template and controller as `publishedData`.  This was necessary because any change to the controller that would be called when selecting a NEES project would also affect the Published data listing. So, they needed to be separated. 
 
Currently, the API call `https://designsafe.dev/api/projects/publication/NEES-XXXX-XXXX.groups` is getting a 404.  I haven't been able to figure out why, because that call is made in `neesCitation` in the `data-browser-service`.  