### PR TITLE
fix google drive navigate into folders

### DIFF
--- a/designsafe/static/scripts/data-depot/components/files-listing/files-listing.component.js
+++ b/designsafe/static/scripts/data-depot/components/files-listing/files-listing.component.js
@@ -92,8 +92,11 @@ class FilesListingCtrl {
             $event.stopPropagation();
         }
         let systemId = file.system || file.systemId;
+        let stateName = this.$state.current.name;
         let filePath;
-        if (file.path == '/') {
+        if (stateName === 'googledriveData') {
+            filePath = file.id;
+        } else if (file.path == '/') {
             filePath = file.path + file.name;
         } else {
             filePath = file.path;
@@ -103,7 +106,6 @@ class FilesListingCtrl {
                 file, this.browser.listing
             );
         }
-        let stateName = this.$state.current.name;
         let version = 1;
         if (file.system === 'nees.public') {
             stateName = 'neesPublished';
@@ -115,7 +117,7 @@ class FilesListingCtrl {
         }
         return this.$state.go(
             stateName,
-            { 
+            {
                 systemId: systemId,
                 filePath: filePath,
                 version: version,
@@ -222,7 +224,7 @@ class FilesListingCtrl {
           if (item.metadata && this.state.type_filters['nees']) {
               return true;
           }
-          return this.state.type_filters[(item.meta || {}).type]; 
+          return this.state.type_filters[(item.meta || {}).type];
       }
       clearFilters() {
           for (const key of Object.keys(this.state.type_filters)) {


### PR DESCRIPTION
Phase 1 PR to just fix navigation into google drive subfolders. Breadcrumbs still need to be fixed.

- Minor formatting fixes in google drive manager
- Change `size` property to `length`, and add property `format` to Google Drive file object in order to display file size in data depot
- Google Drive File file path code improvements -- does not change returned value
- Gives `filePath` field a file id value in state router if `stateName === 'googledriveData'`, which changes the api listing call of a google drive directory to be the object id instead of a path, in order to list the directory contents