### PR TITLE
task/DES-809: bug fixes in NEES publication view

### DIFF
--- a/designsafe/static/scripts/data-depot/components/data-depot-new/data-depot-new.component.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-new/data-depot-new.component.js
@@ -13,7 +13,7 @@ export function DataDepotNewCtrl($scope, $state, $sce, Django, ProjectService, D
 
     $scope.$watch('browser.listing', function() {
       $scope.test.createFiles = false;
-      if ($scope.browser.listing) {
+      if ( ($scope.browser.listing || {}).permissions ) {
         $scope.test.createFiles = $scope.browser.listing.permissions === 'ALL' ||
                                   $scope.browser.listing.permissions.indexOf('WRITE') > -1;
       }

--- a/designsafe/static/scripts/data-depot/components/nees-publication/nees-publication.component.js
+++ b/designsafe/static/scripts/data-depot/components/nees-publication/nees-publication.component.js
@@ -15,6 +15,8 @@ class NeesPublicationCtrl {
     }
     
     $onInit() {
+        this.DataBrowserService.apiParams.fileMgr = 'published';
+        this.DataBrowserService.apiParams.baseUrl = '/api/public/files';
         this.data = {
             customRoot: {
                 name: 'Published',
@@ -26,6 +28,9 @@ class NeesPublicationCtrl {
         
         //Retrieve NEES project name using path
         this.projectName = this.$stateParams.filePath.slice(1).split('.')[0]
+        if (this.projectName[0] === '/') {
+            this.projectName = this.projectName.slice(1) // handle double slash in front of NEES path.
+        }
         this.PublishedService.getNeesPublished(this.projectName)
         .then(res => {
             this.project = res.data;
@@ -44,7 +49,7 @@ class NeesPublicationCtrl {
         if (typeof (file.type) !== 'undefined' && file.type !== 'dir' && file.type !== 'folder') {
             this.DataBrowserService.preview(file, this.browser.listing);
         } else {
-            this.$state.go('neesPublishedData', { filePath: file.path });
+            this.$state.go('neesPublishedData', { filePath: file.path }, { reload: true });
         }
     };
     onSelect($event, file) {

--- a/designsafe/static/scripts/data-depot/components/nees-publication/nees-publication.spec.js
+++ b/designsafe/static/scripts/data-depot/components/nees-publication/nees-publication.spec.js
@@ -80,7 +80,8 @@ describe('neesPublishedComponent', () => {
         )
         expect(ctrl.$state.go).toHaveBeenCalledWith(
             'neesPublishedData', 
-            {filePath: '/NEES-0000-0000.groups/path/to/file'});
+            {filePath: '/NEES-0000-0000.groups/path/to/file'},
+            {reload: true});
     })
     
 })


### PR DESCRIPTION
- Fixed a bug where logged-out users couldn't refresh NEES projects or navigate to them by their URL.
-  Support old-style NEES project URLs (e.g. https://www.designsafe-ci.org/data/browser/public/nees.public//NEES-2009-0732.groups with the double slash)