### PR TITLE
DES-1294: Add google drive usage policy

### DIFF
--- a/designsafe/apps/googledrive_integration/templates/designsafe/apps/googledrive_integration/disconnect.html
+++ b/designsafe/apps/googledrive_integration/templates/designsafe/apps/googledrive_integration/disconnect.html
@@ -12,6 +12,8 @@
         delete any files from either DesignSafe or Google Drive. What <strong>will</strong> happen
         is that you will be removing the authorization you granted DesignSafe to manage files
         and folders in your Google Drive account.
+
+        For further information on usage, see the <a href="{% url 'googledrive_integration:privacy_policy' %">Privacy Policy</a>.
     </p>
     <p class="alert alert-info">
         To reiterate, this will not delete any files. If you wish to delete the files from either

--- a/designsafe/apps/googledrive_integration/templates/designsafe/apps/googledrive_integration/index.html
+++ b/designsafe/apps/googledrive_integration/templates/designsafe/apps/googledrive_integration/index.html
@@ -21,6 +21,9 @@
                             Google Drive integration is enabled. DesignSafe can connect to
                             Google Drive as <em>{{googledrive_connection.displayName}} ({{googledrive_connection.emailAddress}})</em>.
                         </p>
+                        <p>
+                            <a href="{% url 'designsafe_data:data_depot' %}googledrive/" class="btn btn-default">Return to the Data Depot</a>
+                        </p>
                     {% else %}
                         <p class="text-warning">
                             While you have previously authorized DesignSafe to connect
@@ -43,11 +46,12 @@
         </div>
         <div class="col-md-8">
             <p class="lead">
-                <em class="label label-success">New!</em>
                 By connecting your Google Drive account with DesignSafe, you can access your
                 Google Drive files in the DesignSafe Data Depot. You can select files and
                 folders to copy to DesignSafe where you can operate on those files in the
                 Workspace. You can also send files from DesignSafe back to Google Drive.
+
+                For further information on usage, see the <a href="{% url 'googledrive_integration:privacy_policy' %}">Privacy Policy</a>.
             </p>
         </div>
     </div>

--- a/designsafe/apps/googledrive_integration/templates/designsafe/apps/googledrive_integration/privacy-policy.html
+++ b/designsafe/apps/googledrive_integration/templates/designsafe/apps/googledrive_integration/privacy-policy.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block title %}Google Drive Integration{% endblock %}
+
+{% block content %}
+<div class="container">
+    <h1>DesignSafe-CI Google Drive Privacy Policy</h1>
+
+    <p class="lead">
+        By connecting your Google Drive account to DesignSafe, you consent to giving DesignSafe <strong>read</strong> and
+        <strong>write</strong> access to your Google Drive account. DesignSafe makes a secure connection to
+        your Google Drive account to list your data in the Data Depot, and to copy data to and from the DesignSafe's
+        data servers.
+    </p>
+    <p class="alert alert-warning">
+        We request this level of scope access (as opposed to read-only) to give you the best user experience,
+        allowing you to upload field data and simulation results directly to your Google Drive, while also viewing and using these files
+        in experimental workflows by copying data from Google Drive to a directory you own in the Data Depot.
+    </p>
+
+    <p class="alert alert-info">
+        We do not store any personal or identifying information from your Google Drive account, other than an access token
+         and related file metadata, which is limited to mimeType, name, id, modifiedTime, fileExtension, size, and parents.
+    </p>
+    <!-- <hr> -->
+</div>
+{% endblock %}

--- a/designsafe/apps/googledrive_integration/urls.py
+++ b/designsafe/apps/googledrive_integration/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     url(r'^initialize/$', views.initialize_token, name='initialize_token'),
     url(r'^oauth2/$', views.oauth2_callback, name='oauth2_callback'),
     url(r'^disconnect/$', views.disconnect, name='disconnect'),
+    url(r'^privacy-policy/$', views.privacy_policy, name='privacy_policy')
 ]

--- a/designsafe/apps/googledrive_integration/views.py
+++ b/designsafe/apps/googledrive_integration/views.py
@@ -91,13 +91,13 @@ def oauth2_callback(request):
         authorization_response = request.build_absolute_uri()
         logger.debug(authorization_response)
         flow.fetch_token(authorization_response=authorization_response)
-            
+
         credentials = flow.credentials
         token = GoogleDriveUserToken(
             user=request.user,
             credential=credentials
         )
-        
+
         token.save()
 
     except IntegrityError as e:
@@ -129,7 +129,7 @@ def disconnect(request):
             revoke = requests.post('https://accounts.google.com/o/oauth2/revoke',
                 params={'token': googledrive_user_token.credential.token},
                 headers = {'content-type': 'application/x-www-form-urlencoded'})
-            
+
             status_code = getattr(revoke, 'status_code')
 
             googledrive_user_token.delete()
@@ -153,9 +153,13 @@ def disconnect(request):
             logger.error('Disconnect Google Drive; GoogleDriveUserToken delete error.',
                          extra={'user': request.user})
             logger.exception('google drive delete error: {}'.format(e))
-            
+
         messages.success(request, 'Your Google Drive account has been disconnected from DesignSafe.')
 
         return HttpResponseRedirect(reverse('googledrive_integration:index'))
 
     return render(request, 'designsafe/apps/googledrive_integration/disconnect.html')
+
+
+def privacy_policy(request):
+    return render(request, 'designsafe/apps/googledrive_integration/privacy-policy.html')


### PR DESCRIPTION
Per Google, we needed to add a specific Privacy Policy related to Google Drive access in our app:
https://developers.google.com/terms/api-services-user-data-policy

- Adds privacy policy for gdrive (/accounts/applications/googledrive/privacy-policy)
- Add links to privacy policy in google drive status screen (/accounts/applications/googledrive/)

Once this is released to dev and prod, we will need to resubmit the oauth consent form:
https://console.developers.google.com/apis/credentials/consent