### PR TITLE
task/DES-676 uncategorized data notification and experiment sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # DesignSafe-CI Portal Release Notes
 
+## v2.7.6
+
+Fixes:
+
+- Notifications on publication workflow.
+- Sorting of entities.
+
 ## v2.7.5
 
 Fixes:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Build Status](https://travis-ci.org/DesignSafe-CI/portal.svg?branch=master)](https://travis-ci.org/DesignSafe-CI/portal) 
 [![codecov](https://codecov.io/gh/DesignSafe-CI/portal/branch/master/graph/badge.svg)](https://codecov.io/gh/DesignSafe-CI/portal)
+[![Maintainability](https://api.codeclimate.com/v1/badges/8399b864b0d115d86450/maintainability)](https://codeclimate.com/github/DesignSafe-CI/portal/maintainability)
+
 # DesignSafe-CI Portal
 
 ## Prequisites for running the portal application

--- a/designsafe/static/scripts/data-depot/controllers/projects.js
+++ b/designsafe/static/scripts/data-depot/controllers/projects.js
@@ -325,8 +325,9 @@
       project to check for missing files. If there is no categorized files
       within the "_set" we will return a notification to the user.
       */
-      function checkPrjModel(model, modelRelation, prjset, prjtype) {
+      function checkPrjModel(model, modelRelation, prjset, prjtype, setname) {
         if (model === undefined || model.length == 0) {
+          missing.push({'missingSet': setname});
           return;
         }
         model.forEach(function(m) {
@@ -349,23 +350,23 @@
       }
 
       if (ptype == 'simulation') {
-        checkPrjModel(proj.model_set, 'simulations', proj.simulation_set, 'simulation');
-        checkPrjModel(proj.output_set, 'simulations', proj.simulation_set, 'simulation');
-        checkPrjModel(proj.input_set, 'simulations', proj.simulation_set, 'simulation');
-        checkPrjModel(proj.analysis_set, 'simulations', proj.simulation_set, 'simulation');
-        checkPrjModel(proj.report_set, 'simulations', proj.simulation_set, 'simulation');
+        checkPrjModel(proj.model_set, 'simulations', proj.simulation_set, 'simulation', 'model');
+        checkPrjModel(proj.output_set, 'simulations', proj.simulation_set, 'simulation', 'simulation output');
+        checkPrjModel(proj.input_set, 'simulations', proj.simulation_set, 'simulation', 'simulation input');
+        // checkPrjModel(proj.analysis_set, 'simulations', proj.simulation_set, 'simulation', 'analysis');
+        // checkPrjModel(proj.report_set, 'simulations', proj.simulation_set, 'simulation', 'report');
       } else if (ptype == 'experimental') {
-        checkPrjModel(proj.modelconfig_set, 'experiments', proj.experiment_set, 'experiment');
-        checkPrjModel(proj.event_set, 'experiments', proj.experiment_set, 'experiment');
-        checkPrjModel(proj.sensorlist_set, 'experiments', proj.experiment_set, 'experiment');
-        checkPrjModel(proj.analysis_set, 'experiments', proj.experiment_set, 'experiment');
-        checkPrjModel(proj.report_set, 'experiments', proj.experiment_set, 'experiment');
+        checkPrjModel(proj.modelconfig_set, 'experiments', proj.experiment_set, 'experiment', 'model configuration');
+        checkPrjModel(proj.event_set, 'experiments', proj.experiment_set, 'experiment', 'event');
+        checkPrjModel(proj.sensorlist_set, 'experiments', proj.experiment_set, 'experiment', 'sensor list');
+        // checkPrjModel(proj.analysis_set, 'experiments', proj.experiment_set, 'experiment', 'analysis');
+        // checkPrjModel(proj.report_set, 'experiments', proj.experiment_set, 'experiment', 'report');
       } else if (ptype == 'hybrid_simulation') {
-        checkPrjModel(proj.globalmodel_set, 'hybridSimulations', proj.hybridsimulation_set, 'hybrid simulation');
-        checkPrjModel(proj.coordinator_set, 'hybridSimulations', proj.hybridsimulation_set, 'hybrid simulation');
-        checkPrjModel(proj.expsubstructure_set, 'hybridSimulations', proj.hybridsimulation_set, 'hybrid simulation');
-        checkPrjModel(proj.simsubstructure_set, 'hybridSimulations', proj.hybridsimulation_set, 'hybrid simulation');
-        checkPrjModel(proj.expoutput_set, 'hybridSimulations', proj.hybridsimulation_set, 'hybrid simulation');
+        checkPrjModel(proj.globalmodel_set, 'hybridSimulations', proj.hybridsimulation_set, 'hybrid simulation', 'global model');
+        checkPrjModel(proj.coordinator_set, 'hybridSimulations', proj.hybridsimulation_set, 'hybrid simulation', 'master simulation coordinator');
+        checkPrjModel(proj.expsubstructure_set, 'hybridSimulations', proj.hybridsimulation_set, 'hybrid simulation', 'experimental substructure');
+        checkPrjModel(proj.simsubstructure_set, 'hybridSimulations', proj.hybridsimulation_set, 'hybrid simulation', 'simulation substructure');
+        checkPrjModel(proj.expoutput_set, 'hybridSimulations', proj.hybridsimulation_set, 'hybrid simulation', 'output set');
       }
       $scope.browser.missing = missing;
     };

--- a/designsafe/static/scripts/data-depot/controllers/projects.js
+++ b/designsafe/static/scripts/data-depot/controllers/projects.js
@@ -315,6 +315,61 @@
       });
     };
 
+    $scope.checkEmptyCategories = function(){
+      var missing = [];
+      var ptype = $scope.data.project.value.projectType;
+      var proj = $scope.data.project;
+
+      /*
+      This function will reach into each supplied model or "_set" within the
+      project to check for missing files. If there is no categorized files
+      within the "_set" we will return a notification to the user.
+      */
+      function checkPrjModel(model, modelRelation, prjset, prjtype) {
+        if (model === undefined || model.length == 0) {
+          return;
+        }
+        model.forEach(function(m) {
+          if (m.value.files.length === 0) {
+            m.value[modelRelation].forEach(function(mr){
+              prjset.forEach(function(p){
+                if (p.uuid == mr) {
+                  var ptitle = p.value.title;
+                  var modeltitle = m.value.title;
+                  var obj = {};
+                  obj.title = ptitle;
+                  obj.model = modeltitle;
+                  obj.type = prjtype;
+                  missing.push(obj);
+                }
+              });
+            });
+          }
+        });
+      }
+
+      if (ptype == 'simulation') {
+        checkPrjModel(proj.model_set, 'simulations', proj.simulation_set, 'simulation');
+        checkPrjModel(proj.output_set, 'simulations', proj.simulation_set, 'simulation');
+        checkPrjModel(proj.input_set, 'simulations', proj.simulation_set, 'simulation');
+        checkPrjModel(proj.analysis_set, 'simulations', proj.simulation_set, 'simulation');
+        checkPrjModel(proj.report_set, 'simulations', proj.simulation_set, 'simulation');
+      } else if (ptype == 'experimental') {
+        checkPrjModel(proj.modelconfig_set, 'experiments', proj.experiment_set, 'experiment');
+        checkPrjModel(proj.event_set, 'experiments', proj.experiment_set, 'experiment');
+        checkPrjModel(proj.sensorlist_set, 'experiments', proj.experiment_set, 'experiment');
+        checkPrjModel(proj.analysis_set, 'experiments', proj.experiment_set, 'experiment');
+        checkPrjModel(proj.report_set, 'experiments', proj.experiment_set, 'experiment');
+      } else if (ptype == 'hybrid_simulation') {
+        checkPrjModel(proj.globalmodel_set, 'hybridSimulations', proj.hybridsimulation_set, 'hybrid simulation');
+        checkPrjModel(proj.coordinator_set, 'hybridSimulations', proj.hybridsimulation_set, 'hybrid simulation');
+        checkPrjModel(proj.expsubstructure_set, 'hybridSimulations', proj.hybridsimulation_set, 'hybrid simulation');
+        checkPrjModel(proj.simsubstructure_set, 'hybridSimulations', proj.hybridsimulation_set, 'hybrid simulation');
+        checkPrjModel(proj.expoutput_set, 'hybridSimulations', proj.hybridsimulation_set, 'hybrid simulation');
+      }
+      $scope.browser.missing = missing;
+    };
+
     $scope.dateString = function(s){
       var d = Date(s);
       return d;
@@ -329,6 +384,7 @@
     $scope.showPreview = function(){
       //DataBrowserService.state().showMainListing = false;
       //DataBrowserService.state().showPreviewListing = true;
+      $scope.checkEmptyCategories();
       $scope.previewHref = undefined;
       DataBrowserService.showPreview();
       // FileListing.get({'system': $scope.browser.listing.system,

--- a/designsafe/static/scripts/data-depot/templates/project-view.html
+++ b/designsafe/static/scripts/data-depot/templates/project-view.html
@@ -171,7 +171,8 @@
         <div class="alert alert-danger" ng-if="(state.publishPipeline == 'select' || state.publishPipeline == 'review') && state.missing.length > 0">
           <strong>The following categories do not have associated data:</strong>
           <div ng-repeat="missing in state.missing">
-            <span>The category "{{missing.model}}" within the {{missing.type}} "{{missing.title}}" has no categorized files.</span>
+            <span ng-if="missing.model">The category "{{missing.model}}" within the {{missing.type}} "{{missing.title}}" has no categorized files.</span>
+            <span ng-if="!missing.model"> A category for {{missing.missingSet}} has not been created.  </span>
           </div>
           <a href="https://www.youtube.com/watch?v=AZFwNNRj-MI&list=PL2GxvrdFrBlkwHBgQ47pZO-77ZLrJKYHV" target="_blank">
             <i class="fa fa-question-circle"></i> Learn More

--- a/designsafe/static/scripts/data-depot/templates/project-view.html
+++ b/designsafe/static/scripts/data-depot/templates/project-view.html
@@ -168,6 +168,15 @@
         </div>
 
         </div>
+        <div class="alert alert-danger" ng-if="(state.publishPipeline == 'select' || state.publishPipeline == 'review') && state.missing.length > 0">
+          <strong>The following categories do not have associated data:</strong>
+          <div ng-repeat="missing in state.missing">
+            <span>The category "{{missing.model}}" within the {{missing.type}} "{{missing.title}}" has no categorized files.</span>
+          </div>
+          <a href="https://www.youtube.com/watch?v=AZFwNNRj-MI&list=PL2GxvrdFrBlkwHBgQ47pZO-77ZLrJKYHV" target="_blank">
+            <i class="fa fa-question-circle"></i> Learn More
+          </a>
+        </div>
 
         <div style="text-align:center;"
              ng-class="{'pull-right': !state.publishPipeline}">

--- a/designsafe/static/scripts/data-depot/templates/view-hybrid-simulation-relations.html
+++ b/designsafe/static/scripts/data-depot/templates/view-hybrid-simulation-relations.html
@@ -6,7 +6,7 @@
     <!-- TREE START -->
     <ul class="experiments-ul">
         <li class="tree-container"
-            ng-repeat="simulation in $ctrl.data.publication.hybrid_simulations | orderBy: 'value.title'"
+            ng-repeat="simulation in $ctrl.data.publication.hybrid_simulations | orderBy: ['_ui.order', 'value.title']"
             style="border:none;">
           <div class="tree-el">  
               <span class="ul-title"> <strong>{{simulation.value.title}}</strong> </span>

--- a/designsafe/static/scripts/data-depot/templates/view-relations.html
+++ b/designsafe/static/scripts/data-depot/templates/view-relations.html
@@ -6,7 +6,7 @@
     <div class="data-model-tree data-model-preview-tree">
       <ul class="experiments-ul">
         <li class="tree-container"
-            ng-repeat="experiment in $ctrl.data.publication.experimentsList | orderBy: value.title"
+            ng-repeat="experiment in $ctrl.data.publication.experimentsList | orderBy: ['_ui.order', 'value.title']"
             style="border:none;">
           <div class="tree-el">
           <span class="ul-title"> <strong>{{experiment.value.title}}</strong> </span>

--- a/designsafe/static/scripts/data-depot/templates/view-simulation-relations.html
+++ b/designsafe/static/scripts/data-depot/templates/view-simulation-relations.html
@@ -6,7 +6,7 @@
     <!-- TREE START -->
       <ul class="experiments-ul">
         <li class="tree-container"
-            ng-repeat="simulation in $ctrl.data.publication.simulations | orderBy: 'value.title'"
+            ng-repeat="simulation in $ctrl.data.publication.simulations | orderBy: ['_ui.order', 'value.title']"
             style="border:none;">
           <div class="tree-el">  
           <span class="ul-title"> <strong>{{simulation.value.title}}</strong> </span>

--- a/designsafe/static/scripts/ng-designsafe/html/directives/dd-listing.html
+++ b/designsafe/static/scripts/ng-designsafe/html/directives/dd-listing.html
@@ -147,7 +147,7 @@
                 </a>
               </div>
               <div>
-                <div ng-repeat="coordinator in browser.project.getRelated('coordinator_set', [model.uuid])">
+                <div ng-repeat="coordinator in browser.project.getRelated('coordinator_set', [model.uuid]) | orderBy: ['_ui.order', 'value.title']">
                     <div style="border-radius:5px; border-left:1px solid black; border-right:1px solid black;
                     padding:0px 0px 3px 3px; margin: 3px 0px 0px 0px; width:90%;">
                   <a ng-class="coordinator.cssClasses()['text']"
@@ -156,14 +156,14 @@
                     {{coordinator.value.title}}
                   </a>
                   <div style="display:inline-block" ng-repeat="output in browser.project.getRelated('coordinatoroutput_set',
-                                                               [simulation.uuid, model.uuid, coordinator.uuid])">
+                                                               [simulation.uuid, model.uuid, coordinator.uuid]) | orderBy: ['_ui.order', 'value.title']">
                     <a ng-class="output.cssClasses()['text']" href="" ng-click="openPreviewTree()($event, output.uuid)">
                       {{output.value.title}}
                     </a>
                   </div>
                     </div>
                   <div ng-repeat="substructure in browser.project.getRelated('simsubstructure_set',
-                                  [simulation.uuid, model.uuid, coordinator.uuid])"
+                                  [simulation.uuid, model.uuid, coordinator.uuid]) | orderBy: ['_ui.order', 'value.title']"
                        style="margin-top:10px;">
                     <div style="border-radius:5px; border-left:1px solid black; border-right:1px solid black;
                     padding:0px 0px 3px 3px; margin: 3px 0px 0px 0px; width:90%;">
@@ -173,7 +173,7 @@
                           {{substructure.value.title}}
                       </a>
                       <div style="display:inline-block" ng-repeat="output in browser.project.getRelated('simoutput_set',
-                                                                   [simulation.uuid, model.uuid, substructure.uuid])">
+                                                                   [simulation.uuid, model.uuid, substructure.uuid]) | orderBy: ['_ui.order', 'value.title']">
                         <a ng-class="output.cssClasses()['text']" href="" ng-click="openPreviewTree()($event, output.uuid)">
                         {{output.value.title}}
                         </a>
@@ -181,7 +181,7 @@
                     </div>
                   </div>
                   <div ng-repeat="substructure in browser.project.getRelated('expsubstructure_set',
-                                  [simulation.uuid, model.uuid, coordinator.uuid])"
+                                  [simulation.uuid, model.uuid, coordinator.uuid]) | orderBy: ['_ui.order', 'value.title']"
                        style="margin-top:10px;">
                     <div style="border-radius:5px; border-left:1px solid black; border-right:1px solid black;
                     padding:0px 0px 3px 3px; margin: 3px 0px 0px 0px; width:90%;">
@@ -191,7 +191,7 @@
                           {{substructure.value.title}}
                       </a>
                       <div style="display:inline-block" ng-repeat="output in browser.project.getRelated('expoutput_set',
-                                                                   [simulation.uuid, model.uuid, substructure.uuid])">
+                                                                   [simulation.uuid, model.uuid, substructure.uuid]) | orderBy: ['_ui.order', 'value.title']">
                         <a ng-class="output.cssClasses()['text']" href="" ng-click="openPreviewTree()($event, output.uuid)">
                         {{output.value.title}}
                         </a>
@@ -252,7 +252,7 @@
                   </tr>
                   <tr class="simulation-coordinator"
                       style="background:#fff; border:none;"
-                      ng-repeat="coordinator in browser.project.getRelated('coordinator_set', [simulation.uuid, model.uuid]) | orderBy: 'value.title'">
+                      ng-repeat="coordinator in browser.project.getRelated('coordinator_set', [simulation.uuid, model.uuid]) | orderBy: ['_ui.order', 'value.title']">
                    <td colspan="4">
                     <div class="entity-preview-header" id="details-{{coordinator.uuid}}">
                       <button class="btn btn-default btn-sm" ng-class="simInput.cssClasses()['text']"
@@ -285,7 +285,7 @@
                           </td>
                         </tr>
                         <tr style="background:#fff; border:none;"
-                            ng-repeat="output in browser.project.getRelated('coordinatoroutput_set', [simulation.uuid, model.uuid, coordinator.uuid]) | orderBy: 'value.title'">
+                            ng-repeat="output in browser.project.getRelated('coordinatoroutput_set', [simulation.uuid, model.uuid, coordinator.uuid]) | orderBy: ['_ui.order', 'value.title']">
 
                            <td colspan="4">
                             <div class="entity-preview-header" id="details-{{output.uuid}}">
@@ -324,7 +324,7 @@
                         </tr>
                         <tr class="simulation-simsubstructure"
                             style="background:#fff; border:none;"
-                            ng-repeat="substructure in browser.project.getRelated('simsubstructure_set', [simulation.uuid, model.uuid, coordinator.uuid]) | orderBy: 'value.title'">
+                            ng-repeat="substructure in browser.project.getRelated('simsubstructure_set', [simulation.uuid, model.uuid, coordinator.uuid]) | orderBy: ['_ui.order', 'value.title']">
                             <td colspan="6">
                                 <div class="entity-preview-header" id="details-{{substructure.uuid}}">
                                   <button class="btn btn-default btn-sm" ng-class="substructure.cssClasses()['text']"
@@ -357,7 +357,7 @@
                                       </td>
                                     </tr>
                                     <tr style="background:#fff; border:none;"
-                                        ng-repeat="output in browser.project.getRelated('simoutput_set', [simulation.uuid, model.uuid, substructure.uuid]) | orderBy: 'value.title'">
+                                        ng-repeat="output in browser.project.getRelated('simoutput_set', [simulation.uuid, model.uuid, substructure.uuid]) | orderBy: ['_ui.order', 'value.title']">
 
                                        <td colspan="4">
                                         <div class="entity-preview-header" id="details-{{output.uuid}}">
@@ -400,7 +400,7 @@
                         </tr>
                         <tr class="simulation-simsubstructure"
                             style="background:#fff; border:none;"
-                            ng-repeat="substructure in browser.project.getRelated('expsubstructure_set', [simulation.uuid, model.uuid, coordinator.uuid]) | orderBy: 'value.title'">
+                            ng-repeat="substructure in browser.project.getRelated('expsubstructure_set', [simulation.uuid, model.uuid, coordinator.uuid]) | orderBy: ['_ui.order', 'value.title']">
                             <td colspan="6">
                                 <div class="entity-preview-header" id="details-{{substructure.uuid}}">
                                   <button class="btn btn-default btn-sm" ng-class="substructure.cssClasses()['text']"
@@ -433,7 +433,7 @@
                                       </td>
                                     </tr>
                                     <tr style="background:#fff; border:none;"
-                                        ng-repeat="output in browser.project.getRelated('expoutput_set', [simulation.uuid, model.uuid, substructure.uuid]) | orderBy: 'value.title'">
+                                        ng-repeat="output in browser.project.getRelated('expoutput_set', [simulation.uuid, model.uuid, substructure.uuid]) | orderBy: ['_ui.order', 'value.title']">
 
                                        <td colspan="4">
                                         <div class="entity-preview-header" id="details-{{output.uuid}}">
@@ -1229,7 +1229,7 @@
                 </a>
               </div>
               <div>
-                <div ng-repeat="simInput in browser.project.getRelated('input_set', [model.uuid])"
+                <div ng-repeat="simInput in browser.project.getRelated('input_set', [model.uuid]) | orderBy: 'value.title'"
                      style="border-radius:5px; border-left:1px solid black; border-right:1px solid black;
                             padding:0px 0px 3px 3px; margin: 3px 0px 0px 0px; width:90%;">
                   <a ng-class="simInput.cssClasses()['text']"
@@ -1305,7 +1305,7 @@
                   </tr>
                   <tr class="simulation-input"
                       style="background:#fff; border:none;"
-                      ng-repeat="simInput in browser.project.getRelated('input_set', [model.uuid])">
+                      ng-repeat="simInput in browser.project.getRelated('input_set', [model.uuid]) | orderBy: ['value.title']">
                    <td colspan="4">
                     <div class="entity-preview-header" id="details-{{simInput.uuid}}">
                       <button class="btn btn-default btn-sm" ng-class="simInput.cssClasses()['text']"

--- a/designsafe/static/scripts/ng-designsafe/html/modals/data-browser-preview-simulation-tree.html
+++ b/designsafe/static/scripts/ng-designsafe/html/modals/data-browser-preview-simulation-tree.html
@@ -37,7 +37,7 @@
           </div>
           <ul class="model-config-ul">
             <li class="tree-container"
-                ng-repeat="modelConfig in data.project.getRelated('model_set', simulation.uuid) | orderBy: modelConfig.value.title">
+                ng-repeat="modelConfig in data.project.getRelated('model_set', simulation.uuid) | orderBy: 'value.title'">
               <div class="tree-el">
               <span class="label tag-blue"
                     ng-class="{'selected': modelConfig.uuid === data.entityUuid}">Simulation Model</span>
@@ -45,7 +45,7 @@
               </div>
               <ul class="sensor-list-ul">
                 <li class="tree-container"
-                    ng-repeat="simInput in data.project.getRelated('input_set', [simulation.uuid, modelConfig.uuid]) | orderBy: simInput.value.title">
+                    ng-repeat="simInput in data.project.getRelated('input_set', [simulation.uuid, modelConfig.uuid]) | orderBy: 'value.title'">
                   <div class="tree-el">  
                   <span class="label tag-green"
                         ng-class="{'selected': simInput.uuid === data.entityUuid}">Simulation Input</span>
@@ -93,7 +93,7 @@
 
       <ul class="experiments-ul">
         <li class="tree-container"
-            ng-repeat="analysis in data.project.analysis_set | orderBy: analysis.value.title"
+            ng-repeat="analysis in data.project.analysis_set | orderBy: 'value.title'"
             style="border:none;">
           <div class="tree-el">  
           <span class="label tag-light-blue"

--- a/designsafe/static/scripts/ng-designsafe/html/modals/data-browser-preview-tree.html
+++ b/designsafe/static/scripts/ng-designsafe/html/modals/data-browser-preview-tree.html
@@ -7,7 +7,7 @@
     <div class="data-model-tree data-model-preview-tree">
       <ul class="experiments-ul">
         <li class="tree-container"
-            ng-repeat="experiment in data.project.experiment_set | orderBy: experiment.value.title"
+            ng-repeat="experiment in data.project.experiment_set | orderBy: 'value.title'"
             style="border:none;">
           <div class="tree-el">  
           <span class="ul-title">{{experiment.value.title}}</span>


### PR DESCRIPTION
Created a check for project categories without associated data. Previously if a user tried to proceed through the publication pipeline without uncategorized data the selection area would become unresponsive without notifying the user.

Also, the relationship tree for unpublished experimental projects should now sort alphabetically. Included custom sort capability for published projects.