### PR TITLE
Bug/DES-895: NEES URLs are forwarding to malformed DesignSafe URLs

### DIFF
--- a/designsafe/tests.py
+++ b/designsafe/tests.py
@@ -1,0 +1,14 @@
+from django.test import TestCase
+from mock import patch
+from views import redirect_old_nees
+
+class RedirectTest(TestCase):
+    """
+    Assert that the redirect function is called 
+    using a query string made with part of the NEES ID
+    """
+    @patch('django.shortcuts.redirect')
+    def test_redirect_old_nees(self, mock_redirect):
+        mock_redirect.return_value = True
+        redirect_old_nees(685)
+        self.assertTrue(mock_redirect.called_with('/search/?query_string=NEES 0685'))

--- a/designsafe/urls.py
+++ b/designsafe/urls.py
@@ -31,7 +31,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseRedirect
 from designsafe.apps.auth.views import login_options as des_login_options
 from django.contrib.auth.views import logout as des_logout
-from designsafe.views import project_version as des_version
+from designsafe.views import project_version as des_version, redirect_old_nees
 
 # sitemap - classes must be imported and added to sitemap dictionary
 from django.contrib.sitemaps.views import sitemap
@@ -138,10 +138,14 @@ urlpatterns = [
     # version check
     url(r'^version/', des_version),
 
+    # old NEES urls
+    url(r'^warehouse/project/([0-9]+)/?', redirect_old_nees),
+    url(r'^warehouse/experiment/([0-9]+)/project/([0-9]+)/?', redirect_old_nees),
+    url(r'^warehouse/hybrid/([0-9]+)/project/([0-9]+)/?', redirect_old_nees),
+
     # cms handles everything else
     url(r'^', include('djangocms_forms.urls')),
     url(r'^', include('cms.urls')),
-
 ]
 if settings.DEBUG:
     urlpatterns + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/designsafe/urls.py
+++ b/designsafe/urls.py
@@ -139,9 +139,9 @@ urlpatterns = [
     url(r'^version/', des_version),
 
     # old NEES urls
-    url(r'^warehouse/project/([0-9]+)/?', redirect_old_nees),
-    url(r'^warehouse/experiment/[0-9]+/project/([0-9]+)/?', redirect_old_nees),
-    url(r'^warehouse/hybrid/[0-9]+/project/([0-9]+)/?', redirect_old_nees),
+    url(r'^warehouse/project/(?P<nees_prj>[0-9]+)/?', redirect_old_nees),
+    url(r'^warehouse/experiment/[0-9]+/project/(?P<nees_prj>[0-9]+)/?', redirect_old_nees),
+    url(r'^warehouse/hybrid/[0-9]+/project/(?P<nees_prj>[0-9]+)/?', redirect_old_nees),
 
     # cms handles everything else
     url(r'^', include('djangocms_forms.urls')),

--- a/designsafe/urls.py
+++ b/designsafe/urls.py
@@ -140,8 +140,8 @@ urlpatterns = [
 
     # old NEES urls
     url(r'^warehouse/project/([0-9]+)/?', redirect_old_nees),
-    url(r'^warehouse/experiment/([0-9]+)/project/([0-9]+)/?', redirect_old_nees),
-    url(r'^warehouse/hybrid/([0-9]+)/project/([0-9]+)/?', redirect_old_nees),
+    url(r'^warehouse/experiment/[0-9]+/project/([0-9]+)/?', redirect_old_nees),
+    url(r'^warehouse/hybrid/[0-9]+/project/([0-9]+)/?', redirect_old_nees),
 
     # cms handles everything else
     url(r'^', include('djangocms_forms.urls')),

--- a/designsafe/views.py
+++ b/designsafe/views.py
@@ -1,4 +1,4 @@
-import logging, urllib2
+import logging
 from django.http import HttpResponse
 from django.shortcuts import redirect
 

--- a/designsafe/views.py
+++ b/designsafe/views.py
@@ -24,12 +24,12 @@ def project_version(request):
 
     return HttpResponse(version, content_type='text/plain')
 
-def redirect_old_nees(*args):
+def redirect_old_nees(request, nees_prj):
     """
     Parse old NEES.org url and pull out part of the NEES ID (Project Number)
     Returns: call to redirect method to a search page
     """
-    nees_prj = str(args[-1])
+    nees_prj = str(nees_prj)
     if len(nees_prj) is not 4:
         nees_prj = '0'*(4 - len(nees_prj)) + nees_prj
     url = '/search/?query_string=NEES {}'.format(nees_prj)

--- a/designsafe/views.py
+++ b/designsafe/views.py
@@ -1,8 +1,8 @@
-import logging
+import logging, urllib2
 from django.http import HttpResponse
+from django.shortcuts import redirect
 
 logger = logging.getLogger(__name__)
-
 
 def project_version(request):
     try:
@@ -23,3 +23,14 @@ def project_version(request):
         version = 'UNKNOWN'
 
     return HttpResponse(version, content_type='text/plain')
+
+def redirect_old_nees(*args):
+    """
+    Parse old NEES.org url and pull out part of the NEES ID (Project Number)
+    Returns: call to redirect method to a search page
+    """
+    nees_prj = str(args[-1])
+    if len(nees_prj) is not 4:
+        nees_prj = '0'*(4 - len(nees_prj)) + nees_prj
+    url = '/search/?query_string=NEES {}'.format(nees_prj)
+    return redirect(url)


### PR DESCRIPTION
URLs like the following were redirecting to the DesignSafe 404 page. They now redirect to a search page using the project ID in the url.
- https://nees.org/warehouse/experiment/3322/project/685
- https://nees.org/warehouse/hybrid/4176/project/71
- https://nees.org/warehouse/project/666

This was tested using the links in [this document](https://engineering.purdue.edu/IISL/Publications/Technical%20Reports/IISL_Report_008.pdf).

Additionally, test coverage has been added for the redirect view.
