### PR TITLE
bug/DES-1124: Fix bad field validation; Other App Form fixes

### DIFF
--- a/designsafe/apps/workspace/views.py
+++ b/designsafe/apps/workspace/views.py
@@ -45,6 +45,7 @@ def call_api(request, service):
             app_id = request.GET.get('app_id')
             if app_id:
                 data = agave.apps.get(appId=app_id)
+                data['exec_sys'] = agave.systems.get(systemId=data['executionSystem'])
                 lic_type = _app_license_type(app_id)
                 data['license'] = {
                     'type': lic_type

--- a/designsafe/static/scripts/ng-designsafe/ng-designsafe.js
+++ b/designsafe/static/scripts/ng-designsafe/ng-designsafe.js
@@ -34,63 +34,64 @@ import './controllers';
 import './components';
 
 export const ngDesignsafe = angular.module('designsafe',
-                                           ['ng.modernizr',
-                                            'djng.urls',
-                                            'slickCarousel',
-                                            'designsafe.services',
-                                            'designsafe.directives',
-                                            'designsafe.filters',
-                                            'designsafe.models',
-                                            'designsafe.controllers',
-                                            'designsafe.components',
-                                            'ds.notifications',
-                                            'ds.wsBus',
-                                           ])
-.config(['$httpProvider', function($httpProvider) {
-  $httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
-  $httpProvider.defaults.xsrfCookieName = 'csrftoken';
-  $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
-}])
-.config(['WSBusServiceProvider', '$httpProvider', 'toastrConfig',
-  function config(WSBusServiceProvider, $httpProvider, toastrConfig) {
-    /*
-    * https://github.com/Foxandxss/angular-toastr#toastr-customization
-    */
-    angular.extend(toastrConfig, {
-      positionClass: 'toast-bottom-left',
-      timeOut: 20000
-    });
+    ['ng.modernizr',
+        'djng.urls',
+        'slickCarousel',
+        'designsafe.services',
+        'designsafe.directives',
+        'designsafe.filters',
+        'designsafe.models',
+        'designsafe.controllers',
+        'designsafe.components',
+        'ds.notifications',
+        'ds.wsBus',
+    ])
+    .config(['$httpProvider', '$qProvider', function($httpProvider, $qProvider) {
+        $httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+        $httpProvider.defaults.xsrfCookieName = 'csrftoken';
+        $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
+        $qProvider.errorOnUnhandledRejections(false);
+    }])
+    .config(['WSBusServiceProvider', '$httpProvider', 'toastrConfig',
+        function config(WSBusServiceProvider, $httpProvider, toastrConfig) {
+            /*
+      * https://github.com/Foxandxss/angular-toastr#toastr-customization
+      */
+            angular.extend(toastrConfig, {
+                positionClass: 'toast-bottom-left',
+                timeOut: 20000
+            });
 
-    WSBusServiceProvider.setUrl(
-      (window.location.protocol === 'https:' ? 'wss://' : 'ws://') +
-      window.location.hostname +
-      (window.location.port ? ':' + window.location.port : '') +
-      '/ws/websockets?subscribe-broadcast&subscribe-user'
-    );
-  }
-])
-.constant('appCategories', ['Simulation', 'Visualization', 'Data Processing', 'Partner Data Apps', 'Utilities'])
-// Current list of icons for apps
-.constant('appIcons', ['Compress', 'Extract', 'MATLAB', 'Paraview', 'Hazmapper', 'Jupyter', 'ADCIRC', 'QGIS', 'LS-DYNA', 'LS-Pre/Post', 'VisIt', 'OpenFOAM', 'OpenSees', 'NGL'])
+            WSBusServiceProvider.setUrl(
+                (window.location.protocol === 'https:' ? 'wss://' : 'ws://') +
+                window.location.hostname +
+                (window.location.port ? ':' + window.location.port : '') +
+                '/ws/websockets?subscribe-broadcast&subscribe-user'
+            );
+        }
+    ])
+    .constant('appCategories', ['Simulation', 'Visualization', 'Data Processing', 'Partner Data Apps', 'Utilities'])
+    // Current list of icons for apps
+    .constant('appIcons', ['Compress', 'Extract', 'MATLAB', 'Paraview', 'Hazmapper', 'Jupyter', 'ADCIRC', 'QGIS', 'LS-DYNA', 'LS-Pre/Post', 'VisIt', 'OpenFOAM', 'OpenSees', 'NGL']);
 
 ngDesignsafe.requires.push('django.context',
-                           'httpi',
-                           'ngCookies',
-                           'djng.urls',  //TODO: djng
-                           'ui.bootstrap',
-                           'ds.notifications',
-                           'toastr',
-                           'logging',
-                           'ngMaterial');
+    'httpi',
+    'ngCookies',
+    'djng.urls',  //TODO: djng
+    'ui.bootstrap',
+    'ds.notifications',
+    'toastr',
+    'logging',
+    'ngMaterial');
 
 ngDesignsafe.run(['WSBusService', 'logger',
-  function init(WSBusService, logger) {
-    WSBusService.init(WSBusService.url);
-  }]);
+    function init(WSBusService, logger) {
+        WSBusService.init(WSBusService.url);
+    }]);
 ngDesignsafe.run(['NotificationService', 'logger',
-  function init(NotificationService, logger) {
-    NotificationService.init();
-  }]);
+    function init(NotificationService, logger) {
+        NotificationService.init();
+    }]);
 const portal = angular.module('designsafe.portal', []).config(['$httpProvider', function($httpProvider) {
     $httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
     $httpProvider.defaults.xsrfCookieName = 'csrftoken';

--- a/designsafe/static/scripts/workspace/controllers/application-form.js
+++ b/designsafe/static/scripts/workspace/controllers/application-form.js
@@ -207,7 +207,7 @@ export default function ApplicationFormCtrl($scope, $rootScope, $localStorage, $
             } else if (('nodeCount' in jobData) && ('processorsPerNode' in jobData)) {
                 jobData.processorsPerNode = jobData.nodeCount * jobData.processorsPerNode;
             } else if (!('nodeCount' in jobData) && ('processorsPerNode' in jobData)) {
-                jobData.processorsPerNode = jobData.defaultNodeCount * jobData.processorsPerNode;
+                jobData.processorsPerNode = $scope.data.app.defaultNodeCount * jobData.processorsPerNode;
             }
 
             $scope.jobReady = true;

--- a/designsafe/static/scripts/workspace/controllers/application-form.js
+++ b/designsafe/static/scripts/workspace/controllers/application-form.js
@@ -203,11 +203,11 @@ export default function ApplicationFormCtrl($scope, $rootScope, $localStorage, $
 
             // Calculate processorsPerNode if nodeCount parameter submitted
             if (('nodeCount' in jobData) && !('processorsPerNode' in jobData)) {
-                jobData.processorsPerNode = jobData.nodeCount * ($scope.data.app.defaultProcessorsPerNode / $scope.data.app.defaultNodeCount);
+                jobData.processorsPerNode = jobData.nodeCount * ($scope.data.app.defaultProcessorsPerNode || 1) / ($scope.data.app.defaultNodeCount || 1);
             } else if (('nodeCount' in jobData) && ('processorsPerNode' in jobData)) {
                 jobData.processorsPerNode = jobData.nodeCount * jobData.processorsPerNode;
             } else if (!('nodeCount' in jobData) && ('processorsPerNode' in jobData)) {
-                jobData.processorsPerNode = $scope.data.app.defaultNodeCount * jobData.processorsPerNode;
+                jobData.processorsPerNode = ($scope.data.app.defaultNodeCount || 1) * jobData.processorsPerNode;
             }
 
             $scope.jobReady = true;

--- a/designsafe/static/scripts/workspace/services/apps-service.js
+++ b/designsafe/static/scripts/workspace/services/apps-service.js
@@ -158,7 +158,7 @@ export function appsService($http, $q, $translate, djangoUrl, Django) {
                     title: input.details.label,
                     description: input.details.description,
                     id: input.id,
-                    default: input.value.default,
+                    // default: input.value.default,
                     pattern: input.value.validator || undefined,
                 };
                 if (input.semantics.maxCardinality === 1) {

--- a/designsafe/static/scripts/workspace/services/apps-service.js
+++ b/designsafe/static/scripts/workspace/services/apps-service.js
@@ -234,15 +234,17 @@ export function appsService($http, $q, $translate, djangoUrl, Django) {
             return regStr;
         }
 
+        let maxRunTime = app.defaultMaxRunTime || '06:00:00';
+
         schema.properties.maxRunTime = {
             title: 'Maximum job runtime',
-            description: `In HH:MM:SS format. The maximum time you expect this job to run for. After this amount of time your job will be killed by the job scheduler. Shorter run times result in shorter queue wait times. Maximum possible time is ${app.defaultMaxRunTime} (hrs:min:sec).`,
+            description: `In HH:MM:SS format. The maximum time you expect this job to run for. After this amount of time your job will be killed by the job scheduler. Shorter run times result in shorter queue wait times. Maximum possible time is ${maxRunTime} (hrs:min:sec).`,
             type: 'string',
-            pattern: createMaxRunTimeRegex(app.defaultMaxRunTime),
-            validationMessage: `Must be in format HH:MM:SS and be less than ${app.defaultMaxRunTime} (hrs:min:sec).`,
+            pattern: createMaxRunTimeRegex(maxRunTime),
+            validationMessage: `Must be in format HH:MM:SS and be less than ${maxRunTime} (hrs:min:sec).`,
             required: true,
-            'x-schema-form': { placeholder: app.defaultMaxRunTime },
-            default: app.defaultMaxRunTime || '06:00:00',
+            'x-schema-form': { placeholder: maxRunTime },
+            default: maxRunTime,
         };
 
         schema.properties.name = {
@@ -274,11 +276,11 @@ export function appsService($http, $q, $translate, djangoUrl, Django) {
         schema.properties.processorsPerNode = {
             title: 'Processors Per Node',
             description: `Number of processors (cores) per node for the job. e.g. A selection of 16 processors per node along with 4 nodes
-            will result in 16 processors on 4 nodes, with 64 processors total. Default number of processors per node is ${Math.floor(app.defaultProcessorsPerNode / app.defaultNodeCount)}.`,
+            will result in 16 processors on 4 nodes, with 64 processors total. Default number of processors per node is ${Math.floor(app.defaultProcessorsPerNode || 1) / (app.defaultNodeCount || 1)}.`,
             type: 'integer',
-            default: Math.floor(app.defaultProcessorsPerNode / app.defaultNodeCount),
+            default: Math.floor((app.defaultProcessorsPerNode || 1) / (app.defaultNodeCount || 1)),
             minimum: 1,
-            maximum: Math.floor(app.defaultProcessorsPerNode / app.defaultNodeCount),
+            maximum: Math.floor(app.defaultProcessorsPerNode || 1) / (app.defaultNodeCount || 1),
         };
 
         schema.properties.archivePath = {

--- a/designsafe/static/scripts/workspace/services/apps-service.js
+++ b/designsafe/static/scripts/workspace/services/apps-service.js
@@ -99,7 +99,7 @@ export function appsService($http, $q, $translate, djangoUrl, Django) {
                     description: param.details.description,
                     required: param.value.required,
                     default: param.value.default,
-                    pattern: param.value.validator,
+                    pattern: param.value.validator ? param.value.validator : undefined,
                 };
                 switch (param.value.type) {
                     case 'bool':
@@ -149,11 +149,17 @@ export function appsService($http, $q, $translate, djangoUrl, Django) {
                 if (input.id.startsWith('_') || !input.value.visible) {
                     return;
                 }
+                try {
+                    RegExp(input.value.validator);
+                } catch (e) {
+                    input.value.validator = null;
+                }
                 let field = {
                     title: input.details.label,
                     description: input.details.description,
                     id: input.id,
                     default: input.value.default,
+                    pattern: input.value.validator ? input.value.validator : undefined,
                 };
                 if (input.semantics.maxCardinality === 1) {
                     field.type = 'string';
@@ -168,6 +174,7 @@ export function appsService($http, $q, $translate, djangoUrl, Django) {
                         'x-schema-form': { notitle: true },
                         title: input.details.label,
                         description: input.details.description,
+                        pattern: input.value.validator ? input.value.validator : undefined,
                     };
                     if (input.semantics.maxCardinality > 1) {
                         field.maxItems = input.semantics.maxCardinality;

--- a/designsafe/static/scripts/workspace/services/apps-service.js
+++ b/designsafe/static/scripts/workspace/services/apps-service.js
@@ -99,7 +99,7 @@ export function appsService($http, $q, $translate, djangoUrl, Django) {
                     description: param.details.description,
                     required: param.value.required,
                     default: param.value.default,
-                    pattern: param.value.validator ? param.value.validator : undefined,
+                    pattern: param.value.validator || undefined,
                 };
                 switch (param.value.type) {
                     case 'bool':
@@ -159,7 +159,7 @@ export function appsService($http, $q, $translate, djangoUrl, Django) {
                     description: input.details.description,
                     id: input.id,
                     default: input.value.default,
-                    pattern: input.value.validator ? input.value.validator : undefined,
+                    pattern: input.value.validator || undefined,
                 };
                 if (input.semantics.maxCardinality === 1) {
                     field.type = 'string';
@@ -174,7 +174,7 @@ export function appsService($http, $q, $translate, djangoUrl, Django) {
                         'x-schema-form': { notitle: true },
                         title: input.details.label,
                         description: input.details.description,
-                        pattern: input.value.validator ? input.value.validator : undefined,
+                        pattern: input.value.validator || undefined,
                     };
                     if (input.semantics.maxCardinality > 1) {
                         field.maxItems = input.semantics.maxCardinality;

--- a/designsafe/static/scripts/workspace/services/apps-service.js
+++ b/designsafe/static/scripts/workspace/services/apps-service.js
@@ -211,7 +211,7 @@ export function appsService($http, $q, $translate, djangoUrl, Django) {
                     if (!Object.is(arr.length - 1, i)) {
                         tmp = replaceAt(tmp, index, n - 1);
                         if (regStr !== '^') {
-                            regStr += '|';
+                            regStr += '|^';
                         }
                         regStr += tmp.slice(0, index + 1) + regBase.slice(index + 1);
                     }
@@ -234,17 +234,16 @@ export function appsService($http, $q, $translate, djangoUrl, Django) {
             return regStr;
         }
 
-        let maxRunTime = app.defaultMaxRunTime || '06:00:00';
+        let maxQueueRunTime = app.defaultQueue ? app.exec_sys.queues.find((q) => q.name === app.defaultQueue).maxRequestedTime : app.exec_sys.queues.find((q) => q.default === true).maxRequestedTime;
 
         schema.properties.maxRunTime = {
             title: 'Maximum job runtime',
-            description: `In HH:MM:SS format. The maximum time you expect this job to run for. After this amount of time your job will be killed by the job scheduler. Shorter run times result in shorter queue wait times. Maximum possible time is ${maxRunTime} (hrs:min:sec).`,
+            description: `In HH:MM:SS format. The maximum time you expect this job to run for. After this amount of time your job will be killed by the job scheduler. Shorter run times result in shorter queue wait times. Maximum possible time is ${maxQueueRunTime} (hrs:min:sec).`,
             type: 'string',
-            pattern: createMaxRunTimeRegex(maxRunTime),
-            validationMessage: `Must be in format HH:MM:SS and be less than ${maxRunTime} (hrs:min:sec).`,
+            pattern: createMaxRunTimeRegex(maxQueueRunTime),
+            validationMessage: `Must be in format HH:MM:SS and be less than ${maxQueueRunTime} (hrs:min:sec).`,
             required: true,
-            'x-schema-form': { placeholder: maxRunTime },
-            default: maxRunTime,
+            'x-schema-form': { placeholder: app.defaultMaxRunTime || '06:00:00' },
         };
 
         schema.properties.name = {

--- a/designsafe/static/scripts/workspace/services/apps-service.js
+++ b/designsafe/static/scripts/workspace/services/apps-service.js
@@ -276,7 +276,7 @@ export function appsService($http, $q, $translate, djangoUrl, Django) {
         schema.properties.processorsPerNode = {
             title: 'Processors Per Node',
             description: `Number of processors (cores) per node for the job. e.g. A selection of 16 processors per node along with 4 nodes
-            will result in 16 processors on 4 nodes, with 64 processors total. Default number of processors per node is ${Math.floor(app.defaultProcessorsPerNode || 1) / (app.defaultNodeCount || 1)}.`,
+            will result in 4 nodes with 16 processors each, 64 processors total. Default number of processors per node is ${Math.floor(app.defaultProcessorsPerNode || 1) / (app.defaultNodeCount || 1)}.`,
             type: 'integer',
             default: Math.floor((app.defaultProcessorsPerNode || 1) / (app.defaultNodeCount || 1)),
             minimum: 1,

--- a/designsafe/static/scripts/workspace/services/jobs-service.js
+++ b/designsafe/static/scripts/workspace/services/jobs-service.js
@@ -9,9 +9,9 @@ export function jobsService($http, djangoUrl) {
         options.offest = options.offest || 0;
         return $http.get(djangoUrl.reverse('designsafe_workspace:call_api', ['jobs']), {
             params: options,
-        }).then(resp => {
+        }).then((resp) => {
             let data = resp.data;
-            data.forEach(d => {
+            data.forEach((d) => {
                 d.created = new Date(d.created);
             });
             return data;


### PR DESCRIPTION
- Fixes processorsPerNode calculation.
- Accommodate missing defaults in app form.
- Overhauls maxRunTime field in app job submission form. Now strictly validates based on defaultMaxRunTime defined in the app, or the maxRequestedTime of the queue if no default given.
- Fixes a bug caused by blank inputs by removing them from the job submission.
- Suppresses uncaught exceptions on client side qProvider