### PR TITLE
bug/DES-1064 - Email Confirmation Erroneous Rejection Message

### DIFF
--- a/designsafe/apps/accounts/views.py
+++ b/designsafe/apps/accounts/views.py
@@ -499,6 +499,7 @@ def email_confirmation(request, code=None):
                 tas = TASClient()
                 user = tas.get_user(username=username)
                 if tas.verify_user(user['id'], code, password=password):
+                    logger.info('TAS Account activation succeeded.')
                     check_or_create_agave_home_dir.apply(args=(user["username"],))
                     return HttpResponseRedirect(reverse('designsafe_accounts:manage_profile'))
                 else:


### PR DESCRIPTION
Users were getting a misleading error message when confirming the email. Their email addresses were being confirmed in TAS, but an error message was telling them that the addresses weren't.

This was because of an unnecessary  `get_user_model` call that was causing an exception. This call has been removed 

I also improved some messaging, so that logs will show when a user's email account has been confirmed in TAS successfully.