### PR TITLE
change TicketsService from factory to service

### DIFF
--- a/designsafe/static/scripts/ng-designsafe/services/index.js
+++ b/designsafe/static/scripts/ng-designsafe/services/index.js
@@ -31,7 +31,7 @@ designsafeServices.factory('notificationFactory', notificationFactory);
 designsafeServices.factory('ProjectEntitiesService', ProjectEntitiesService);
 designsafeServices.factory('ProjectService', ProjectService);
 designsafeServices.factory('SystemsService', SystemsService);
-designsafeServices.factory('TicketsService', TicketsService);
+designsafeServices.service('TicketsService', TicketsService);
 designsafeServices.service('UserService', UserService);
 
 


### PR DESCRIPTION
TicketsService was mistakenly instantiated as a `factory` in the ES6 branch. This PR fixes that by defining it as a `service`