### PR TITLE
Bug/DES-1064 - Email Confirmation View Rejection Message

### DIFF
--- a/designsafe/apps/accounts/views.py
+++ b/designsafe/apps/accounts/views.py
@@ -499,7 +499,8 @@ def email_confirmation(request, code=None):
                 tas = TASClient()
                 user = tas.get_user(username=username)
                 if tas.verify_user(user['id'], code, password=password):
-                    check_or_create_agave_home_dir.apply(args=(user["username"],))
+                    logger.info('TAS Account activation succeeded.')
+                    check_or_create_agave_home_dir.apply(args=(user["username"],)) # This will likely fail to index the homedir
                     return HttpResponseRedirect(reverse('designsafe_accounts:manage_profile'))
                 else:
                     messages.error(request,

--- a/designsafe/apps/auth/tasks.py
+++ b/designsafe/apps/auth/tasks.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 def check_or_create_agave_home_dir(username):
     try:
         # TODO should use OS calls to create directory.
-        user = get_user_model().objects.get(username=username)
         logger.info(
             "Checking home directory for user=%s on "
             "default storage systemId=%s",
@@ -63,6 +62,7 @@ def check_or_create_agave_home_dir(username):
 
                 try:   
                     logger.info("Indexing the home directory for user=%s", username)
+                    user = get_user_model().objects.get(username=username)
                     fm = FileManager(user)
                     fm.indexer.index(
                         settings.AGAVE_STORAGE_SYSTEM,


### PR DESCRIPTION
Users were getting a misleading error message when confirming the email.  Their emails were being confirmed in TAS, but an error message was telling them that it wasn't. 

This was because of an early `get_user_model` call that was causing an exception.  This call has been moved to a place where the exception will be handled better.  It will likely still fail at email confirmation, but will succeed later in the `agave_oauth_callback` function.

I also improved some messaging, so that logs will show when a user's email account has been confirmed in TAS successfully.