### PR TITLE
task/DES-941 and task/DES-942: Persist publication filters on search

### DIFF
--- a/designsafe/static/scripts/data-depot/components/files-listing/files-listing.component.js
+++ b/designsafe/static/scripts/data-depot/components/files-listing/files-listing.component.js
@@ -18,6 +18,7 @@ class FilesListingCtrl {
 
     $onInit() {
         this._ui = { loading: false, error: false };
+        this.state = this.DataBrowserService.state()
         this.bread = (path, system) => {
             if (!path) {
                 return;
@@ -64,14 +65,6 @@ class FilesListingCtrl {
             this.allowSelect = false;
             return this.filesList;
         };
-
-        this.toggles = {
-            experimental: false,
-            simulation: false,
-            hybrid: false,
-            nees: false,
-            other: false
-        }
     }
 
     breadcrumbBrowse($event, path) {
@@ -191,8 +184,8 @@ class FilesListingCtrl {
       }
       areFiltersEmpty() {
           let noneToggled = true
-          for (const key of Object.keys(this.toggles)) {
-              if (this.toggles[key]) {
+          for (const key of Object.keys(this.state.type_filters)) {
+              if (this.state.type_filters[key]) {
                   noneToggled = false
               }
           }
@@ -205,14 +198,14 @@ class FilesListingCtrl {
           if (this.areFiltersEmpty()) {
               return true
           }
-          if (item.metadata && this.toggles['nees']) {
+          if (item.metadata && this.state.type_filters['nees']) {
               return true
           }
-          return this.toggles[(item.meta || {}).type]; 
+          return this.state.type_filters[(item.meta || {}).type]; 
       }
       clearFilters() {
-          for (const key of Object.keys(this.toggles)) {
-              this.toggles[key] = false
+          for (const key of Object.keys(this.state.type_filters)) {
+              this.state.type_filters[key] = false
           }
       }
 }

--- a/designsafe/static/scripts/data-depot/components/files-listing/files-listing.public.template.html
+++ b/designsafe/static/scripts/data-depot/components/files-listing/files-listing.public.template.html
@@ -1,12 +1,12 @@
 <div style="background-color:white;padding:10px"> 
     <a  ng-if="$ctrl.$stateParams.query_string"ng-href="/data/browser/public/"><i class="fa fa-arrow-left"></i> Back to all publications</a>
     <p ng-if="$ctrl.$stateParams.query_string">{{filtered.length}} Results found for <b>{{$ctrl.$stateParams.query_string}}</b></p>
-    <p><b>Publication Type</b> <a ng-if=!$ctrl.areFiltersEmpty() ng-click="$ctrl.clearFilters()">clear</a></p>
-    <label class="checkbox-inline custom-control-input my-error"><input type="checkbox" value="" ng-model="$ctrl.toggles.experimental">Experimental</label>
-    <label class="checkbox-inline"><input type="checkbox" value="" ng-model="$ctrl.toggles.simulation" >Simulation</label>
-    <label class="checkbox-inline"><input type="checkbox" value="" ng-model="$ctrl.toggles.hybrid">Hybrid Simulation</label>
-    <label class="checkbox-inline"><input type="checkbox" value="" ng-model="$ctrl.toggles.nees">NEES</label>
-    <label class="checkbox-inline"><input type="checkbox" value="" ng-model="$ctrl.toggles.other">Other</label>
+    <p><b>Publication Type</b> <a ng-if=!$ctrl.areFiltersEmpty() ng-click="$ctrl.clearFilters()">Clear</a></p>
+    <label class="checkbox-inline custom-control-input my-error"><input type="checkbox" value="" ng-model="$ctrl.state.type_filters.experimental">Experimental</label>
+    <label class="checkbox-inline"><input type="checkbox" value="" ng-model="$ctrl.state.type_filters.simulation" >Simulation</label>
+    <label class="checkbox-inline"><input type="checkbox" value="" ng-model="$ctrl.state.type_filters.hybrid">Hybrid Simulation</label>
+    <label class="checkbox-inline"><input type="checkbox" value="" ng-model="$ctrl.state.type_filters.nees">NEES</label>
+    <label class="checkbox-inline"><input type="checkbox" value="" ng-model="$ctrl.state.type_filters.other">Other</label>
   </div>
 <div class="table-responsive">
     <div

--- a/designsafe/static/scripts/ng-designsafe/services/data-browser-service.js
+++ b/designsafe/static/scripts/ng-designsafe/services/data-browser-service.js
@@ -37,7 +37,14 @@ export function DataBrowserService($rootScope, $http, $q, $uibModal,
     showMainListing: true,
     showPreviewListing: false,
     ui: {},
-    tests: null
+    tests: null,
+    type_filters: {
+      experimental: false,
+      simulation: false,
+      hybrid: false,
+      nees: false,
+      other: false
+    }
   };
 
   var projectBreadcrumbSubject = new Subject();


### PR DESCRIPTION
- Capitalize the Clear button in Publication search filters
- Search in Publications now persists any user-selected filters. This is done by moving the filters into `DataBrowserService.currentState` so they are accessible after the state change.