### PR TITLE
Task/DES-684 Modified location of Data Depot header, moved the 'Learn About The Da…

### DIFF
--- a/designsafe/apps/data/templates/data/data_depot.html
+++ b/designsafe/apps/data/templates/data/data_depot.html
@@ -6,18 +6,18 @@
 {% endblock %}
 {% block content %}
     <div class="container">
-        <div>
-            <ddmain style="position: relative;">
-                <ddtoolbar></ddtoolbar>
-                <div class="row">
-                    <div class="col-sm-3 col-md-2">
-                        
-                        <ddnew></ddnew> 
-                        <ddnav></ddnav>
-                    </div>
-                    <div class="col-sm-9 col-md-10">
-                        <ui-view></ui-view>
-                    </div>
+        <ddmain style="position: relative;">    
+            <div class="row">
+                <div class="col-sm-3 col-md-2">
+                    <h1 class="headline headline-research" id="headline-data-depot">
+                        <span class="hl hl-research">Data Depot</span>
+                    </h1>
+                    <ddnew></ddnew> 
+                    <ddnav></ddnav>
+                </div>
+                <div class="col-sm-9 col-md-10">
+                    <ddtoolbar></ddtoolbar>
+                    <ui-view></ui-view>
                 </div>
             </div>
         </ddmain>

--- a/designsafe/static/scripts/data-depot/components/data-depot-nav/data-depot-nav.component.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-nav/data-depot-nav.component.html
@@ -30,8 +30,12 @@
       </a>
     </div>
     <div>
-      <a class="" href="https://www.designsafe-ci.org/rw/user-guides/data-publication-guidelines/" target="_blank">
+      <a class="" href="/rw/user-guides/data-publication-guidelines/" target="_blank">
         <i class="fa fa-info-circle"></i> Curation Guidelines
       </a>
     </div>
+    <div>
+        <a href="/rw/user-guide/data-depot" target="_blank"><i class="fa fa-info-circle"></i> Learn About the <br/>Data Depot</a>
+    </div>
+
   </div>

--- a/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.html
@@ -10,82 +10,84 @@
             </form>
             -->
         </div>
-        <div class="btn-toolbar btn-toolbar-right" role="toolbar" aria-label="Data Browser Toolbar">
+        <div class="btn-toolbar btn-toolbar-left" role="toolbar" aria-label="Data Browser Toolbar">
             <form class="navbar-form navbar-left" ng-submit="$ctrl.ddSearch()" style="display:flex" 
             ng-hide="['Dropbox', 'Box', 'Google Drive', 'Project View', 'NEES Published'].includes($ctrl.placeholder())">
                 <input class="form-control" style="width:240px;" placeholder="Find in {{ $ctrl.placeholder() }}" ng-model="$ctrl.search.queryString">
                 <button class="btn btn-default" style="clear: right;"> <i class="fa fa-search"></i> </button>
             </form>
-            <div class="btn-group-data-depot-toolbar btn-group">
-                <button class="btn btn-sm btn-default" title="Categorize"
-                        ng-click="$ctrl.viewCategories()"
-                        ng-disabled="!$ctrl.browser.tests.canViewCategories ||
-                                      $ctrl.browser.project.publicationStatus === 'publishing'"
-                        ng-if="$ctrl.browser.listing.system.startsWith('project') &&
-                               $ctrl.browser.project.value.projectType != 'other'">
-                    <img src="/static/images/ds-icons/icon-categorize.svg" width="50px" height="16px"/>
-                    <span style="display:block;">Categorize</span>
-                </button>
-                <button class="btn btn-sm btn-default" title="Categorize" ng-click="$ctrl.viewMetadata()"
-                         ng-disabled="!$ctrl.browser.tests.canViewMetadata ||
-                                      $ctrl.browser.project.publicationStatus === 'publishing'">
-                    <i class="fa fa-tags"></i><span style="display:block;">Tag</span>
-                </button>
-                <button class="btn btn-sm btn-default" title="Rename" ng-click="$ctrl.rename()"
-                         ng-disabled="!$ctrl.browser.tests.canRename ||
-                                      $ctrl.browser.project.publicationStatus === 'publishing'">
-                    <i class="fa fa-pencil"></i><span style="display:block;">Rename</span>
-                </button>
+            <div class="btn-toolbar-right">
+                <div class="btn-group-data-depot-toolbar btn-group">
+                    <button class="btn btn-sm btn-default" title="Categorize"
+                            ng-click="$ctrl.viewCategories()"
+                            ng-disabled="!$ctrl.browser.tests.canViewCategories ||
+                                        $ctrl.browser.project.publicationStatus === 'publishing'"
+                            ng-if="$ctrl.browser.listing.system.startsWith('project') &&
+                                $ctrl.browser.project.value.projectType != 'other'">
+                        <img src="/static/images/ds-icons/icon-categorize.svg" width="50px" height="16px"/>
+                        <span style="display:block;">Categorize</span>
+                    </button>
+                    <button class="btn btn-sm btn-default" title="Categorize" ng-click="$ctrl.viewMetadata()"
+                            ng-disabled="!$ctrl.browser.tests.canViewMetadata ||
+                                        $ctrl.browser.project.publicationStatus === 'publishing'">
+                        <i class="fa fa-tags"></i><span style="display:block;">Tag</span>
+                    </button>
+                    <button class="btn btn-sm btn-default" title="Rename" ng-click="$ctrl.rename()"
+                            ng-disabled="!$ctrl.browser.tests.canRename ||
+                                        $ctrl.browser.project.publicationStatus === 'publishing'">
+                        <i class="fa fa-pencil"></i><span style="display:block;">Rename</span>
+                    </button>
+                </div>
+                <div class="btn-group-data-depot-toolbar btn-group">
+                    <button class="btn btn-sm btn-default" title="Move" ng-click="$ctrl.move()"
+                            ng-disabled="!$ctrl.browser.tests.canMove ||
+                                        $ctrl.browser.project.publicationStatus === 'publishing'">
+                        <i class="fa fa-arrows"></i><span style="display:block;">Move</span>
+                    </button>
+                    <button class="btn btn-sm btn-default" title="Copy" ng-click="$ctrl.copy()"
+                            ng-disabled="!$ctrl.browser.tests.canCopy ||
+                                        $ctrl.browser.project.publicationStatus === 'publishing'">
+                        <i class="fa fa-copy"></i><span style="display:block;">Copy</span>
+                    </button>
+                    <button class="btn btn-sm btn-default" title="Preview" ng-click="$ctrl.preview()"
+                            ng-disabled="!$ctrl.browser.tests.canPreview ||
+                                        $ctrl.browser.project.publicationStatus === 'publishing'">
+                        <i class="fa fa-binoculars"></i><span style="display:block;">Preview</span>
+                    </button>
+                    <button class="btn btn-sm btn-default" title="Preview Images" ng-click="$ctrl.previewImages()" ng-disabled="!$ctrl.browser.tests.canPreviewImages">
+                        <i class="fa fa-photo"></i><span style="display:block;">Preview Images</span>
+                    </button>
+                    <button class="btn btn-sm btn-default" title="Preview Citation" ng-if="$ctrl.browser.listing.system.startsWith('nees')" ng-click="$ctrl.showCitation()" ng-disabled="!$ctrl.browser.tests.canViewCitation || $ctrl.browser.selected[0].name.includes('NEES')">
+                        <i class="fa fa-book" style="color:#5bc0de;"></i><span style="display:block;">Citation</span>
+                    </button>
+                </div>
+                <div class="btn-group-data-depot-toolbar btn-group">
+        
+                    <button class="btn btn-sm btn-default" title="Download" ng-click="$ctrl.download()"
+                            ng-disabled="!$ctrl.browser.tests.canDownload">
+                        <i class="fa fa-cloud-download"></i><span style="display:block;">Download</span>
+                    </button>
+                </div>
+                <div class="btn-group-data-depot-toolbar btn-group">
+                    <button class="btn btn-sm btn-default" title="Move to trash" ng-click="$ctrl.trash()"
+                            ng-disabled="!$ctrl.browser.tests.canTrash ||
+                                        $ctrl.browser.project.publicationStatus === 'publishing'"
+                            ng-if="!$ctrl.browser.tests.canDelete">
+                        <i class="fa fa-trash"></i><span style="display:block;">Move to Trash</span>
+                    </button>
+                    <button class="btn btn-sm btn-danger" title="Delete selected files" ng-click="$ctrl.rm()" ng-disabled="!$ctrl.browser.tests.canDelete" ng-if="$ctrl.browser.tests.canDelete">
+                        <i class="fa fa-trash"></i><span style="display:block;">Delete selected files</span>
+                    </button>
+                </div>
+                <!--
+                <div class="btn-group">
+                    <button class="btn btn-sm btn-info" title="Details for {{ browser.listing.name }}" ng-click="ops.details()">
+                        <i class="fa fa-info-circle"></i><span style="display:block;">Details</span>
+                        <span class="sr-only">{{ browser.listing.name }}</span>
+                    </button>
+                </div>
+                -->
             </div>
-            <div class="btn-group-data-depot-toolbar btn-group">
-                <button class="btn btn-sm btn-default" title="Move" ng-click="$ctrl.move()"
-                         ng-disabled="!$ctrl.browser.tests.canMove ||
-                                      $ctrl.browser.project.publicationStatus === 'publishing'">
-                    <i class="fa fa-arrows"></i><span style="display:block;">Move</span>
-                </button>
-                <button class="btn btn-sm btn-default" title="Copy" ng-click="$ctrl.copy()"
-                         ng-disabled="!$ctrl.browser.tests.canCopy ||
-                                      $ctrl.browser.project.publicationStatus === 'publishing'">
-                    <i class="fa fa-copy"></i><span style="display:block;">Copy</span>
-                </button>
-                <button class="btn btn-sm btn-default" title="Preview" ng-click="$ctrl.preview()"
-                         ng-disabled="!$ctrl.browser.tests.canPreview ||
-                                      $ctrl.browser.project.publicationStatus === 'publishing'">
-                    <i class="fa fa-binoculars"></i><span style="display:block;">Preview</span>
-                </button>
-                <button class="btn btn-sm btn-default" title="Preview Images" ng-click="$ctrl.previewImages()" ng-disabled="!$ctrl.browser.tests.canPreviewImages">
-                    <i class="fa fa-photo"></i><span style="display:block;">Preview Images</span>
-                </button>
-                <button class="btn btn-sm btn-default" title="Preview Citation" ng-if="$ctrl.browser.listing.system.startsWith('nees')" ng-click="$ctrl.showCitation()" ng-disabled="!$ctrl.browser.tests.canViewCitation || $ctrl.browser.selected[0].name.includes('NEES')">
-                    <i class="fa fa-book" style="color:#5bc0de;"></i><span style="display:block;">Citation</span>
-                </button>
-             </div>
-             <div class="btn-group-data-depot-toolbar btn-group">
-    
-                <button class="btn btn-sm btn-default" title="Download" ng-click="$ctrl.download()"
-                         ng-disabled="!$ctrl.browser.tests.canDownload">
-                    <i class="fa fa-cloud-download"></i><span style="display:block;">Download</span>
-                </button>
-            </div>
-            <div class="btn-group-data-depot-toolbar btn-group">
-                <button class="btn btn-sm btn-default" title="Move to trash" ng-click="$ctrl.trash()"
-                         ng-disabled="!$ctrl.browser.tests.canTrash ||
-                                      $ctrl.browser.project.publicationStatus === 'publishing'"
-                         ng-if="!$ctrl.browser.tests.canDelete">
-                    <i class="fa fa-trash"></i><span style="display:block;">Move to Trash</span>
-                </button>
-                 <button class="btn btn-sm btn-danger" title="Delete selected files" ng-click="$ctrl.rm()" ng-disabled="!$ctrl.browser.tests.canDelete" ng-if="$ctrl.browser.tests.canDelete">
-                    <i class="fa fa-trash"></i><span style="display:block;">Delete selected files</span>
-                </button>
-            </div>
-            <!--
-            <div class="btn-group">
-                <button class="btn btn-sm btn-info" title="Details for {{ browser.listing.name }}" ng-click="ops.details()">
-                    <i class="fa fa-info-circle"></i><span style="display:block;">Details</span>
-                    <span class="sr-only">{{ browser.listing.name }}</span>
-                </button>
-            </div>
-            -->
         </div>
     </div>
     

--- a/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.html
@@ -16,7 +16,7 @@
                 <input class="form-control" style="width:240px;" placeholder="Find in {{ $ctrl.placeholder() }}" ng-model="$ctrl.search.queryString">
                 <button class="btn btn-default" style="clear: right;"> <i class="fa fa-search"></i> </button>
             </form>
-            <div class="btn-group" style="margin-left:0px">
+            <div class="btn-group-data-depot-toolbar btn-group">
                 <button class="btn btn-sm btn-default" title="Categorize"
                         ng-click="$ctrl.viewCategories()"
                         ng-disabled="!$ctrl.browser.tests.canViewCategories ||
@@ -37,7 +37,7 @@
                     <i class="fa fa-pencil"></i><span style="display:block;">Rename</span>
                 </button>
             </div>
-            <div class="btn-group" style="margin-left:0px">
+            <div class="btn-group-data-depot-toolbar btn-group">
                 <button class="btn btn-sm btn-default" title="Move" ng-click="$ctrl.move()"
                          ng-disabled="!$ctrl.browser.tests.canMove ||
                                       $ctrl.browser.project.publicationStatus === 'publishing'">
@@ -60,14 +60,14 @@
                     <i class="fa fa-book" style="color:#5bc0de;"></i><span style="display:block;">Citation</span>
                 </button>
              </div>
-             <div class="btn-group" style="margin-left:0px">
+             <div class="btn-group-data-depot-toolbar btn-group">
     
                 <button class="btn btn-sm btn-default" title="Download" ng-click="$ctrl.download()"
                          ng-disabled="!$ctrl.browser.tests.canDownload">
                     <i class="fa fa-cloud-download"></i><span style="display:block;">Download</span>
                 </button>
             </div>
-            <div class="btn-group" style="margin-left:0px">
+            <div class="btn-group-data-depot-toolbar btn-group">
                 <button class="btn btn-sm btn-default" title="Move to trash" ng-click="$ctrl.trash()"
                          ng-disabled="!$ctrl.browser.tests.canTrash ||
                                       $ctrl.browser.project.publicationStatus === 'publishing'"

--- a/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.html
@@ -16,7 +16,7 @@
                 <input class="form-control" style="width:240px;" placeholder="Find in {{ $ctrl.placeholder() }}" ng-model="$ctrl.search.queryString">
                 <button class="btn btn-default" style="clear: right;"> <i class="fa fa-search"></i> </button>
             </form>
-            <div class="btn-group">
+            <div class="btn-group" style="margin-left:0px">
                 <button class="btn btn-sm btn-default" title="Categorize"
                         ng-click="$ctrl.viewCategories()"
                         ng-disabled="!$ctrl.browser.tests.canViewCategories ||
@@ -37,7 +37,7 @@
                     <i class="fa fa-pencil"></i><span style="display:block;">Rename</span>
                 </button>
             </div>
-            <div class="btn-group">
+            <div class="btn-group" style="margin-left:0px">
                 <button class="btn btn-sm btn-default" title="Move" ng-click="$ctrl.move()"
                          ng-disabled="!$ctrl.browser.tests.canMove ||
                                       $ctrl.browser.project.publicationStatus === 'publishing'">
@@ -60,14 +60,14 @@
                     <i class="fa fa-book" style="color:#5bc0de;"></i><span style="display:block;">Citation</span>
                 </button>
              </div>
-             <div class="btn-group">
+             <div class="btn-group" style="margin-left:0px">
     
                 <button class="btn btn-sm btn-default" title="Download" ng-click="$ctrl.download()"
                          ng-disabled="!$ctrl.browser.tests.canDownload">
                     <i class="fa fa-cloud-download"></i><span style="display:block;">Download</span>
                 </button>
             </div>
-            <div class="btn-group">
+            <div class="btn-group" style="margin-left:0px">
                 <button class="btn btn-sm btn-default" title="Move to trash" ng-click="$ctrl.trash()"
                          ng-disabled="!$ctrl.browser.tests.canTrash ||
                                       $ctrl.browser.project.publicationStatus === 'publishing'"

--- a/designsafe/static/styles/main.css
+++ b/designsafe/static/styles/main.css
@@ -250,6 +250,11 @@ h4 {
   margin-bottom: 20px;
 }
 
+#headline-data-depot {
+  font-size:28px;
+  margin-top:16px;
+}
+
 .headline::after {
   content: "___";
   color: #333;

--- a/designsafe/static/styles/main.css
+++ b/designsafe/static/styles/main.css
@@ -487,6 +487,9 @@ label.required:after,
     margin-left: -2px;
 }
 
+.btn-toolbar > .btn-group-data-depot-toolbar {
+  margin-left:0px;
+}
 
 .callout {
   padding: 1em;


### PR DESCRIPTION
Created data depot header on top of left nav, moved toolbar to top of ui-view.
Added Learn about Data Depot link under Curation Guidelines link.
Fixed wrapping issue with toolbar buttons, but justifying the "Find in..." text box to the left and the buttons to the right.
![screen shot 2019-03-04 at 10 12 02 am](https://user-images.githubusercontent.com/3372719/53746072-0a2fc580-3e66-11e9-8480-f4d180931508.png)
![screen shot 2019-03-04 at 10 12 21 am](https://user-images.githubusercontent.com/3372719/53746071-0a2fc580-3e66-11e9-8dd1-087c612baeba.png)


