### PR TITLE
Hotfix: typo in My Data search route

### DIFF
--- a/designsafe/static/scripts/data-depot/index.js
+++ b/designsafe/static/scripts/data-depot/index.js
@@ -78,7 +78,7 @@ function config($httpProvider, $locationProvider, $stateProvider, $urlRouterProv
       url: '/agave-search/?query_string&offset&limit',
       //controller: 'MyDataCtrl',
       //template: require('./templates/agave-search-data-listing.html'),
-      component: 'my-data',
+      component: 'myData',
       params: {
         systemId: 'designsafe.storage.default',
         filePath: '$SEARCH'


### PR DESCRIPTION
Needed to change `my-data` to `myData` otherwise searching My Data gives an unknown provider error.