### PR TITLE
Bug/DES-948 - Fix 403 caused by missing CSRF token in preview

### DIFF
--- a/designsafe/apps/api/public_data/views.py
+++ b/designsafe/apps/api/public_data/views.py
@@ -24,6 +24,8 @@ from django.http import (HttpResponseRedirect,
                          JsonResponse)
 from django.shortcuts import render
 from django.contrib.auth import get_user_model, login
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 from designsafe.apps.api.views import BaseApiView
 from designsafe.apps.api.mixins import SecureMixin
 from designsafe.apps.api.agave import get_service_account_client
@@ -96,6 +98,10 @@ class PublicDataListView(BaseApiView):
 
 class PublicMediaView(FileMediaView):
     """Media view to render metadata"""
+
+    @method_decorator(csrf_exempt)
+    def dispatch(self, *args, **kwargs):
+        return super(PublicMediaView, self).dispatch(*args, **kwargs)
 
     def get(self, request, *args, **kwargs):
         return super(PublicMediaView, self).get(request, *args, **kwargs)

--- a/designsafe/apps/data/views/base.py
+++ b/designsafe/apps/data/views/base.py
@@ -186,6 +186,10 @@ class DataDepotPublishedView(TemplateView):
 
     This view will be used when a user goes directly to a published project.
     """
+    @method_decorator(ensure_csrf_cookie)
+    def dispatch(self, request, *args, **kwargs):
+        return super(DataDepotPublishedView, self).dispatch(request, *args, **kwargs)
+
     template_name = 'data/data_depot.html'
 
     def get_context_data(self, **kwargs):

--- a/designsafe/apps/data/views/base.py
+++ b/designsafe/apps/data/views/base.py
@@ -186,9 +186,6 @@ class DataDepotPublishedView(TemplateView):
 
     This view will be used when a user goes directly to a published project.
     """
-    @method_decorator(ensure_csrf_cookie)
-    def dispatch(self, request, *args, **kwargs):
-        return super(DataDepotPublishedView, self).dispatch(request, *args, **kwargs)
 
     template_name = 'data/data_depot.html'
 

--- a/designsafe/apps/data/views/base.py
+++ b/designsafe/apps/data/views/base.py
@@ -186,7 +186,6 @@ class DataDepotPublishedView(TemplateView):
 
     This view will be used when a user goes directly to a published project.
     """
-
     template_name = 'data/data_depot.html'
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Non users who directly visited or were linked to published projects on DesignSafe would receive a 403 error when trying to preview project files.

Using the `csrf_exempt` decorator in the `DataDepotPublishedView` class did not seem to work, so I used it in the `PublicMediaView` instead.