### PR TITLE
remove appDefinition from job submission for aloe

### DIFF
--- a/designsafe/apps/workspace/views.py
+++ b/designsafe/apps/workspace/views.py
@@ -184,6 +184,8 @@ def call_api(request, service):
                         if not any(p['id'] == param for p in job_post['appDefinition']['parameters']):
                             del job_post['parameters'][param]
 
+                    del job_post['appDefinition']
+
                     job_post['notifications'] = [
                         {'url': jobs_wh_url,
                         'event': e}


### PR DESCRIPTION
Need to remove `appDefinition` from `job_post` for aloe job submission to go through.