### PR TITLE
Task/DES-1252 - Show tags from parent directory on children

### DIFF
--- a/designsafe/static/scripts/ng-designsafe/services/file-listing.js
+++ b/designsafe/static/scripts/ng-designsafe/services/file-listing.js
@@ -42,13 +42,19 @@ export function FileListing($http, $q) {
         _.each(entities, function(entity){
             if (typeof entity !== 'undefined' &&
             typeof entity._links !== 'undefined' &&
-            typeof entity._links.associationIds !== 'undefined'){
-                _.each(entity._links.associationIds, function(asc){
-                    if (asc.title === 'file'){
+            typeof entity._links.associationIds !== 'undefined') {
+                _.each(entity._links.associationIds, function (asc) {
+                    if (asc.title === 'file') {
                         var comps = asc.href.split('project-' + projectId, 2);
-                        if ( comps.length === 2 &&
-                   path.replace(/^\/+/, '') === comps[1].replace(/^\/+/, '')){
+                        if (comps.length === 2 && path.replace(/^\/+/, '') === comps[1].replace(/^\/+/, '')) {
                             self._entities.push(entity);
+                        }
+                        if (!comps[1].replace(/^\/+/, '').includes('.')) {
+                            if (comps.length === 2 && self._parent.path.replace(/^\/+/, '').startsWith(comps[1].replace(/^\/+/, ''))) {
+                                if (!self._parent._entities.includes(entity)) {
+                                    self._parent._entities.push(entity);
+                                }
+                            }
                         }
                     }
                 });

--- a/designsafe/static/scripts/projects/components/file-categories/field-recon-file-tags.json
+++ b/designsafe/static/scripts/projects/components/file-categories/field-recon-file-tags.json
@@ -3,7 +3,6 @@
         "name": "Collection",
         "tags": {
             "General": [
-                "Other",
                 "3D Model",
                 "Area",
                 "Audio",

--- a/designsafe/static/scripts/projects/components/file-categories/file-categories.template.html
+++ b/designsafe/static/scripts/projects/components/file-categories/file-categories.template.html
@@ -8,6 +8,17 @@
                 {{entityTag}}
             </div>
             <div style="width:100%;" class="file-tag-list">
+                <table class="file-tag-item file-tag-table" data-ng-repeat="parent in $ctrl.file._parent._entities">
+                    <tr style="vertical-align: top;">
+                        <td>
+                            <div class="file-category-label" style="width:50%;">
+                                <span class="label curation" data-ng-class="parent.cssClasses()['tag']">
+                                    {{ parent.value.title }}
+                                </span>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
                 <table class="file-tag-item file-tag-table" data-ng-repeat="entity in $ctrl.file._entities">
                     <tr style="vertical-align: top;">
                         <td style="width:49%;">


### PR DESCRIPTION
- When categorizing a folder we wanted the files within the folder to show that parent tag
- Also removed an extra "other" option from a list of selectable categories

Categorized File
![Main](https://user-images.githubusercontent.com/29575979/67035018-69350880-f0de-11e9-9ab4-25aa2d62064a.png)

**BEFORE**
![Before Folder](https://user-images.githubusercontent.com/29575979/67035044-7225da00-f0de-11e9-939a-260a71389349.png)

**AFTER**
![After Folder](https://user-images.githubusercontent.com/29575979/67035051-7520ca80-f0de-11e9-8348-3938813602e2.png)
