### PR TITLE
bug/DES-1218

### DIFF
--- a/designsafe/static/scripts/data-depot/components/files-listing/files-listing.component.js
+++ b/designsafe/static/scripts/data-depot/components/files-listing/files-listing.component.js
@@ -68,11 +68,10 @@ class FilesListingCtrl {
         }
         let systemId = this.browser.listing.system || this.browser.listing.systemId;
         let stateName = this.$state.current.name;
-        let filePath = '/';
+        let filePath = '';
         let version = 1;
         for (var i = 0; i < this.breadcrumbs.length; i++) {
             filePath = filePath.concat(this.breadcrumbs[i] + '/');
-            console.log(filePath);
             if (this.breadcrumbs[i] === path) { break; }
         }
         return this.$state.go(

--- a/designsafe/static/scripts/data-depot/components/files-listing/files-listing.component.js
+++ b/designsafe/static/scripts/data-depot/components/files-listing/files-listing.component.js
@@ -71,7 +71,8 @@ class FilesListingCtrl {
         let filePath = '/';
         let version = 1;
         for (var i = 0; i < this.breadcrumbs.length; i++) {
-            filePath = filePath.concat(this.breadcrumbs[i]);
+            filePath = filePath.concat(this.breadcrumbs[i] + '/');
+            console.log(filePath);
             if (this.breadcrumbs[i] === path) { break; }
         }
         return this.$state.go(


### PR DESCRIPTION
The breadcrumb links are creating malformed URLs.  There are no / in the URL paths.  For example:

"https://agave.designsafe-ci.org/files/v2/listings/system/designsafe.storage.default//usernamePRJ-1299DigitalDataReport"

They should form URLs like this:

"https://agave.designsafe-ci.org/files/v2/listings/system/designsafe.storage.default//username/PRJ-1299/DigitalDataReport"