### PR TITLE
fix/des 960:  Add processorsPerNode option for parallel apps

### DIFF
--- a/designsafe/static/scripts/workspace/controllers/application-form.js
+++ b/designsafe/static/scripts/workspace/controllers/application-form.js
@@ -130,8 +130,14 @@ export default function ApplicationFormCtrl($scope, $rootScope, $localStorage, $
         } else {
             items.push('maxRunTime', 'name', 'archivePath');
         }
-        if ($scope.data.app.parallelism == 'PARALLEL' && !$scope.data.app.tags.includes('hideNodeCount')) {
-            items.push('nodeCount');
+        if ($scope.data.app.parallelism == 'PARALLEL') {
+            if (!$scope.data.app.tags.includes('hideNodeCount')) {
+                items.push('nodeCount');
+            }
+            if (!$scope.data.app.tags.includes('hideProcessorsPerNode')) {
+                items.push('processorsPerNode');
+            }
+
         }
         $scope.form.form.push({
             type: 'fieldset',
@@ -194,8 +200,12 @@ export default function ApplicationFormCtrl($scope, $rootScope, $localStorage, $
             }
 
             // Calculate processorsPerNode if nodeCount parameter submitted
-            if (_.has(jobData, 'nodeCount')) {
+            if (('nodeCount' in jobData) && !('processorsPerNode' in jobData)) {
                 jobData.processorsPerNode = jobData.nodeCount * ($scope.data.app.defaultProcessorsPerNode / $scope.data.app.defaultNodeCount);
+            } else if (('nodeCount' in jobData) && ('processorsPerNode' in jobData)) {
+                jobData.processorsPerNode = jobData.nodeCount * jobData.processorsPerNode;
+            } else if (!('nodeCount' in jobData) && ('processorsPerNode' in jobData)) {
+                jobData.processorsPerNode = jobData.defaultNodeCount * jobData.processorsPerNode;
             }
 
             $scope.jobReady = true;

--- a/designsafe/static/scripts/workspace/services/apps-service.js
+++ b/designsafe/static/scripts/workspace/services/apps-service.js
@@ -191,6 +191,16 @@ export function appsService($http, $q, $translate, djangoUrl) {
                 }),
             },
         };
+        
+        schema.properties.processorsPerNode = {
+            title: 'Processors Per Node',
+            description: `Number of processors (cores) per node for the job. e.g. A selection of 16 processors per node along with 4 nodes
+            will result in 16 processors on 4 nodes, with 64 processors total. Default number of processors per node is ${Math.floor(app.defaultProcessorsPerNode / app.defaultNodeCount)}.`,
+            type: 'integer',
+            default: Math.floor(app.defaultProcessorsPerNode / app.defaultNodeCount),
+            minimum: 1,
+            maximum: Math.floor(app.defaultProcessorsPerNode / app.defaultNodeCount),
+        };
 
         schema.properties.archivePath = {
             title: 'Job output archive location (optional)',

--- a/designsafe/static/scripts/workspace/services/simple-list-service.js
+++ b/designsafe/static/scripts/workspace/services/simple-list-service.js
@@ -17,6 +17,13 @@ export function simpleListService($http, $q, djangoUrl, appCategories, appIcons)
         this.binMap = {};
     };
 
+    SimpleList.prototype.tagIncludesParam = function(definition, param) {
+        return definition.tags &&
+            Array.isArray(definition.tags) &&
+            definition.tags.filter((s) => s.includes(`${param}:`))[0] &&
+            definition.tags.filter((s) => s.includes(`${param}:`))[0].split(':')[1];
+    };
+
     SimpleList.prototype.getDefaultLists = function(query) {
         let self = this,
             deferred = $q.defer();
@@ -33,12 +40,6 @@ export function simpleListService($http, $q, djangoUrl, appCategories, appIcons)
                  * @param {String} param - Parameter to search for in definition.tags, i.e. 'appIcon'
                  * @return {Boolean}
                  */
-                function tagIncludesParam(definition, param) {
-                    return definition.tags &&
-                        Array.isArray(definition.tags) &&
-                        definition.tags.filter(s => s.includes(`${param}:`))[0] &&
-                        definition.tags.filter(s => s.includes(`${param}:`))[0].split(':')[1];
-                }
 
                 let appsByCategory = {};
                 angular.forEach(self.tabs, function(tab) {
@@ -65,8 +66,8 @@ export function simpleListService($http, $q, djangoUrl, appCategories, appIcons)
                                 }
                                 return false;
                             });
-                        } else if (tagIncludesParam(appMeta.value.definition, 'appIcon')) {
-                            const appIcon = appMeta.value.definition.tags.filter(s => s.includes('appIcon'))[0].split(':')[1];
+                        } else if (self.tagIncludesParam(appMeta.value.definition, 'appIcon')) {
+                            const appIcon = appMeta.value.definition.tags.filter((s) => s.includes('appIcon'))[0].split(':')[1];
 
                             // Use icon for binning of apps, with '_icon-letter' appended to denote the icon will be a letter, not a true icon
                             appMeta.value.definition.appIcon = appMeta.value.definition.orderBy = `${appIcon}_icon-letter`;
@@ -96,8 +97,8 @@ export function simpleListService($http, $q, djangoUrl, appCategories, appIcons)
                             let appCategory;
                             if (appMeta.value.definition.appCategory) {
                                 appCategory = appMeta.value.definition.appCategory;
-                            } else if (tagIncludesParam(appMeta.value.definition, 'appCategory')) {
-                                appCategory = appMeta.value.definition.tags.filter(s => s.includes('appCategory'))[0].split(':')[1];
+                            } else if (self.tagIncludesParam(appMeta.value.definition, 'appCategory')) {
+                                appCategory = appMeta.value.definition.tags.filter((s) => s.includes('appCategory'))[0].split(':')[1];
                             }
 
                             // Place appMeta in category
@@ -176,7 +177,7 @@ export function simpleListService($http, $q, djangoUrl, appCategories, appIcons)
 
                 deferred.resolve(self);
             },
-            function(apps) {
+            function() {
                 deferred.reject();
             }
         );


### PR DESCRIPTION
- option can be hidden by adding the string `'hideProcessorsPerNode'` into an app's tags