### PR TITLE
DES-706: Update project breadcrumbs for Angular 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v3.0.0-20181101
 
+Improvements:
+
+- Better breadcrumbs for Angular 1.6+
+
 Fixes:
 
 - Help links for workspace (DES-526).

--- a/designsafe/static/scripts/data-depot/controllers/projects.js
+++ b/designsafe/static/scripts/data-depot/controllers/projects.js
@@ -20,7 +20,7 @@ export function ProjectRootCtrl($scope, $rootScope, $state, $stateParams, $trans
     };
 
 
-    $rootScope.$on('updateProjectsBreadcrumbs', function($event, toState, toStateParams) {
+    DataBrowserService.projectBreadcrumbSubject.subscribe( () =>  {
       $scope.data.navItems = [{href: $state.href('projects.list'), label: 'Projects'}];
 
       // Create a function that checks if 'toStateParams.projectTitle' is empty. Replace it if so...
@@ -103,7 +103,7 @@ export function ProjectRootCtrl($scope, $rootScope, $state, $stateParams, $trans
     ProjectService.list({offset:offset, limit:limit}).then(function(projects) {
       $scope.ui.busy = false;
       $scope.data.projects = _.map(projects, function(p) { p.href = $state.href('projects.view', {projectId: p.uuid}); return p; });
-      $rootScope.$emit('updateProjectsBreadcrumbs', {})
+      DataBrowserService.projectBreadcrumbSubject.next()
     });
 
     $scope.onBrowse = function onBrowse($event, project) {
@@ -1096,7 +1096,7 @@ export function ProjectRootCtrl($scope, $rootScope, $state, $stateParams, $trans
                               {'query_string': $state.params.query_string})
       .then(function () {
         $scope.browser = DataBrowserService.state();
-        $rootScope.$emit('updateProjectsBreadcrumbs')
+        DataBrowserService.projectBreadcrumbSubject.next()
         $scope.browser.busy = true;
         $scope.browser.busyListing = true;
         $scope.browser.listing.href = $state.href('projects.view.data', {

--- a/designsafe/static/scripts/ng-designsafe/services/data-browser-service.js
+++ b/designsafe/static/scripts/ng-designsafe/services/data-browser-service.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import { Subject } from 'rxjs'
 
 export function nbv($window) { //from http://jameshill.io/articles/angular-third-party-injection-pattern/
   if ($window.nbv) {
@@ -18,7 +19,6 @@ export function nbv($window) { //from http://jameshill.io/articles/angular-third
 export function DataBrowserService($rootScope, $http, $q, $uibModal,
                   $state, Django, FileListing, Logging,
                   SystemsService, nbv, ProjectEntitiesService) {
-    'ngInject';
   var logger = Logging.getLogger('ngDesignSafe.DataBrowserService');
 
   /**
@@ -38,6 +38,8 @@ export function DataBrowserService($rootScope, $http, $q, $uibModal,
     ui: {},
     tests: null
   };
+
+  var projectBreadcrumbSubject = new Subject();
 
   var efs = {
     'experimental': [
@@ -2738,6 +2740,7 @@ function toggleProjects(projects, reset) {
     state: state,
     apiParameters: apiParameters,
     currentState: currentState,
+    projectBreadcrumbSubject: projectBreadcrumbSubject,
 
     /* data/files functions */
     allowedActions: allowedActions,

--- a/designsafe/static/scripts/ng-designsafe/services/index.js
+++ b/designsafe/static/scripts/ng-designsafe/services/index.js
@@ -14,8 +14,8 @@ import { UserService } from './user-service';
 
 let designsafeServices = angular.module('designsafe.services', []);
 
-designsafeServices.factory('nbv', ['$window', nbv]);
-designsafeServices.factory('DataBrowserService', ['$rootScope', '$http', '$q', '$uibModal', '$state', 'Django', 'FileListing', 'Logging', 'SystemsService', 'nbv', 'ProjectEntitiesService', DataBrowserService]);
+designsafeServices.factory('nbv', nbv);
+designsafeServices.factory('DataBrowserService', DataBrowserService);
 designsafeServices.factory(
     'DataService', [
         '$rootScope',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2609,7 +2609,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
@@ -2691,7 +2691,7 @@
     },
     "cssnano": {
       "version": "3.10.0",
-      "resolved": "http://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
       "dev": true,
       "requires": {
@@ -8422,7 +8422,7 @@
     },
     "postcss-calc": {
       "version": "5.3.1",
-      "resolved": "http://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
       "dev": true,
       "requires": {
@@ -8454,7 +8454,7 @@
     },
     "postcss-discard-comments": {
       "version": "2.0.4",
-      "resolved": "http://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
       "dev": true,
       "requires": {
@@ -8472,7 +8472,7 @@
     },
     "postcss-discard-empty": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
       "dev": true,
       "requires": {
@@ -8481,7 +8481,7 @@
     },
     "postcss-discard-overridden": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
       "dev": true,
       "requires": {
@@ -8490,7 +8490,7 @@
     },
     "postcss-discard-unused": {
       "version": "2.2.3",
-      "resolved": "http://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "dev": true,
       "requires": {
@@ -8509,7 +8509,7 @@
     },
     "postcss-merge-idents": {
       "version": "2.1.7",
-      "resolved": "http://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "dev": true,
       "requires": {
@@ -8548,7 +8548,7 @@
     },
     "postcss-minify-font-values": {
       "version": "1.0.5",
-      "resolved": "http://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
       "dev": true,
       "requires": {
@@ -8559,7 +8559,7 @@
     },
     "postcss-minify-gradients": {
       "version": "1.0.5",
-      "resolved": "http://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
       "dev": true,
       "requires": {
@@ -8569,7 +8569,7 @@
     },
     "postcss-minify-params": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
       "dev": true,
       "requires": {
@@ -8581,7 +8581,7 @@
     },
     "postcss-minify-selectors": {
       "version": "2.1.1",
-      "resolved": "http://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
       "dev": true,
       "requires": {
@@ -8848,7 +8848,7 @@
     },
     "postcss-normalize-charset": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
       "dev": true,
       "requires": {
@@ -8857,7 +8857,7 @@
     },
     "postcss-normalize-url": {
       "version": "3.0.8",
-      "resolved": "http://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
       "dev": true,
       "requires": {
@@ -8879,7 +8879,7 @@
     },
     "postcss-reduce-idents": {
       "version": "2.4.0",
-      "resolved": "http://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "dev": true,
       "requires": {
@@ -8889,7 +8889,7 @@
     },
     "postcss-reduce-initial": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
       "dev": true,
       "requires": {
@@ -8898,7 +8898,7 @@
     },
     "postcss-reduce-transforms": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
       "dev": true,
       "requires": {
@@ -8920,7 +8920,7 @@
     },
     "postcss-svgo": {
       "version": "2.1.6",
-      "resolved": "http://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
       "dev": true,
       "requires": {
@@ -8932,7 +8932,7 @@
     },
     "postcss-unique-selectors": {
       "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
       "dev": true,
       "requires": {
@@ -8949,7 +8949,7 @@
     },
     "postcss-zindex": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "dev": true,
       "requires": {
@@ -9265,7 +9265,7 @@
     },
     "reduce-css-calc": {
       "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "objectpath": "^1.2.1",
     "prismjs": "^1.6.0",
     "raw-loader": "^0.5.1",
+    "rxjs": "^6.3.3",
     "slick-carousel": "^1.8.1",
     "tether": "^1.4.5",
     "tv4": "^1.3.0",


### PR DESCRIPTION
Project breadcrumbs work with angular 1.6+ and no longer break when the user clicks them or refreshes the page.

Breadcrumbs are updated after each project/file listing by pushing to an RxJS subject kept in the data browser service.