### PR TITLE
another hotfix for Rapid metadata in the preview window as per talks …

### DIFF
--- a/designsafe/static/scripts/data-depot/components/file-metadata/file-metadata.controller.js
+++ b/designsafe/static/scripts/data-depot/components/file-metadata/file-metadata.controller.js
@@ -13,6 +13,13 @@ class FileMetadataComponentCtrl {
             //
             try {
                 this.metadata = resp[1];
+                Object.keys(this.metadata).filter((key)=>{
+                    if (key.startsWith('_') || this.metadata[key] === '') {
+                        delete this.metadata[key];
+                    }
+                });
+                // Convert the object to an Array for the template
+                this.metadata = Object.keys(this.metadata).map( (key)=> {return [key, this.metadata[key]];});
             } catch(err) {
                 this.metadata = null;
             }

--- a/designsafe/static/scripts/data-depot/components/file-metadata/file-metadata.spec.js
+++ b/designsafe/static/scripts/data-depot/components/file-metadata/file-metadata.spec.js
@@ -1,6 +1,6 @@
 
 
-fdescribe("FileMetadataComponent", ()=> {
+describe("FileMetadataComponent", ()=> {
     var FileListing,
         $rootScope,
         $compile,
@@ -28,10 +28,12 @@ fdescribe("FileMetadataComponent", ()=> {
             lastModified: new Date('2018-01-01T12:00:00-06:00'),
             queryString: '',
         };
-        let meta = [{
+        let meta = [{},{
             key1: 'val1',
             key2: 'val2',
-            geolocation: [{ latitude: 0, longitude: 0 }]
+            geolocation: [{ latitude: 0, longitude: 0 }],
+            key3: '',
+            _key5: 'val5'
         }];
         fl = FileListing.init(options);
         spyOn(fl, 'getAssociatedMetadata').and.returnValue($q.when(meta));
@@ -62,12 +64,20 @@ fdescribe("FileMetadataComponent", ()=> {
         expect(element.find('table').html()).toContain('test/test.txt');
     });
 
-    it('FileMetadata component should correcly parse the geolocation tag', ()=>{
+    it('FileMetadata component should correctly parse the geolocation tag', ()=>{
         let el = angular.element("<file-metadata file='fl'></file-metadata>");
         element = $compile(el)(scope);
         scope.$digest();
         expect(element.find('table').html()).toContain('geolocation');
         expect(element.find('table').html()).toContain('(0, 0)');
+    });
+
+    it('FileMetadata component should not show nulls or keys that start with _', ()=>{
+        let el = angular.element("<file-metadata file='fl'></file-metadata>");
+        element = $compile(el)(scope);
+        scope.$digest();
+        expect(element.find('table').html()).not.toContain('key3');
+        expect(element.find('table').html()).not.toContain('val5');
     });
 
 

--- a/designsafe/static/scripts/data-depot/components/file-metadata/file-metadata.template.html
+++ b/designsafe/static/scripts/data-depot/components/file-metadata/file-metadata.template.html
@@ -23,10 +23,10 @@
                     <th>Last modified</th>
                     <td>{{ $ctrl.file.lastModified|date:"short" }}</td>
                 </tr>
-                <tr ng-repeat="(key, val) in $ctrl.metadata" ng-if="val">
-                    <td> <b> {{ key }} </b> </td>
-                    <td ng-if="key === 'geolocation'"> ({{ val[0].latitude }}, {{ val[0].longitude }}) </td>
-                    <td ng-if="key !== 'geolocation'"> {{ val }} </td>
+                <tr ng-repeat="rec in $ctrl.metadata | orderBy: rec[0]">
+                    <td> <b> {{ rec[0] }} </b> </td>
+                    <td ng-if="rec[0] === 'geolocation'"> ({{ rec[1][0].latitude }}, {{ rec[1][0].longitude }}) </td>
+                    <td ng-if="rec[0] !== 'geolocation'"> {{ rec[1] }} </td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
Removes all keys that start with underscore, alphabetizes the entries in the table. 