### PR TITLE
bug/indexer-040119: Set basePath during standard indexing

### DIFF
--- a/designsafe/libs/elasticsearch/utils.py
+++ b/designsafe/libs/elasticsearch/utils.py
@@ -96,6 +96,7 @@ def index_level(client, path, folders, files, systemId, username, reindex=False,
             obj_dict.pop('permissions')
             obj_dict.pop('trail')
             obj_dict.pop('_links')
+            obj_dict['basePath'] = os.path.dirname(obj.path)
             doc = BaseESFile(username, reindex=reindex, **obj_dict)
             
             saved = doc.save()


### PR DESCRIPTION
I managed to delete the line that set `basePath` on indexed files before pushing the CEP indexer port. This fix replaces it. 