### PR TITLE
bug/DES-1009: Limit project indexer to once per day

### DIFF
--- a/designsafe/celery.py
+++ b/designsafe/celery.py
@@ -29,7 +29,7 @@ app.conf.update(
         },
         'reindex_projects': {
             'task': 'designsafe.apps.api.tasks.reindex_projects',
-            'schedule': crontab(hour="*/24")
+            'schedule': crontab(hour="*/24", minute=0)
         }
     }
 )


### PR DESCRIPTION
The crontab needs a `minute` argument.