### PR TITLE
Task/DES-1333: Create Author Information Modal

### DIFF
--- a/designsafe/apps/api/users/views.py
+++ b/designsafe/apps/api/users/views.py
@@ -66,6 +66,8 @@ class SearchView(SecureMixin, View):
                 'email': user.email,
                 'username': user.username,
             }
+            if(user.profile.orcid_id):
+                res_dict['orcid_id'] = user.profile.orcid_id
             try:
                 user_tas = TASClient().get_user(username=q)
                 res_dict['profile'] = {

--- a/designsafe/static/scripts/data-depot/components/projects/index.js
+++ b/designsafe/static/scripts/data-depot/components/projects/index.js
@@ -39,6 +39,7 @@ import { ManageFieldReconMissionsComponent } from '../../../projects/components/
 import { ManageFieldReconCollectionsComponent } from '../../../projects/components/manage-field-recon/collections/manage-field-recon-collections.component.js';
 import { ManageFieldReconReportsComponent } from '../../../projects/components/manage-field-recon/reports/manage-field-recon-reports.component.js';
 import { PublishedCitationComponent } from '../../../projects/components/publication-citation/publication-citation.component.js';
+import { AuthorInformationModalComponent } from './publication-preview/modals/author-information-modal.component';
 
 let ddProjectsComponents = angular.module('dd.components.projects', []);
 
@@ -82,5 +83,6 @@ ddProjectsComponents.component('fieldReconMissionsModal', ManageFieldReconMissio
 ddProjectsComponents.component('fieldReconCollectionsModal', ManageFieldReconCollectionsComponent);
 ddProjectsComponents.component('fieldReconReportsModal', ManageFieldReconReportsComponent);
 ddProjectsComponents.component('publishedCitationModal', PublishedCitationComponent);
+ddProjectsComponents.component('authorInformationModal', AuthorInformationModalComponent);
 
 export default ddProjectsComponents;

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.component.js
@@ -1,0 +1,28 @@
+import AuthorInformationModalTemplate from './author-information-modal.template.html';
+
+class AuthorInformationModalCtrl {
+    constructor() { }
+
+    $onInit() { 
+        this.author = this.resolve.author;
+        this.first = this.author.fname;
+        this.last = this.author.lname;
+        this.email = this.author.email;
+        this.institution = this.author.inst;
+    }
+
+    close() {
+        return;
+    }
+}
+
+export const AuthorInformationModalComponent = {
+    template: AuthorInformationModalTemplate,
+    controller: AuthorInformationModalCtrl,
+    controllerAs: '$ctrl',
+    bindings: {
+        resolve: '<',
+        close: '&',
+        dismiss: '&'
+    },
+};

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.component.js
@@ -1,7 +1,10 @@
 import AuthorInformationModalTemplate from './author-information-modal.template.html';
 
 class AuthorInformationModalCtrl {
-    constructor() { }
+    constructor(UserService) {
+        'ng-inject';
+        this.UserService = UserService;
+    }
 
     $onInit() { 
         this.author = this.resolve.author;
@@ -9,6 +12,10 @@ class AuthorInformationModalCtrl {
         this.last = this.author.lname;
         this.email = this.author.email;
         this.institution = this.author.inst;
+        this.username = this.author.name;
+        this.UserService.get(this.username).then((res) => {
+            this.orcid = res.orcid_id;
+        });
     }
 
     close() {

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.component.js
@@ -1,10 +1,7 @@
 import AuthorInformationModalTemplate from './author-information-modal.template.html';
 
 class AuthorInformationModalCtrl {
-    constructor(UserService) {
-        'ngInject';
-        this.UserService = UserService;
-    }
+    constructor() { }
 
     $onInit() { 
         this.author = this.resolve.author;
@@ -13,9 +10,9 @@ class AuthorInformationModalCtrl {
         this.email = this.author.email;
         this.institution = this.author.inst;
         this.username = this.author.name;
-        this.UserService.get(this.username).then((res) => {
-            this.orcid = res.orcid_id;
-        });
+        if (this.author.orcid) {
+            this.orcid = this.author.orcid;
+        }
     }
 
     close() {

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.component.js
@@ -2,7 +2,7 @@ import AuthorInformationModalTemplate from './author-information-modal.template.
 
 class AuthorInformationModalCtrl {
     constructor(UserService) {
-        'ng-inject';
+        'ngInject';
         this.UserService = UserService;
     }
 

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.template.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.template.html
@@ -2,17 +2,29 @@
     <strong>{{ $ctrl.last }}, {{ $ctrl.first }}</strong>
     <strong ng-click="$ctrl.close()" class="fa fa-times"></strong>
 </div>
-<div class="modal-body" style="display: flex; justify-content: space-between;">
-    <div>
-        <p>First Name</p>
-        <p>Last Name</p>
-        <p>Email</p>
-        <p>Institution</p>
-    </div>
-    <div>
-        <p style="font-weight: bold">{{ $ctrl.first }}</p>
-        <p style="font-weight: bold">{{ $ctrl.last }}</p>
-        <p style="font-weight: bold">{{ $ctrl.email }}</p>
-        <p style="font-weight: bold">{{ $ctrl.institution }}</p>
-    </div>
+<div class="modal-body">
+    <table style="width: 95%">
+        <tbody>
+            <tr>
+                <td style="width: 45%"><p>First Name</p></td>
+                <td><p style="font-weight: bold">{{ $ctrl.first }}</p></td>
+            </tr>
+            <tr>
+                <td style="width: 45%"><p>Last Name</p></td>
+                <td><p style="font-weight: bold">{{ $ctrl.last }}</p></td>
+            </tr>
+            <tr>
+                <td style="width: 45%"><p>Email</p></td>
+                <td><p style="font-weight: bold">{{ $ctrl.email }}</p></td>
+            </tr>
+            <tr>
+                <td style="width: 45%"><p>Institution</p></td>
+                <td><p style="font-weight: bold">{{ $ctrl.institution }}</p></td>
+            </tr>
+            <tr ng-if="$ctrl.orcid">
+                <td style="width: 45%"><p>ORCID ID</p></td>
+                <td><p style="font-weight: bold">{{ $ctrl.orcid }}</p></td>
+            </tr>
+        </tbody>
+    </table>
 </div>

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.template.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.template.html
@@ -1,0 +1,18 @@
+<div class="modal-header" style="background-color: #c6c6c6; display: flex; justify-content: space-between;">
+    <strong>{{ $ctrl.last }}, {{ $ctrl.first }}</strong>
+    <strong ng-click="$ctrl.close()" class="fa fa-times"></strong>
+</div>
+<div class="modal-body" style="display: flex; justify-content: space-between;">
+    <div>
+        <p>First Name</p>
+        <p>Last Name</p>
+        <p>Email</p>
+        <p>Institution</p>
+    </div>
+    <div>
+        <p style="font-weight: bold">{{ $ctrl.first }}</p>
+        <p style="font-weight: bold">{{ $ctrl.last }}</p>
+        <p style="font-weight: bold">{{ $ctrl.email }}</p>
+        <p style="font-weight: bold">{{ $ctrl.institution }}</p>
+    </div>
+</div>

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
@@ -207,7 +207,10 @@
                         </div>
                         <div style="display: inline-block; width:78%; font-weight: bold;">
                             <span ng-if="$ctrl.readOnly">
-                                <ds-author-list authors="mission.authors"></ds-author-list>
+                                <!-- <ds-author-list authors="mission.authors"></ds-author-list> -->
+                                <span ng-repeat="author in mission.authors">
+                                    <a href="#" ng-click="$ctrl.showAuthor(author)">{{ author.lname }}, {{ author.fname }}</a>; 
+                                </span>
                             </span>
                             <span ng-if="!$ctrl.readOnly">
                                 <ds-author-list authors="mission.value.authors"></ds-author-list>

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
@@ -14,13 +14,17 @@
             <tr class="prj-row">
                 <td>PI</td>
                 <td class="prj-data">
-                    <ds-user-list usernames="[$ctrl.browser.project.value.pi]"></ds-user-list>
+                    <a href="#" ng-click="$ctrl.showAuthor($ctrl.piDisplay)">
+                        {{ $ctrl.piDisplay.lname}}, {{ $ctrl.piDisplay.fname }}
+                    </a>
                 </td>
             </tr>
             <tr ng-if="$ctrl.browser.project.value.coPis.length">
                 <td>CoPIs</td>
                 <td class="prj-data">
-                    <ds-user-list usernames="$ctrl.browser.project.value.coPis"></ds-user-list>
+                    <span ng-repeat="coPi in $ctrl.coPIDisplay">
+                        <a href="#" ng-click="$ctrl.showAuthor(coPi)">{{coPi.lname}}, {{coPi.fname}}</a><span ng-if="!$last">;</span>
+                    </span>
                 </td>
             </tr>
             <tr class="prj-row" ng-if="$ctrl.readOnly">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
@@ -168,7 +168,9 @@
                     <div style="display:inline-block; width:20%; vertical-align: top;">Authors</div>
                     <div style="display:inline-block; width:78%; font-weight: bold;">
                         <span ng-if="$ctrl.readOnly">
-                            <ds-author-list authors="hybsim.authors"></ds-author-list>
+                            <span ng-repeat="author in hybsim.authors">
+                                <a href="#" ng-click="$ctrl.showAuthor(author)">{{ author.lname }}, {{ author.fname }}</a>; 
+                            </span>
                         </span>
                         <span ng-if="!$ctrl.readOnly">
                             <ds-author-list authors="hybsim.value.authors"></ds-author-list>

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
@@ -173,7 +173,10 @@
                     <div style="display:inline-block; width:20%; vertical-align: top;">Authors</div>
                     <div style="display:inline-block; width:78%; font-weight: bold;">
                         <span ng-if="$ctrl.readOnly">
-                            <ds-author-list authors="simulation.authors"></ds-author-list>
+                            <!-- <ds-author-list authors="simulation.authors"></ds-author-list> -->
+                            <span ng-repeat="author in simulation.authors">
+                                <a href="#" ng-click="$ctrl.showAuthor(author)">{{ author.lname }}, {{ author.fname }}</a>; 
+                            </span>
                         </span>
                         <span ng-if="!$ctrl.readOnly">
                             <ds-author-list authors="simulation.value.authors"></ds-author-list>

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
@@ -170,7 +170,10 @@
                     <div style="display:inline-block; width:20%; vertical-align: top;">Authors</div>
                     <div style="display:inline-block; width:78%; font-weight: bold;">
                         <span ng-if="$ctrl.readOnly">
-                            <ds-author-list authors="experiment.authors"></ds-author-list>
+                            <!-- <ds-author-list authors="experiment.authors"></ds-author-list> -->
+                            <span ng-repeat="author in experiment.authors">
+                                <a href="#" ng-click="$ctrl.showAuthor(author)">{{ author.lname }}, {{ author.fname }}</a>; 
+                            </span>
                         </span>
                         <span ng-if="!$ctrl.readOnly">
                             <ds-author-list authors="experiment.value.authors"></ds-author-list>

--- a/designsafe/static/scripts/data-depot/components/published/published-view.component.js
+++ b/designsafe/static/scripts/data-depot/components/published/published-view.component.js
@@ -114,6 +114,12 @@ class PublishedViewCtrl {
                     this.version = this.browser.publication.version || 1;
                     this.type = this.browser.publication.project.value.projectType;
                     this.ui.loading = false;
+
+                    // Generate text for PI
+                    this.piDisplay = this.browser.publication.authors.find((author) => author.name === this.browser.project.value.pi)
+                    // Generate CoPI list
+                    this.coPIDisplay = this.project.value.coPis.map((coPi) => this.browser.publication.authors.find((author) => author.name === coPi));
+
                 }).then( () => {
                     this.prepProject();
                 });

--- a/designsafe/static/scripts/data-depot/components/published/published-view.component.js
+++ b/designsafe/static/scripts/data-depot/components/published/published-view.component.js
@@ -6,7 +6,7 @@ import OtherPublicationTemplate from '../projects/publication-preview/publicatio
 import experimentalData from '../../../projects/components/manage-experiments/experimental-data.json';
 
 class PublishedViewCtrl {
-    constructor($stateParams, DataBrowserService, PublishedService, FileListing, $uibModal, $http, djangoUrl){
+    constructor($stateParams, DataBrowserService, PublishedService, FileListing, $uibModal, $http, djangoUrl, UserService){
         'ngInject';
         this.$stateParams = $stateParams;
         this.DataBrowserService = DataBrowserService;
@@ -15,6 +15,7 @@ class PublishedViewCtrl {
         this.$uibModal = $uibModal;
         this.$http = $http;
         this.djangoUrl = djangoUrl;
+        this.UserService = UserService;
     }
 
     $onInit() {
@@ -234,12 +235,17 @@ class PublishedViewCtrl {
     }
 
     showAuthor(author) {
-        this.$uibModal.open({
-            component: 'authorInformationModal',
-            resolve: {
-                author
-            },
-            size: 'sm'
+        this.UserService.get(author.name).then((res) => {
+            if (res.orcid_id) {
+                author.orcid = res.orcid_id;
+            }
+            this.$uibModal.open({
+                component: 'authorInformationModal',
+                resolve: {
+                    author
+                },
+                size: 'sm'
+            });
         });
     }
 

--- a/designsafe/static/scripts/data-depot/components/published/published-view.component.js
+++ b/designsafe/static/scripts/data-depot/components/published/published-view.component.js
@@ -227,6 +227,16 @@ class PublishedViewCtrl {
         }
     }
 
+    showAuthor(author) {
+        this.$uibModal.open({
+            component: 'authorInformationModal',
+            resolve: {
+                author
+            },
+            size: 'sm'
+        });
+    }
+
     treeDiagram() {
         this.$uibModal.open({
             component: 'projectTree',


### PR DESCRIPTION
Replaced `ds-author-list` directive with series of anchor elements for contact information modals. Only uses object that has email and institution information.

<img width="1170" alt="Screen Shot 2019-11-04 at 3 07 17 PM" src="https://user-images.githubusercontent.com/47395902/68158405-2912ba00-ff15-11e9-876f-969ec8762d84.png">
