### PR TITLE
bug/DES-1120: Don't use invalid regex in app form

### DIFF
--- a/designsafe/static/scripts/workspace/controllers/application-form.js
+++ b/designsafe/static/scripts/workspace/controllers/application-form.js
@@ -108,6 +108,8 @@ export default function ApplicationFormCtrl($scope, $rootScope, $localStorage, $
         // reset formValid, var is used for invalid form msg
         $scope.data.formValid = [];
 
+        let readOnly = $scope.data.needsLicense || $scope.data.unavailable || $scope.data.systemDown;
+
         /* inputs */
         let items = [];
         if ($scope.form.schema.properties.inputs) {
@@ -118,7 +120,7 @@ export default function ApplicationFormCtrl($scope, $rootScope, $localStorage, $
         }
         $scope.form.form.push({
             type: 'fieldset',
-            readonly: ($scope.data.needsLicense || $scope.data.unavailable || $scope.data.systemDown),
+            readonly: readOnly,
             title: 'Inputs',
             items: items,
         });
@@ -141,14 +143,14 @@ export default function ApplicationFormCtrl($scope, $rootScope, $localStorage, $
         }
         $scope.form.form.push({
             type: 'fieldset',
-            readonly: ($scope.data.needsLicense || $scope.data.unavailable || $scope.data.systemDown),
+            readonly: readOnly,
             title: 'Job details',
             items: items,
         });
 
         /* buttons */
         items = [];
-        if (!($scope.data.needsLicense || $scope.data.unavailable || $scope.data.systemDown)) {
+        if (!readOnly) {
             items.push({ type: 'submit', title: ($scope.data.app.tags.includes('Interactive') ? 'Launch' : 'Run'), style: 'btn-primary' });
         }
         items.push({ type: 'button', title: 'Close', style: 'btn-link', onClick: 'closeApp()' });

--- a/designsafe/static/scripts/workspace/services/apps-service.js
+++ b/designsafe/static/scripts/workspace/services/apps-service.js
@@ -89,6 +89,11 @@ export function appsService($http, $q, $translate, djangoUrl, Django) {
                 if (!param.value.visible || param.id.startsWith('_')) {
                     return;
                 }
+                try {
+                    RegExp(param.value.validator);
+                } catch (e) {
+                    param.value.validator = null;
+                }
                 let field = {
                     title: param.details.label,
                     description: param.details.description,


### PR DESCRIPTION
Sometimes a regex validation pattern defined in an agave app definition for an input or parameter is incompatible with javascript's regex validator. In this case, don't use the validator in order to preserve the form entry