### PR TITLE
Task/DES-451

### DIFF
--- a/designsafe/static/scripts/data-depot/components/data-depot-new/data-depot-new.component.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-new/data-depot-new.component.html
@@ -29,7 +29,7 @@
                         <i class="fa fa-file-o fa-stack-2x"></i>
                         <i class="fa fa-cloud-upload fa-stack-1x"></i>
                     </span>
-                    <span>File upload</span>
+                    <span>File upload: max 100MB</span>
                 </a>
             </li>
             <li ng-class="{'disabled': ! test.createFiles}">
@@ -38,7 +38,7 @@
                         <i class="fa fa-folder-o fa-stack-2x"></i>
                         <i class="fa fa-cloud-upload fa-stack-1x"></i>
                     </span>
-                    <span>Folder upload</span>
+                    <span>Folder upload: max 25 files</span>
                 </a>
             </li>
             <li ng-class="{'disabled': ! test.createFiles}" ng-init="popoverOpened=false" ng-mouseover="popoverOpened=true" ng-mouseleave="popoverOpened=false">

--- a/designsafe/static/scripts/ng-designsafe/html/modals/data-browser-service-upload.html
+++ b/designsafe/static/scripts/ng-designsafe/html/modals/data-browser-service-upload.html
@@ -11,7 +11,7 @@
     </p>
     <form>
         <div class="form-group">
-            <label for="id-choose-files">Select {{ state.directoryUpload && state.directoryUploadSupported ? 'folder' : 'files' }}</label>
+            <label for="id-choose-files">Select {{ state.directoryUpload && state.directoryUploadSupported ? 'folder' : 'files' }} (for more than 100 MB or 25 files, please use Globus to upload)</label>
             <input type="file" multiple class="form-control" id="id-choose-files" name="choose-files"
                    ng-disabled="state.uploading || state.retry"
                    ng-attr-directory="{{ state.directoryUpload && 'true' || undefined }}"


### PR DESCRIPTION
• In My Data, change option text under "+Add":
        "FIle upload" –> "File upload: max 100 MB"
        "Folder upload" –> "File upload: max 100 MB"
• In the subsequent form when "File upload" or "Folder upload" is selected, add to:
        "Select files" the additional text:
                 (for more than 100 MB or 25 files, please use Globus to upload)
• I'll talk with Hedda about changing the text to clarify these rules in user-guides