### PR TITLE
hotfix: comment out a line in the repair_paths util

### DIFF
--- a/designsafe/libs/elasticsearch/utils.py
+++ b/designsafe/libs/elasticsearch/utils.py
@@ -135,7 +135,7 @@ def repair_paths(limit=1000):
             hit.update(**{'basePath': os.path.dirname(new_path)})
 
             # use from_path to remove any duplicates.
-            IndexedFile.from_path(hit.system, hit.path)
+            # IndexedFile.from_path(hit.system, hit.path)
 
         search_after = res.hits.hits[-1]['sort']
         logger.debug(search_after)


### PR DESCRIPTION
Trying do dedup while fixing the paths was giving weird transport errors when trying to delete things. Commenting out that line for now.