### PR TITLE
Task/DES-1111 - Change file apiParams for published area

### DIFF
--- a/designsafe/static/scripts/projects/components/file-categories/file-categories.component.js
+++ b/designsafe/static/scripts/projects/components/file-categories/file-categories.component.js
@@ -10,6 +10,10 @@ import { values } from '@uirouter/core';
 
 const getFileUuid = (file) => {
     let promise;
+    if (file.apiParams.fileMgr === 'published') {
+        // change the params if for published files.
+        file.apiParams = {baseUrl: "/api/agave/files", fileMgr: "agave"};
+    }
     if (_.isEmpty(file.uuid())) {
         promise = file.getMeta();
     } else {


### PR DESCRIPTION
It looks like files were redirecting and 404ing in the published area because they did not have the expected apiParams.