### PR TITLE
bug/DES-1171: Update project model in elasticsearch

### DIFF
--- a/designsafe/apps/api/projects/models.py
+++ b/designsafe/apps/api/projects/models.py
@@ -59,15 +59,10 @@ class Project(BaseMetadataResource):
     def ES_search(cls, agave_client, query_string, username, **kwargs):
         from designsafe.apps.projects.models.elasticsearch import IndexedProject
         from elasticsearch_dsl import Q
-        pi_query = Q({'nested': {'path': 'value', 'query': {
-            'term': {'value.pi._exact': username}}
-        }})
-        copi_query = Q({'nested': {'path': 'value', 'query': {
-            'term': {'value.coPis._exact': username}}
-        }})
-        team_query = Q({'nested': {'path': 'value', 'query': {
-            'term': {'value.teamMembers._exact': username}}
-        }})
+   
+        pi_query = Q({'term': {'value.pi._exact': username}})
+        copi_query = Q({'term': {'value.coPis._exact': username}})
+        team_query = Q({'term': {'value.teamMembers._exact': username}})
         records = IndexedProject.search().query('query_string', query=query_string, default_operator='and')
         records = records.filter(pi_query | copi_query | team_query )
         records = records.extra(from_=kwargs.get('offset', 0), size=kwargs.get('limit',100))

--- a/designsafe/apps/api/tasks.py
+++ b/designsafe/apps/api/tasks.py
@@ -701,7 +701,7 @@ def reindex_projects(self):
             in_loop = False
         else:
             for project in listing:
-                    index_or_update_project.apply_async(args=[project.uuid], queue='api')
+                index_or_update_project.apply_async(args=[project.uuid], queue='api')
    
 @shared_task(bind=True, max_retries=5)
 def copy_publication_files_to_corral(self, project_id):

--- a/designsafe/apps/api/tasks.py
+++ b/designsafe/apps/api/tasks.py
@@ -654,7 +654,10 @@ def index_or_update_project(self, uuid):
 
     to_index = {key: value for key, value in project_meta.iteritems() if key != '_links'}
     to_index['value'] = {key: value for key, value in project_meta['value'].iteritems() if key != 'teamMember'}
-
+    if not isinstance(to_index['value'].get('awardNumber', []), list):
+        to_index['value']['awardNumber'] = [{'number': to_index['value']['awardNumber'] }]
+    if to_index['value'].get('guestMembers', []) == [None]:
+        to_index['value']['guestMembers'] = []
     project_search = IndexedProject.search().filter(
         Q({'term': 
             {'uuid._exact': uuid}
@@ -698,8 +701,8 @@ def reindex_projects(self):
             in_loop = False
         else:
             for project in listing:
-                index_or_update_project.apply_async(args=[project.uuid], queue='api')
-
+                    index_or_update_project.apply_async(args=[project.uuid], queue='api')
+   
 @shared_task(bind=True, max_retries=5)
 def copy_publication_files_to_corral(self, project_id):
     from designsafe.libs.elasticsearch.docs.publications import BaseESPublication

--- a/designsafe/apps/projects/models/elasticsearch.py
+++ b/designsafe/apps/projects/models/elasticsearch.py
@@ -27,13 +27,47 @@ class IndexedProject(DocType):
     name = Text(fields={'_exact': Keyword()})
     created = Date()
     owner = Text(fields={'_exact': Keyword()})
-    value = Nested(
+    value = Object(
         properties={
             'teamMembers': Text(fields={'_exact': Keyword()}, multi=True),
+            'guestMembers': Nested(properties={
+                'guest': Boolean(),
+                'lname': Text(fields={'_exact': Keyword()}),
+                'inst': Text(),
+                'user': Keyword(),
+                'fname': Text(fields={'_exact': Keyword()}),
+                'email': Text(fields={'_exact': Keyword()}), 
+                'order': Long()
+            }, multi=True),
+            'teamOrder': Nested(properties={
+                'guest': Boolean(),
+                'name': Text(fields={'_exact': Keyword()}),
+                'lname': Text(fields={'_exact': Keyword()}),
+                'inst': Text(),
+                'user': Keyword(),
+                'fname': Text(fields={'_exact': Keyword()}),
+                'email': Text(fields={'_exact': Keyword()}), 
+                'order': Long()
+            }, multi=True), 
+            'fileTags': Nested(properties={
+                'fileUuid': Keyword(),
+                'tagName': Keyword(),
+                'format': Keyword(),
+                'lastModified': Date(),
+        
+            }, multi=True),
+
+            'nhEventStart': Date(),
+            'nhEventEnd': Date(),
+            'nhType': Text(fields={'_exact': Keyword()}),
+            'nhTypeOther': Text(fields={'_exact': Keyword()}),
+            'nhEvent': Text(fields={'_exact': Keyword()}),
+
             'coPis': Text(fields={'_exact': Keyword()}, multi=True),
             'projectType': Text(fields={'_exact': Keyword()}, analyzer='english'),
             'description': Text(analyzer='english'),
             'projectId': Text(fields={'_exact': Keyword()}),
+            'dataType': Text(fields={'_exact': Keyword()}),
             'title': Text(analyzer='english'),
             'keywords': Text(analyzer='english'),
             'ef': Text(analyzer='english'),
@@ -43,7 +77,10 @@ class IndexedProject(DocType):
                 'delete': Boolean()
             }),
             'pi': Text(fields={'_exact': Keyword()}),
-            'awardNumber': Text(fields={'_exact': Keyword()})
+            'awardNumber': Nested(properties={
+                'number': Keyword(),
+                'name': Text(fields={'_exact': Keyword()}),
+            }, multi=True),
         })
 
     class Meta:


### PR DESCRIPTION
We needed to add some fields to support newer style projects. After merging, we'll need to run `python manage.py swap_reindex --index='projects'`.