### PR TITLE
bug/DES-1072: Infinite recursion in indexer

### DIFF
--- a/designsafe/libs/elasticsearch/docs/files.py
+++ b/designsafe/libs/elasticsearch/docs/files.py
@@ -99,5 +99,6 @@ class BaseESFile(BaseESResource):
         if self.format == 'folder':
             children = self.children()
             for child in children:
-                child.delete()
+                if child.path != self.path:
+                    child.delete()
         self._wrapped.delete()

--- a/designsafe/libs/elasticsearch/utils.py
+++ b/designsafe/libs/elasticsearch/utils.py
@@ -111,7 +111,7 @@ def index_level(client, path, folders, files, systemId, username, reindex=False,
     children_paths = [_file.path for _file in folders + files]
     es_root = BaseESFile(username, systemId, path, reindex=reindex)
     for doc in es_root.children():
-        if doc is not None and doc.path not in children_paths:
+        if doc is not None and doc.path not in children_paths and doc.path != path:
             doc.delete()
 
 @python_2_unicode_compatible


### PR DESCRIPTION
Fixes an infinite recursion in cases where the root of a storage system is indexed as a child of that same system. This is a feature of at least some legacy projects.