### PR TITLE
Task/DES-1364: Remove "Team Members" from Project Citations

### DIFF
--- a/designsafe/static/scripts/projects/components/publication-citation/publication-citation.component.js
+++ b/designsafe/static/scripts/projects/components/publication-citation/publication-citation.component.js
@@ -18,8 +18,14 @@ class PublicationCitationCtrl {
             this.auths = angular.copy(this.entity.authors);
             this.doi = this.entity.doi;
         } else if (this.publication.project.value.projectType !== 'other') {
-            // exp,hyb,sim,field
-            this.auths = angular.copy(this.publication.authors);
+            // exp,hyb,sim,field 
+            let authIds = [];
+            if (this.publication.project.value.coPis) {
+                authIds = this.publication.project.value.coPis.concat(this.publication.project.value.pi);
+            } else {
+                authIds = [this.publication.project.value.pi];
+            }
+            this.auths = this.publication.authors.filter((author) => authIds.includes(author.name));
         } else {
             // other
             this.auths = angular.copy(this.publication.project.value.teamOrder);


### PR DESCRIPTION
Replaced `this.auths` with values from coPis and PI fields instead of authors

Example shown uses [PRJ-1434](https://www.designsafe-ci.org/data/browser/public/designsafe.storage.published/PRJ-1434)
<img width="697" alt="Screen Shot 2019-11-08 at 10 41 22 AM" src="https://user-images.githubusercontent.com/47395902/68494744-8f992000-0214-11ea-852f-fb3229d9f330.png">
