### PR TITLE
task/DES-1165 - Update Canonical URLs on Published Project Templates

### DIFF
--- a/designsafe/apps/data/views/base.py
+++ b/designsafe/apps/data/views/base.py
@@ -229,6 +229,7 @@ class DataDepotLegacyPublishedView(TemplateView):
         nees_id = kwargs['project_id'].strip('.groups').strip('/')
         logger.debug('nees_id: %s', nees_id)
         pub = BaseESPublicationLegacy(nees_id=nees_id)
+        context['neesId'] = nees_id.split('/')[0]
         context['citation_title'] = pub.title
         context['citation_date'] = getattr(pub, 'startDate', '')
         experiments = getattr(pub, 'experiments')

--- a/designsafe/apps/data/views/base.py
+++ b/designsafe/apps/data/views/base.py
@@ -191,6 +191,7 @@ class DataDepotPublishedView(TemplateView):
         logger.info('Get context Data')
         pub = BaseESPublication(project_id=kwargs['project_id'].strip('/'))
         logger.debug('pub: %s', pub.to_dict())
+        context['projectId'] = pub.projectId
         context['citation_title'] = pub.project.value.title
         context['citation_date'] = pub.created
         context['doi'] = pub.project.doi

--- a/designsafe/sitemaps.py
+++ b/designsafe/sitemaps.py
@@ -180,6 +180,7 @@ class ProjectSitemap(sitemaps.Sitemap):
             
             for proj in projects['children']:
                 if 'project' in proj:
+                    # designsafe projects
                     subpath = {
                         'root' : reverse('designsafe_data:data_depot'),
                         'project' : proj['project'],
@@ -193,7 +194,7 @@ class ProjectSitemap(sitemaps.Sitemap):
                         'project' : proj['path'],
                         'system' : proj['system']
                     }
-                    projPath.append('{root}public/{system}/{project}'.format(**subpath))
+                    projPath.append('{root}public/{system}{project}'.format(**subpath))
                 else:
                     continue
             count += 200

--- a/designsafe/templates/base.html
+++ b/designsafe/templates/base.html
@@ -9,7 +9,11 @@
       <meta name="viewport" content="width=device-width">
       <meta name="description" content="{{ site.description }}">
       <link rel="icon" href="{% static 'favicon.ico' %}">
-      <link rel="canonical" href="{{request.get_full_path}}">
+      {% if 'designsafe.storage.published' in request.get_full_path %}
+      <link rel="canonical" href="https://www.designsafe-ci.org/data/browser/public/designsafe.storage.published/{{projectId}}">
+      {% else %}
+      <link rel="canonical" href="https://www.designsafe-ci.org{{request.get_full_path}}">
+      {% endif %}
       {% block head_extra %}{% endblock %}
       <!-- styles -->
       <link href="{% static 'vendor/bootstrap-ds/css/bootstrap.css' %}" rel="stylesheet" type="text/css">

--- a/designsafe/templates/base.html
+++ b/designsafe/templates/base.html
@@ -11,6 +11,8 @@
       <link rel="icon" href="{% static 'favicon.ico' %}">
       {% if 'designsafe.storage.published' in request.get_full_path %}
       <link rel="canonical" href="https://www.designsafe-ci.org/data/browser/public/designsafe.storage.published/{{projectId}}">
+      {% elif 'nees.public' in request.get_full_path %}
+      <link rel="canonical" href="https://www.designsafe-ci.org/data/browser/public/nees.public/{{neesId}}.groups">
       {% else %}
       <link rel="canonical" href="https://www.designsafe-ci.org{{request.get_full_path}}">
       {% endif %}

--- a/designsafe/templates/base.html
+++ b/designsafe/templates/base.html
@@ -12,7 +12,7 @@
       {% if 'designsafe.storage.published' in request.get_full_path %}
       <link rel="canonical" href="https://www.designsafe-ci.org/data/browser/public/designsafe.storage.published/{{projectId}}">
       {% elif 'nees.public' in request.get_full_path %}
-      <link rel="canonical" href="https://www.designsafe-ci.org/data/browser/public/nees.public/{{neesId}}.groups">
+      <link rel="canonical" href="https://www.designsafe-ci.org/data/browser/public/nees.public/{{neesId}}">
       {% else %}
       <link rel="canonical" href="https://www.designsafe-ci.org{{request.get_full_path}}">
       {% endif %}


### PR DESCRIPTION
**Description:**  
Update Canonical URLs on Published Project Templates to an absolute URLs to match the sitemap. Also updated the sitemap for NEES Published Project URLs to have on a single slash. This is to improve discoverability by Google.

**Migrations:**  
No migrations.

**Expected behavior:**
1. Canonical URLs on Published projects should be absolute URLs that match the URL of the published project. If you access the project by navigating through the portal, there may be a double slash in the URL before the Project ID. You can just remove one of those slashes to reach the actual URL of the project.
2. Sitemap should have a single slash after all published projects liste
