### PR TITLE
Add "Data Depot" to Title Tags on Non-Publication Pages

### DIFF
--- a/designsafe/apps/data/templates/data/data_depot.html
+++ b/designsafe/apps/data/templates/data/data_depot.html
@@ -19,7 +19,10 @@
     <!--data/data_depot.html-->
 {% endblock %}
 {% block title %}
-{% if citation_title %}{{citation_title}} {% endif %}
+{% if citation_title %}{{citation_title}} 
+{% else %}
+Data Depot
+{% endif %}
 {% endblock %}
 {% block head_extra %}
     <base href="{% url 'designsafe_data:data_depot' %}">


### PR DESCRIPTION
Added conditional statement to title block that fills in 'Data Depot' when the page has no citation title.