### PR TITLE
DES-727: Bug with search, does not link to right place on some NEES projects

### DIFF
--- a/designsafe/static/scripts/search/components/search-listing/search-listing.component.html
+++ b/designsafe/static/scripts/search/components/search-listing/search-listing.component.html
@@ -31,7 +31,7 @@
           </div>
           <!-- This is for old nees projects -->
           <div ng-if="!$ctrl.data.projectId">
-            <h4><a ng-href="/data/browser/public/{{$ctrl.data.system}}/{{$ctrl.data.name}}"  target="_self"> {{$ctrl.data.title}} </a> </h4>
+            <h4><a ng-href="/data/browser/public/{{$ctrl.data.system}}/{{$ctrl.data.name}}.groups"  target="_self"> {{$ctrl.data.title}} </a> </h4>
             <p> {{$ctrl.data.description}} </p>
             <span class="label label-primary"> Created: {{$ctrl.data.startDate | date:'short'}} </span>
           </div>


### PR DESCRIPTION
The issue here was that NEES projects in site search were being linked to through URLS formatted like:
`/data/browser/public/nees.public/{project_name}` 
when they should look like:
`/data/browser/public/nees.public/{project_name}.groups`

Clicking on NEES projects in site search should now link to the files for that project.