### PR TITLE
Ticket body newline issue

### DIFF
--- a/designsafe/apps/djangoRT/views.py
+++ b/designsafe/apps/djangoRT/views.py
@@ -92,7 +92,7 @@ def ticketcreate(request):
             )
 
             ticket = rtModels.Ticket(subject=form.cleaned_data['subject'],
-                                     problem_description="\n  ".join(ticket_body),
+                                     problem_description="\n  ".join(ticket_body.splitlines()),
                                      requestor=form.cleaned_data['email'],
                                      cc=form.cleaned_data.get('cc', ''))
 

--- a/designsafe/apps/djangoRT/views.py
+++ b/designsafe/apps/djangoRT/views.py
@@ -92,7 +92,7 @@ def ticketcreate(request):
             )
 
             ticket = rtModels.Ticket(subject=form.cleaned_data['subject'],
-                                     problem_description=ticket_body,
+                                     problem_description="\n  ".join(ticket_body),
                                      requestor=form.cleaned_data['email'],
                                      cc=form.cleaned_data.get('cc', ''))
 


### PR DESCRIPTION
Added a space between ticket body and new line in DjangoRT. This solution was implemented in [CEP](https://bitbucket.org/taccaci/core-exp-portal/pull-requests/163/ticket-body-newline-issue/diff) by Carrie Arnold and ported over to DesignSafe by me.