### PR TITLE
Don't return non-"published" publications in pubs search

### DIFF
--- a/designsafe/apps/api/agave/filemanager/public_search_index.py
+++ b/designsafe/apps/api/agave/filemanager/public_search_index.py
@@ -421,7 +421,7 @@ class PublicElasticFileManager(BaseFileManager):
         nees_published_search = LegacyPublicationIndexed.search()\
             .query(nees_published_query)\
             .extra(from_=offset, size=limit)
-        des_published_query = Q('bool', must=[Q('query_string', query=query_string)])
+        des_published_query = Q('bool', must=[Q('query_string', query=query_string), Q({'term': {'status': status}}) ])
         des_published_search = PublicationIndexed.search()\
             .query(des_published_query)\
             .extra(from_=offset, size=limit)


### PR DESCRIPTION
Make sure publication search only returns documents with status='published'. It looks like this filter got clobbered in a merge at some point.

This addresses ticket ID 48728