### PR TITLE
Task/DES-1265: Multiple metadata values need to align top with the key, not align center

### DIFF
--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.scss
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.scss
@@ -106,3 +106,7 @@
   border-color: #B59300;
   white-space: normal;
 }
+
+td {
+  vertical-align: top;
+}


### PR DESCRIPTION
Updated publication-preview styling

**Before**
<img width="957" alt=" 1" src="https://user-images.githubusercontent.com/47395902/67800417-359a9c80-fa55-11e9-9197-bd8ff28a1247.png">

**After**
<img width="959" alt="2" src="https://user-images.githubusercontent.com/47395902/67800461-43502200-fa55-11e9-82f4-d3021f7c16c5.png">

_This image is at a different breakpoint_
<img width="549" alt="Screen Shot 2019-10-29 at 2 07 23 PM" src="https://user-images.githubusercontent.com/47395902/67800648-a2ae3200-fa55-11e9-9024-f5148f676b26.png">
