### PR TITLE
Bug/DES-1146 - Fix 403 response from published file listing

### DIFF
--- a/designsafe/static/scripts/projects/components/file-categories/file-categories.component.js
+++ b/designsafe/static/scripts/projects/components/file-categories/file-categories.component.js
@@ -10,12 +10,8 @@ import { values } from '@uirouter/core';
 
 const getFileUuid = (file) => {
     let promise;
-    if (file.apiParams.fileMgr === 'published') {
-        // change the params if for published files.
-        file.apiParams = {baseUrl: "/api/agave/files", fileMgr: "agave"};
-    }
     if (_.isEmpty(file.uuid())) {
-        promise = file.getMeta();
+        promise = file.fetch();
     } else {
         let my_promise = () => {
             let prm = new Promise((resolve)=>{


### PR DESCRIPTION
removed conditional api params
`file.getMeta()` directs to a view that requires login. Replaced with `file.fetch()` which will use `PublicDataListView` instead.