### PR TITLE
DES-1297 - Add DOI Metatags for new Publication Templates

### DIFF
--- a/designsafe/apps/data/views/base.py
+++ b/designsafe/apps/data/views/base.py
@@ -194,9 +194,9 @@ class DataDepotPublishedView(TemplateView):
         context['projectId'] = pub.projectId
         context['citation_title'] = pub.project.value.title
         context['citation_date'] = pub.created
-        if pub.project.value.to_dict().has_key('dois'):
+        if pub.project.value.to_dict().get('dois') != None: #This is for newer publications
             context['doi'] = pub.project.value.dois[0]
-        if pub.project.to_dict().has_key('doi'):
+        elif pub.project.to_dict().get('doi') != None: #This is for older publications
             context['doi'] = pub.project.doi
         context['keywords'] = pub.project.value.keywords.split(',')
         context['authors'] = [{

--- a/designsafe/apps/data/views/base.py
+++ b/designsafe/apps/data/views/base.py
@@ -194,11 +194,10 @@ class DataDepotPublishedView(TemplateView):
         context['projectId'] = pub.projectId
         context['citation_title'] = pub.project.value.title
         context['citation_date'] = pub.created
-        #new version:
-        context['doi'] = pub.project.value.dois[0]
-        #old version:
-        #context['doi'] = pub.project.doi
-
+        if pub.project.value.to_dict().has_key('dois'):
+            context['doi'] = pub.project.value.dois[0]
+        if pub.project.to_dict().has_key('doi'):
+            context['doi'] = pub.project.doi
         context['keywords'] = pub.project.value.keywords.split(',')
         context['authors'] = [{
             'full_name': '{last_name}, {first_name}'.format(

--- a/designsafe/apps/data/views/base.py
+++ b/designsafe/apps/data/views/base.py
@@ -194,7 +194,11 @@ class DataDepotPublishedView(TemplateView):
         context['projectId'] = pub.projectId
         context['citation_title'] = pub.project.value.title
         context['citation_date'] = pub.created
-        context['doi'] = pub.project.doi
+        #new version:
+        context['doi'] = pub.project.value.dois[0]
+        #old version:
+        #context['doi'] = pub.project.doi
+
         context['keywords'] = pub.project.value.keywords.split(',')
         context['authors'] = [{
             'full_name': '{last_name}, {first_name}'.format(

--- a/designsafe/apps/data/views/base.py
+++ b/designsafe/apps/data/views/base.py
@@ -233,6 +233,7 @@ class DataDepotLegacyPublishedView(TemplateView):
         nees_id = kwargs['project_id'].strip('.groups').strip('/')
         logger.debug('nees_id: %s', nees_id)
         pub = BaseESPublicationLegacy(nees_id=nees_id)
+        logger.debug('pub: %s', pub.to_dict())
         context['neesId'] = nees_id.split('/')[0]
         context['citation_title'] = pub.title
         context['citation_date'] = getattr(pub, 'startDate', '')


### PR DESCRIPTION
Updated `get_context_data` to bring DOIs into metatags for new publications (`version: 2`).