### PR TITLE
Task/DES-1363 (HotFix) - Prevent ui data from being removed from published project metadata

### DIFF
--- a/designsafe/apps/projects/managers/publication.py
+++ b/designsafe/apps/projects/managers/publication.py
@@ -271,6 +271,8 @@ def _delete_unused_fields(dict_obj):
     for key in dict_obj:
         if key.endswith('_set'):
             keys_to_delete.append(key)
+        if key.startswith('_ui'):
+            continue
         if key.startswith('_'):
             keys_to_delete.append(key)
 


### PR DESCRIPTION
Need to keep the _ui data on the project in order to rebuild the project's entity diagram.