### PR TITLE
task/DES-1006: Don't show files in other users' My Data

### DIFF
--- a/designsafe/apps/api/agave/views.py
+++ b/designsafe/apps/api/agave/views.py
@@ -63,8 +63,7 @@ class FileListingView(BaseApiView):
                 file_path = request.user.username
 
             if system_id == AgaveFileManager.DEFAULT_SYSTEM_ID and \
-                (file_path.strip('/') == '$SHARE' or
-                 file_path.strip('/').split('/')[0] != request.user.username):
+                (file_path.strip('/') == '$SHARE'):
 
                 listing = ElasticFileManager.listing(system=system_id,
                                                      file_path=file_path,


### PR DESCRIPTION
Before, if you tried to access another user's My Data, we would check that user's files for anything you had Read permission for and display those. This is unintuitive/potentially insecure, so now My Data is locked to a user's own files. 