### PR TITLE
task/DES-1143 - Modify sitemap to use absolute path of each URL

### DIFF
--- a/designsafe/sitemaps.py
+++ b/designsafe/sitemaps.py
@@ -53,12 +53,17 @@ from designsafe.apps.dashboard import urls as dashboard_urls
 from designsafe.apps.box_integration import urls as box_integration_urls
 from designsafe.apps.dropbox_integration import urls as dropbox_integration_urls
 from designsafe.apps.googledrive_integration import urls as googledrive_integration_urls
+from cms.sitemaps import CMSSitemap
 
 # Home
 class HomeSitemap(sitemaps.Sitemap):
     priority = 1.0
     changefreq = 'weekly'
 
+    def get_urls(self, site=None, **kwargs):
+        site = Site(domain='www.designsafe-ci.org')
+        return super(HomeSitemap, self).get_urls(site=site, **kwargs)
+    
     def items(self):
         return ['']
 
@@ -89,6 +94,10 @@ class SubSitemap(sitemaps.Sitemap):
 class StaticViewSitemap(sitemaps.Sitemap):
     priority = 0.7
     changefreq = 'weekly'
+
+    def get_urls(self, site=None, **kwargs):
+        site = Site(domain='www.designsafe-ci.org')
+        return super(StaticViewSitemap, self).get_urls(site=site, **kwargs)
 
     def items(self):
 
@@ -127,6 +136,10 @@ class DynamicViewSitemap(sitemaps.Sitemap):
     priority = 0.8
     changefreq = 'weekly'
 
+    def get_urls(self, site=None, **kwargs):
+        site = Site(domain='www.designsafe-ci.org')
+        return super(DynamicViewSitemap, self).get_urls(site=site, **kwargs)
+
     def items(self):
 
         names_list = []
@@ -149,6 +162,10 @@ class DynamicViewSitemap(sitemaps.Sitemap):
 class ProjectSitemap(sitemaps.Sitemap):
     priority = 0.6
     changefreq = 'weekly'
+
+    def get_urls(self, site=None, **kwargs):
+        site = Site(domain='www.designsafe-ci.org')
+        return super(ProjectSitemap, self).get_urls(site=site, **kwargs)
 
     def items(self):
         client = get_service_account_client()
@@ -184,3 +201,14 @@ class ProjectSitemap(sitemaps.Sitemap):
 
     def location(self, item):
         return item
+
+
+class CMSSitemap_modified(CMSSitemap):
+    priority = .7
+    changefreq = 'weekly'
+
+    def get_urls(self, site=None, **kwargs):
+        site = Site(domain='www.designsafe-ci.org')
+        return super(CMSSitemap, self).get_urls(site=site, **kwargs)
+
+

--- a/designsafe/sitemaps.py
+++ b/designsafe/sitemaps.py
@@ -203,7 +203,7 @@ class ProjectSitemap(sitemaps.Sitemap):
         return item
 
 
-class CMSSitemap_modified(CMSSitemap):
+class DesignSafeCMSSitemap(CMSSitemap):
     priority = .7
     changefreq = 'weekly'
 

--- a/designsafe/urls.py
+++ b/designsafe/urls.py
@@ -36,13 +36,8 @@ from designsafe.views import project_version as des_version
 
 # sitemap - classes must be imported and added to sitemap dictionary
 from django.contrib.sitemaps.views import sitemap
-from cms.sitemaps import CMSSitemap
-from designsafe.sitemaps import StaticViewSitemap, DynamicViewSitemap, HomeSitemap, ProjectSitemap, SubSitemap
+from designsafe.sitemaps import StaticViewSitemap, DynamicViewSitemap, HomeSitemap, ProjectSitemap, SubSitemap, CMSSitemap_modified
 from designsafe import views
-
-# cms preferences
-CMSSitemap.priority = 0.7
-CMSSitemap.changefreq = 'weekly'
 
 sitemaps = {
     'home': HomeSitemap,
@@ -50,7 +45,7 @@ sitemaps = {
     'static': StaticViewSitemap,
     'dynamic': DynamicViewSitemap,
     'projects': ProjectSitemap,
-    'cmspages': CMSSitemap,
+    'cmspages': CMSSitemap_modified,
 }
 
 urlpatterns = [

--- a/designsafe/urls.py
+++ b/designsafe/urls.py
@@ -36,7 +36,7 @@ from designsafe.views import project_version as des_version
 
 # sitemap - classes must be imported and added to sitemap dictionary
 from django.contrib.sitemaps.views import sitemap
-from designsafe.sitemaps import StaticViewSitemap, DynamicViewSitemap, HomeSitemap, ProjectSitemap, SubSitemap, CMSSitemap_modified
+from designsafe.sitemaps import StaticViewSitemap, DynamicViewSitemap, HomeSitemap, ProjectSitemap, SubSitemap, DesignSafeCMSSitemap
 from designsafe import views
 
 sitemaps = {
@@ -45,7 +45,7 @@ sitemaps = {
     'static': StaticViewSitemap,
     'dynamic': DynamicViewSitemap,
     'projects': ProjectSitemap,
-    'cmspages': CMSSitemap_modified,
+    'cmspages': DesignSafeCMSSitemap,
 }
 
 urlpatterns = [


### PR DESCRIPTION
It can be a SEO problem to have the site map show pages without `www` but then have the server redirect those requests to `www` pages. Google is smart enough to see the redirect but the content can be considered duplicate or not authoritative. Updated the sitemap page URLs to include the `www` since that is how our server is configured to redirect all requests.