### PR TITLE
Task/DES-868(931) - Incorrect PI in project, and Duplicated Entities Fix

### DIFF
--- a/designsafe/static/scripts/data-depot/components/data-depot-nav/data-depot-nav.component.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-nav/data-depot-nav.component.js
@@ -1,97 +1,94 @@
 import DataDepotNavTemplate from './data-depot-nav.component.html'
 
 class DataDepotNavCtrl {
-    constructor($scope, $rootScope, $state, Django) {
-        'ngInject';
+  constructor($scope, $rootScope, $state, Django) {
+    'ngInject';
 
-        this.$scope = $scope
-        this.$rootScope = $rootScope
-        this.$state = $state
-        this.Django = Django
-    }
-
-    $onInit() {
-  
-      this.routerItems = [];
-  
-      this.myDataFileId = 'designsafe.storage.default/' + this.Django.user + '/';
-      this.sharedFileId = 'designsafe.storage.default/$SHARE/';
-  
-      this.routerItems.push(
-          {
-            name: 'Published',
-            collapsible: false,
-            state: 'publicData',
-            description: "Curated data/projects with DOI's"
-          },
-          {
-            name: 'Community Data',
-            collapsible: false,
-            state: 'communityData',
-            description: 'Non-curated user-contributed data'
-          }
-      );
-  
-      if (this.Django.context.authenticated) {
-        this.routerItems.splice(0, 0,
-            {
-              name: 'My Data',
-              collapsible: false,
-              state: 'myData',
-              description: 'Private directory for your data'
-            },
-            {
-              name: 'My Projects',
-              collapsible: false,
-              state: 'projects.list',
-              description: 'Group access to shared directories'
-            },
-            {
-              name: 'Shared with Me',
-              collapsible: false,
-              state: 'sharedData',
-              description: 'Data other users shared with me'
-            },
-            {
-              name: 'Box.com',
-              collapsible: false,
-              state: 'boxData',
-              description: 'Access to my Box files for copying'
-            },
-            {
-              name: 'Dropbox.com',
-              collapsible: false,
-              state: 'dropboxData',
-              description: 'Access to my Dropbox for copying'
-            },
-            {
-              name: 'Google Drive',
-              collapsible: false,
-              state: 'googledriveData',
-              description: 'Access to my Google Drive for copying'
-            }
-        );
-      }
-    }
-  
-    itemClicked(routerItem) {
-        if (routerItem.collapsible) {
-          routerItem.collapse = ! routerItem.collapse;
-        }
-      };
-  
-      // allows state to be refreshed
-      // by clicking current nav button
-    stateReload(childItem) {
-        this.$state.go(childItem, {query_string: null}, {reload: true, inherit: false, location: true});
-      };
-  
-    
+    this.$scope = $scope;
+    this.$rootScope = $rootScope;
+    this.$state = $state;
+    this.Django = Django;
   }
- 
-  
-  export const DataDepotNavComponent = {
-    controller: DataDepotNavCtrl,
-    controllerAs: '$ctrl',
-    template: DataDepotNavTemplate
+
+  $onInit() {
+    this.routerItems = [];
+
+    this.myDataFileId = 'designsafe.storage.default/' + this.Django.user + '/';
+    this.sharedFileId = 'designsafe.storage.default/$SHARE/';
+
+    this.routerItems.push(
+      {
+        name: 'Published',
+        collapsible: false,
+        state: 'publicData',
+        description: "Curated data/projects with DOI's"
+      },
+      {
+        name: 'Community Data',
+        collapsible: false,
+        state: 'communityData',
+        description: 'Non-curated user-contributed data'
+      }
+    );
+
+    if (this.Django.context.authenticated) {
+      this.routerItems.splice(0, 0,
+        {
+          name: 'My Data',
+          collapsible: false,
+          state: 'myData',
+          description: 'Private directory for your data'
+        },
+        {
+          name: 'My Projects',
+          collapsible: false,
+          state: 'projects.list',
+          description: 'Group access to shared directories'
+        },
+        {
+          name: 'Shared with Me',
+          collapsible: false,
+          state: 'sharedData',
+          description: 'Data other users shared with me'
+        },
+        {
+          name: 'Box.com',
+          collapsible: false,
+          state: 'boxData',
+          description: 'Access to my Box files for copying'
+        },
+        {
+          name: 'Dropbox.com',
+          collapsible: false,
+          state: 'dropboxData',
+          description: 'Access to my Dropbox for copying'
+        },
+        {
+          name: 'Google Drive',
+          collapsible: false,
+          state: 'googledriveData',
+          description: 'Access to my Google Drive for copying'
+        }
+      );
+    }
+  }
+
+  itemClicked(routerItem) {
+    if (routerItem.collapsible) {
+      routerItem.collapse = !routerItem.collapse;
+    }
+  }
+
+  // allows state to be refreshed
+  // by clicking current nav button
+  stateReload(childItem) {
+    this.$state.go(childItem, { query_string: null }, { reload: true, inherit: false, location: true });
+  }
 }
+
+
+export const DataDepotNavComponent = {
+  controller: DataDepotNavCtrl,
+  controllerAs: '$ctrl',
+  template: DataDepotNavTemplate
+};

--- a/designsafe/static/scripts/data-depot/components/projects/curation-directory/curation-directory.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/curation-directory/curation-directory.component.html
@@ -64,13 +64,25 @@
         </colgroup>
         <tr>
             <td class="tg-0lax">
-                <button class="btn btn-project-l grayed-out" ng-click="$ctrl.goWork()">
-                    Working Directory</button>
-                <button class="btn btn-project-m" ng-click="$ctrl.goCuration()"
-                        ng-if="$ctrl.browser.project.value.projectType !== 'other'">
-                    Curation Directory</button>
-                <button class="btn btn-project-r grayed-out" ng-click="$ctrl.goPreview()">
-                    Publication Preview</button>
+                <button class="btn btn-project-l grayed-out"
+                        ng-click="$ctrl.goWork()"
+                        ng-disabled="$ctrl.loading"
+                >
+                    Working Directory
+                </button>
+                <button class="btn btn-project-m"
+                        ng-click="$ctrl.goCuration()"
+                        ng-if="$ctrl.browser.project.value.projectType !== 'other'"
+                        ng-disabled="$ctrl.loading"
+                >
+                    Curation Directory
+                </button>
+                <button class="btn btn-project-r grayed-out"
+                        ng-click="$ctrl.goPreview()"
+                        ng-disabled="$ctrl.loading"
+                >
+                    Publication Preview
+                </button>
             </td>
             <td class="tg-0lax" ng-if="!$ctrl.loading">
                 <div ng-hide="$ctrl.browser.project.value.projectType === 'other'">                    

--- a/designsafe/static/scripts/data-depot/components/projects/project-view/project-view.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/project-view/project-view.component.html
@@ -62,14 +62,24 @@
         </colgroup>
         <tr>
           <td>
-            <button class="btn btn-project-l" ng-click="$ctrl.workingDirectory()">
+            <button class="btn btn-project-l"
+                    ng-click="$ctrl.workingDirectory()"
+                    ng-disabled="$ctrl.loading"
+            >
               Working Directory</button>
             <button class="btn btn-project-m grayed-out"
                     ng-click="$ctrl.curationDirectory()"
-                    ng-if="$ctrl.browser.project.value.projectType !== 'other'">
-              Curation Directory</button>
-            <button class="btn btn-project-r grayed-out" ng-click="$ctrl.publicationPreview()">
-              Publication Preview</button>
+                    ng-if="$ctrl.browser.project.value.projectType !== 'other'"
+                    ng-disabled="$ctrl.loading"
+            >
+              Curation Directory
+            </button>
+            <button class="btn btn-project-r grayed-out"
+                    ng-click="$ctrl.publicationPreview()"
+                    ng-disabled="$ctrl.loading"
+            >
+              Publication Preview
+            </button>
           </td>
           <td>
           </td>

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
@@ -64,12 +64,24 @@
         </colgroup>
         <tr>
             <td class="tg-0lax">
-                <button class="btn btn-project-l grayed-out" ng-click="$ctrl.goWork()">
-                    Working Directory</button>
-                <button class="btn btn-project-m grayed-out" ng-click="$ctrl.goCuration()">
-                    Curation Directory</button>
-                <button class="btn btn-project-r" ng-click="publicationPreview()">
-                    Publication Preview</button>
+                <button class="btn btn-project-l grayed-out"
+                        ng-click="$ctrl.goWork()"
+                        ng-disabled="$ctrl.loading"
+                >
+                    Working Directory
+                </button>
+                <button class="btn btn-project-m grayed-out"
+                        ng-click="$ctrl.goCuration()"
+                        ng-disabled="$ctrl.loading"
+                >
+                    Curation Directory
+                </button>
+                <button class="btn btn-project-r"
+                        ng-click="publicationPreview()"
+                        ng-disabled="$ctrl.loading"
+                >
+                    Publication Preview
+                </button>
             </td>
             <td class="tg-0lax">
                 <div class="btn-group pull-right" role="group" aria-label="Publish buttons">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.html
@@ -64,10 +64,16 @@
         </colgroup>
         <tr>
             <td class="tg-0lax">
-                <button class="btn btn-project-l grayed-out" ng-click="$ctrl.goWork()">
-                    Working Directory</button>
-                <button class="btn btn-project-r" ng-click="publicationPreview()">
-                    Publication Preview</button>
+                <button class="btn btn-project-l grayed-out"
+                        ng-click="$ctrl.goWork()"
+                >
+                    Working Directory
+                </button>
+                <button class="btn btn-project-r"
+                        ng-click="publicationPreview()"
+                >
+                    Publication Preview
+                </button>
             </td>
             <td class="tg-0lax">
                 <div class="btn-group pull-right" role="group" aria-label="Publish buttons">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
@@ -64,12 +64,24 @@
         </colgroup>
         <tr>
             <td class="tg-0lax">
-                <button class="btn btn-project-l grayed-out" ng-click="$ctrl.goWork()">
-                    Working Directory</button>
-                <button class="btn btn-project-m grayed-out" ng-click="$ctrl.goCuration()">
-                    Curation Directory</button>
-                <button class="btn btn-project-r" ng-click="publicationPreview()">
-                    Publication Preview</button>
+                <button class="btn btn-project-l grayed-out"
+                        ng-click="$ctrl.goWork()"
+                        ng-disabled="$ctrl.loading"
+                >
+                    Working Directory
+                </button>
+                <button class="btn btn-project-m grayed-out"
+                        ng-click="$ctrl.goCuration()"
+                        ng-disabled="$ctrl.loading"
+                >
+                    Curation Directory
+                </button>
+                <button class="btn btn-project-r"
+                        ng-click="publicationPreview()"
+                        ng-disabled="$ctrl.loading"
+                >
+                    Publication Preview
+                </button>
             </td>
             <td class="tg-0lax">
                 <div class="btn-group pull-right" role="group" aria-label="Publish buttons">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
@@ -64,12 +64,24 @@
         </colgroup>
         <tr>
             <td class="tg-0lax">
-                <button class="btn btn-project-l grayed-out" ng-click="$ctrl.goWork()">
-                    Working Directory</button>
-                <button class="btn btn-project-m grayed-out" ng-click="$ctrl.goCuration()">
-                    Curation Directory</button>
-                <button class="btn btn-project-r" ng-click="publicationPreview()">
-                    Publication Preview</button>
+                <button class="btn btn-project-l grayed-out"
+                        ng-click="$ctrl.goWork()"
+                        ng-disabled="$ctrl.loading"
+                >
+                    Working Directory
+                </button>
+                <button class="btn btn-project-m grayed-out"
+                        ng-click="$ctrl.goCuration()"
+                        ng-disabled="$ctrl.loading"
+                >
+                    Curation Directory
+                </button>
+                <button class="btn btn-project-r"
+                        ng-click="publicationPreview()"
+                        ng-disabled="$ctrl.loading"
+                >
+                    Publication Preview
+                </button>
             </td>
             <td class="tg-0lax">
                 <div class="btn-group pull-right" role="group" aria-label="Publish buttons">

--- a/designsafe/static/scripts/data-depot/index.js
+++ b/designsafe/static/scripts/data-depot/index.js
@@ -202,6 +202,7 @@ function config(
                             system: 'designsafe.storage.default',
                             permissions: [],
                         };
+                        delete DataBrowserService.currentState.project;
                     },
                 ],
             },


### PR DESCRIPTION
1. Navigating from a personal project to the My Projects listing would not clear the project data stored in the DataBrowserService state. This would cause incorrect data to be displayed when clicking into a new project.
2. When users quickly browse between the Working Dir, Curation Dir, and Publication Preview there is a chance for the project entities to resolve twice resulting in duplicated experiments and categories. I've disabled the navigation buttons between these states while the data is loading.
3. Made some formatting changes in data-depot-nav

![1](https://user-images.githubusercontent.com/29575979/55418577-93571c80-5538-11e9-88fa-7e9586ec5b4d.png)
![2](https://user-images.githubusercontent.com/29575979/55418582-9520e000-5538-11e9-83d0-07b74e94ce67.png)
