### PR TITLE
Hotfix-Bug/DES-1113 - Change archive path for publication

### DIFF
--- a/designsafe/apps/api/tasks.py
+++ b/designsafe/apps/api/tasks.py
@@ -896,18 +896,18 @@ def save_publication(self, project_id):
         logger.error('Proj Id: %s. %s', project_id, exc, exc_info=True)
         raise self.retry(exc=exc)
 
-@shared_task(bind=True)
-def zip_project_files(self, project_uuid):
-    from designsafe.apps.projects.models.agave.base import Project
-    from designsafe.apps.api.agave import get_service_account_client
+# @shared_task(bind=True)
+# def zip_project_files(self, project_uuid):
+#     from designsafe.apps.projects.models.agave.base import Project
+#     from designsafe.apps.api.agave import get_service_account_client
 
-    try:
-        ag = get_service_account_client()
-        proj = Project.manager().get(ag, uuid=project_uuid)
-        proj.archive()
-    except Exception as exc:
-        logger.error('Zip Proj UUID: %s. %s', project_uuid, exc, exc_info=True)
-        raise self.retry(exc=exc)
+#     try:
+#         ag = get_service_account_client()
+#         proj = Project.manager().get(ag, uuid=project_uuid)
+#         proj.archive()
+#     except Exception as exc:
+#         logger.error('Zip Proj UUID: %s. %s', project_uuid, exc, exc_info=True)
+#         raise self.retry(exc=exc)
 
 @shared_task(bind=True)
 def zip_publication_files(self, project_id):

--- a/designsafe/apps/projects/models/agave/base.py
+++ b/designsafe/apps/projects/models/agave/base.py
@@ -150,11 +150,11 @@ class Project(MetadataModel):
 
     def archive(self):
         ARCHIVE_NAME = str(self.project_id) + '_archive.zip'
-        proj_dir = '/corral-repl/tacc/NHERI/projects/{}'.format(self.uuid)
+        proj_dir = '/corral-repl/tacc/NHERI/published/{}'.format(self.project_id)
 
         # open directory permissions
         def open_perms(project_directory):
-            os.chmod('/corral-repl/tacc/NHERI/projects/', 0777)
+            os.chmod('/corral-repl/tacc/NHERI/published/', 0777)
             archive_path = os.path.join(project_directory)
             for root, dirs, files in os.walk(archive_path):
                 os.chmod(root, 0777)
@@ -165,7 +165,7 @@ class Project(MetadataModel):
 
         # close directory permissions
         def close_perms(project_directory):
-            os.chmod('/corral-repl/tacc/NHERI/projects/', 0555)
+            os.chmod('/corral-repl/tacc/NHERI/published/', 0555)
             archive_path = os.path.join(project_directory)
             for root, dirs, files in os.walk(archive_path):
                 os.chmod(root, 0555)


### PR DESCRIPTION
- The `zip_publication_files` task was pointed to the wrong directory. This caused permissions issues with projects.
- Commented out `zip_project_files` since it has not been finished.
- This fixes the issue of permissions being changed on the projects directory instead of the publications directory