### PR TITLE
task/DES-935: fixing My Data file listing pagination

### DIFF
--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/files-listing.template.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/files-listing.template.html
@@ -1,7 +1,10 @@
 <div class="table-responsive" data-ng-class="{'preview-wrapper': $ctrl.browser.showPreviewListing}">
-    <div data-ds-infinite-scroll
-         data-scroll-bottom="$ctrl.scrollToBottom()"
-         data-bottom-height="0"
+    <div
+        class="ds-table-display-wrapper"
+        data-ds-infinite-scroll
+        data-scroll-bottom="$ctrl.scrollToBottom()"
+        data-scroll-top="$ctrl.scrollToTop()"
+        data-bottom-height="0"
     >
         <div>
             <span ng-repeat="path in $ctrl.breadcrumbs track by $index">
@@ -26,7 +29,7 @@
             </thead>
             <tbody>
                 <tr data-ng-if="!$ctrl.browser.busyListing"
-                    data-ng-repeat="item in $ctrl.listing().children | orderBy: ['type', 'ext', 'name']"
+                    data-ng-repeat="item in $ctrl.listing().children"
                     ng-class="{highlight: item._ui.selected}"
                 >
                     <td class="unselectable">


### PR DESCRIPTION
updated files-listing template for pagination and removing sorting by item type for now

This affects the My Data listing, files listing within a project, and potentially a file listing within a publication (though I have not tested that last one).

If you are on Keith's Walk Experiment Demo project, I copied my lotsoftestfiles directory into that project to test the pagination there, so that's available to anyone for testing as well.