### PR TITLE
Task/DES-1079 - Update UUIDs of file tags for published files

### DIFF
--- a/designsafe/apps/api/projects/views.py
+++ b/designsafe/apps/api/projects/views.py
@@ -88,14 +88,13 @@ class PublicationView(BaseApiView):
                         countdown=60
                     )
                 ) |
+                tasks.swap_file_tag_uuids.si(pub.project_id) |
                 tasks.set_publish_status.si(
                     pub.projectId,
                     data.get('mainEntityUuids')
                 ) |
-                tasks.zip_publication_files.si(pub.projectId) |
-                tasks.swap_file_tag_uuids.si(pub.project_id)
+                tasks.zip_publication_files.si(pub.projectId)
             ).apply_async()
-
 
         return JsonResponse({'status': 200,
                              'response': {

--- a/designsafe/apps/api/projects/views.py
+++ b/designsafe/apps/api/projects/views.py
@@ -92,8 +92,10 @@ class PublicationView(BaseApiView):
                     pub.projectId,
                     data.get('mainEntityUuids')
                 ) |
-                tasks.zip_publication_files.si(pub.projectId)
+                tasks.zip_publication_files.si(pub.projectId) |
+                tasks.swap_file_tag_uuids.si(pub.project_id)
             ).apply_async()
+
 
         return JsonResponse({'status': 200,
                              'response': {

--- a/designsafe/apps/api/tasks.py
+++ b/designsafe/apps/api/tasks.py
@@ -860,7 +860,7 @@ def swap_file_tag_uuids(self, project_id):
     """
     from designsafe.apps.projects.managers import publication as PublicationManager
     try:
-        PublicationManager.redirect_file_tags(project_id)
+        PublicationManager.fix_file_tags(project_id)
     except Exception as exc:
         logger.error('File Tag Correction Error: %s. %s', project_id, exc, exc_info=True)
         raise self.retry(exc=exc)

--- a/designsafe/apps/api/tasks.py
+++ b/designsafe/apps/api/tasks.py
@@ -850,6 +850,22 @@ def zip_publication_files(self, project_id):
         raise self.retry(exc=exc)
 
 @shared_task(bind=True)
+def swap_file_tag_uuids(self, project_id):
+    """Swap File Tag UUID's
+
+    This task will update each file tag's file uuid from the file in
+    the project directory to the copied file in the published storage system
+
+    :param str project_id: Project Id.
+    """
+    from designsafe.apps.projects.managers import publication as PublicationManager
+    try:
+        PublicationManager.redirect_file_tags(project_id)
+    except Exception as exc:
+        logger.error('File Tag Correction Error: %s. %s', project_id, exc, exc_info=True)
+        raise self.retry(exc=exc)
+
+@shared_task(bind=True)
 def set_publish_status(self, project_id, entity_uuids, publish_dois=False):
     from designsafe.apps.projects.managers import publication as PublicationManager
     # Only publish DOIs created from prod

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-team/pipeline-team.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-team/pipeline-team.component.js
@@ -66,6 +66,7 @@ class PipelineTeamCtrl {
         var projectData = {
             title: this.project.value.title,
             uuid: this.project.uuid,
+            dois: this.project.value.dois,
             fileTags: this.project.value.fileTags,
             projectId: this.project.value.projectId,
             projectType: this.project.value.projectType,

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.html
@@ -140,8 +140,8 @@
                 <i class="fa fa-spinner fa-spin"></i> Loading...
             </h3>
         </div>
-        <div ng-hide="this.ui.loading">
-            <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listing" params="$ctrl.fl"></files-listing>
+        <div ng-if="$ctrl.fl">
+            <files-listing browser="$ctrl.browser" params="$ctrl.fl"></files-listing>
         </div>
     </div>
 </div>

--- a/designsafe/static/scripts/data-depot/components/published/published-view.component.js
+++ b/designsafe/static/scripts/data-depot/components/published/published-view.component.js
@@ -6,7 +6,7 @@ import OtherPublicationTemplate from '../projects/publication-preview/publicatio
 import experimentalData from '../../../projects/components/manage-experiments/experimental-data.json';
 
 class PublishedViewCtrl {
-    constructor($stateParams, DataBrowserService, PublishedService, FileListing, $uibModal, $http, djangoUrl, UserService){
+    constructor($stateParams, DataBrowserService, PublishedService, FileListing, $uibModal, $http, djangoUrl, UserService, $q){
         'ngInject';
         this.$stateParams = $stateParams;
         this.DataBrowserService = DataBrowserService;
@@ -16,6 +16,7 @@ class PublishedViewCtrl {
         this.$http = $http;
         this.djangoUrl = djangoUrl;
         this.UserService = UserService;
+        this.$q = $q;
     }
 
     $onInit() {
@@ -44,6 +45,9 @@ class PublishedViewCtrl {
                     this.browser.listings[evt.uuid] = { children: [] };
                 }
                 this.browser.listings[evt.uuid].children.push(file);
+            });
+            this.browser.listings[evt.uuid].children.forEach((child) => {
+                child._entities.push(evt);
             });
         };
 

--- a/designsafe/static/scripts/projects/components/file-categories/file-categories.component.js
+++ b/designsafe/static/scripts/projects/components/file-categories/file-categories.component.js
@@ -129,7 +129,8 @@ class FileCategoriesCtrl {
         getFileUuid(this.file).then((file) => {
             this.project.value.fileTags.push({
                 fileUuid: file.uuid(),
-                tagName: tagName
+                tagName: tagName,
+                path: this.file.path
             });
         }).then(() => {
             let projectData = {};
@@ -178,7 +179,8 @@ class FileCategoriesCtrl {
         getFileUuid(this.file).then((file)=>{
             entity.value.fileTags.push({
                 fileUuid: file.uuid(),
-                tagName: tagName
+                tagName: tagName,
+                path: this.file.path
             });
         }).then(() => {
             return this.ProjectEntitiesService.update({


### PR DESCRIPTION
**NOTICE: This should be merged with task/DES-1358**

This fix adds a "path" to the file tag object within a project/entities' metadata. A task was added to fix newly created tags and older tags without the "path" when a project is published. Lastly, there was a bug fixed with other publications not saving the "dois" field when proceeding through the pipeline.