### PR TITLE
Task/DES-1420: Collection and Mission title text needs to be center aligned

### DIFF
--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
@@ -147,7 +147,7 @@
                         style="width:100%;">
                         <table style="width:100%">
                             <tr>
-                                <td style="text-align: left;">
+                                <td class="tab-cell">
                                     <span>Reports Collection | <strong>{{mission.value.title}}</strong></span>
                                 </td>
                                 <td style="text-align: right;">
@@ -241,7 +241,7 @@
                     <button class="btn tab-experiment collapsed" data-toggle="collapse" data-target="#data-{{mission.uuid}}" style="width:100%;">
                         <table style="width:100%">
                             <tr>
-                                <td style="text-align: left;">
+                                <td class="tab-cell">
                                     <span>Mission | <strong>{{mission.value.title}}</strong></span>
                                 </td>
                                 <td style="text-align: right;">
@@ -342,7 +342,7 @@
                                         style="width:100%;">
                                         <table style="width:100%">
                                             <tr>
-                                                <td style="text-align: left;">
+                                                <td class="tab-cell">
                                                     <span>Collection | <strong>{{collection.value.title}}</strong></span>
                                                 </td>
                                                 <td style="text-align: right;">
@@ -419,7 +419,7 @@
                                         style="width:100%;">
                                         <table style="width:100%">
                                             <tr>
-                                                <td style="text-align: left;">
+                                                <td class="tab-cell">
                                                     <span>Social Sciences Collection | <strong>{{collection.value.title}}</strong></span>
                                                 </td>
                                                 <td style="text-align: right;">
@@ -562,7 +562,7 @@
                                         style="width:100%;">
                                         <table style="width:100%">
                                             <tr>
-                                                <td style="text-align: left;">
+                                                <td class="tab-cell">
                                                     <span>Engineering/Geosciences Collection | <strong>{{collection.value.title}}</strong></span>
                                                 </td>
                                                 <td style="text-align: right;">
@@ -666,7 +666,7 @@
                                         style="width:100%;">
                                         <table style="width:100%">
                                             <tr>
-                                                <td style="text-align: left;">
+                                                <td class="tab-cell">
                                                     <span>Research Planning Collection | <strong>{{collection.value.title}}</strong></span>
                                                 </td>
                                                 <td style="text-align: right;">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
@@ -120,7 +120,7 @@
             <button class="btn collapsed tab-report" data-toggle="collapse" data-target="#files-{{report.uuid}}" style="width:100%;">
                 <table style="width:100%">
                     <tr>
-                        <td style="text-align: left;">
+                        <td class="tab-cell">
                             <span>Report | <strong>{{report.value.title}}</strong></span>
                         </td>
                         <td style="text-align: right;">
@@ -145,7 +145,7 @@
             <button class="btn tab-experiment collapsed" data-toggle="collapse" data-target="#data-{{hybsim.uuid}}" style="width:100%;">
                 <table style="width:100%">
                     <tr>
-                        <td style="text-align: left;">
+                        <td class="tab-cell">
                             <span>Hybrid Simulation | <strong>{{hybsim.value.title}}</strong></span>
                         </td>
                         <td style="text-align: right;">
@@ -228,7 +228,7 @@
                                 <button class="btn collapsed tab-report" data-toggle="collapse" data-target="#files-{{report.uuid}}" style="width:100%;">
                                     <table style="width:100%">
                                         <tr>
-                                            <td style="text-align: left;">
+                                            <td class="tab-cell">
                                                 <span>Report | <strong>{{report.value.title}}</strong></span>
                                             </td>
                                             <td style="text-align: right;">
@@ -254,7 +254,7 @@
                                     style="width:100%;">
                                     <table style="width:100%">
                                         <tr>
-                                            <td style="text-align: left;">
+                                            <td class="tab-cell">
                                                 <span>Global Model | <strong>{{model.value.title}}</strong></span>
                                             </td>
                                             <td style="text-align: right;">
@@ -290,7 +290,7 @@
                                                 style="width:100%;">
                                                 <table style="width:100%">
                                                     <tr>
-                                                        <td style="text-align: left;">
+                                                        <td class="tab-cell">
                                                             <span>Coordinator | <strong>{{coordinator.value.title}}</strong></span>
                                                         </td>
                                                         <td style="text-align: right;">
@@ -327,7 +327,7 @@
                                                         <button class="btn collapsed tab-event" data-toggle="collapse" data-target="#files-{{cout.uuid}}{{model.uuid}}" style="width:100%;">
                                                             <table style="width:100%">
                                                                 <tr>
-                                                                    <td style="text-align: left;">
+                                                                    <td class="tab-cell">
                                                                         <span>Coordinator Output | <strong>{{cout.value.title}}</strong></span>
                                                                     </td>
                                                                     <td style="text-align: right;">
@@ -371,7 +371,7 @@
                                                         >
                                                             <table style="width:100%">
                                                                 <tr>
-                                                                    <td style="text-align: left;">
+                                                                    <td class="tab-cell">
                                                                         <span>Simulation Substructure | <strong>{{simsub.value.title}}</strong></span>
                                                                     </td>
                                                                     <td style="text-align: right;">
@@ -415,7 +415,7 @@
                                                                 >
                                                                     <table style="width:100%">
                                                                         <tr>
-                                                                            <td style="text-align: left;">
+                                                                            <td class="tab-cell">
                                                                                 <span>Simulation Output | <strong>{{sout.value.title}}</strong></span>
                                                                             </td>
                                                                             <td style="text-align: right;">
@@ -462,7 +462,7 @@
                                                         >
                                                             <table style="width:100%">
                                                                 <tr>
-                                                                    <td style="text-align: left;">
+                                                                    <td class="tab-cell">
                                                                         <span>Experimental Substrucutre | <strong>{{expsub.value.title}}</strong></span>
                                                                     </td>
                                                                     <td style="text-align: right;">
@@ -506,7 +506,7 @@
                                                                 >
                                                                     <table style="width:100%">
                                                                         <tr>
-                                                                            <td style="text-align: left;">
+                                                                            <td class="tab-cell">
                                                                                 <span>Experimental Output | <strong>{{eout.value.title}}</strong></span>
                                                                             </td>
                                                                             <td style="text-align: right;">
@@ -544,7 +544,7 @@
                                     style="width:100%;">
                                     <table style="width:100%">
                                         <tr>
-                                            <td style="text-align: left;">
+                                            <td class="tab-cell">
                                                 <span>Analysis | <strong>{{analysis.value.title}}</strong></span>
                                             </td>
                                             <td style="text-align: right;">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
@@ -125,7 +125,7 @@
             <button class="btn collapsed tab-report" data-toggle="collapse" data-target="#files-{{report.uuid}}" style="width:100%;">
                 <table style="width:100%">
                     <tr>
-                        <td style="text-align: left;">
+                        <td class="tab-cell">
                             <span>Report | <strong>{{report.value.title}}</strong></span>
                         </td>
                         <td style="text-align: right;">
@@ -150,7 +150,7 @@
             <button class="btn tab-experiment collapsed" data-toggle="collapse" data-target="#data-{{simulation.uuid}}" style="width:100%;">
                 <table style="width:100%">
                     <tr>
-                        <td style="text-align: left;">
+                        <td class="tab-cell">
                             <span>Simulation | <strong>{{simulation.value.title}}</strong></span>
                         </td>
                         <td style="text-align: right;">
@@ -234,7 +234,7 @@
                                 <button class="btn collapsed tab-report" data-toggle="collapse" data-target="#files-{{report.uuid}}" style="width:100%;">
                                     <table style="width:100%">
                                         <tr>
-                                            <td style="text-align: left;">
+                                            <td class="tab-cell">
                                                 <span>Report | <strong>{{report.value.title}}</strong></span>
                                             </td>
                                             <td style="text-align: right;">
@@ -258,7 +258,7 @@
                                     style="width:100%;">
                                     <table style="width:100%">
                                         <tr>
-                                            <td style="text-align: left;">
+                                            <td class="tab-cell">
                                                 <span>Simulation Model | <strong>{{model.value.title}}</strong></span>
                                             </td>
                                             <td style="text-align: right;">
@@ -294,7 +294,7 @@
                                                 style="width:100%;">
                                                 <table style="width:100%">
                                                     <tr>
-                                                        <td style="text-align: left;">
+                                                        <td class="tab-cell">
                                                             <span>Simulation Input | <strong>{{input.value.title}}</strong></span>
                                                         </td>
                                                         <td style="text-align: right;">
@@ -331,7 +331,7 @@
                                                         <button class="btn collapsed tab-outpt" data-toggle="collapse" data-target="#files-{{output.uuid}}{{model.uuid}}" style="width:100%;">
                                                             <table style="width:100%">
                                                                 <tr>
-                                                                    <td style="text-align: left;">
+                                                                    <td class="tab-cell">
                                                                         <span>Simulation Output | <strong>{{output.value.title}}</strong></span>
                                                                     </td>
                                                                     <td style="text-align: right;">
@@ -364,7 +364,7 @@
                                     style="width:100%;">
                                     <table style="width:100%">
                                         <tr>
-                                            <td style="text-align: left;">
+                                            <td class="tab-cell">
                                                 <span>Analysis | <strong>{{analysis.value.title}}</strong></span>
                                             </td>
                                             <td style="text-align: right;">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
@@ -122,7 +122,7 @@
             <button class="btn tab-report" data-toggle="collapse" data-target="#files-{{report.uuid}}" style="width:100%;">
                 <table style="width:100%">
                     <tr>
-                        <td style="text-align: left;">
+                        <td class="tab-cell">
                             <span>Report | <strong>{{report.value.title}}</strong></span>
                         </td>
                         <td style="text-align: right;">
@@ -147,7 +147,7 @@
             <button class="btn tab-experiment collapsed" data-toggle="collapse" data-target="#data-{{experiment.uuid}}" style="width:100%;">
                 <table style="width:100%">
                     <tr>
-                        <td style="text-align: left;">
+                        <td class="tab-cell">
                             <span>Experiment | <strong>{{experiment.value.title}}</strong></span>
                         </td>
                         <td style="text-align: right;">
@@ -252,7 +252,7 @@
                                 <button class="btn collapsed tab-report" data-toggle="collapse" data-target="#files-{{report.uuid}}" style="width:100%;">
                                     <table style="width:100%">
                                         <tr>
-                                            <td style="text-align: left;">
+                                            <td class="tab-cell">
                                                 <span>Report | <strong>{{report.value.title}}</strong></span>
                                             </td>
                                             <td style="text-align: right;">
@@ -278,7 +278,7 @@
                                     style="width:100%;">
                                     <table style="width:100%">
                                         <tr>
-                                            <td style="text-align: left;">
+                                            <td class="tab-cell">
                                                 <span>Model Configuration | <strong>{{modelConfig.value.title}}</strong></span>
                                             </td>
                                             <td style="text-align: right;">
@@ -317,7 +317,7 @@
                                                 >
                                                 <table style="width:100%">
                                                     <tr>
-                                                        <td style="text-align: left;">
+                                                        <td class="tab-cell">
                                                             <span>Sensor Information | <strong>{{sensorList.value.title}}</strong></span>
                                                         </td>
                                                         <td style="text-align: right;">
@@ -354,7 +354,7 @@
                                                         <button class="btn collapsed tab-event" data-toggle="collapse" data-target="#files-{{event.uuid}}{{modelConfig.uuid}}" style="width:100%;">
                                                             <table style="width:100%">
                                                                 <tr>
-                                                                    <td style="text-align: left;">
+                                                                    <td class="tab-cell">
                                                                         <span>Event | <strong>{{event.value.title}}</strong></span>
                                                                     </td>
                                                                     <td style="text-align: right;">
@@ -387,7 +387,7 @@
                                     style="width:100%;">
                                     <table style="width:100%">
                                         <tr>
-                                            <td style="text-align: left;">
+                                            <td class="tab-cell">
                                                 <span>Analysis | <strong>{{analysis.value.title}}</strong></span>
                                             </td>
                                             <td style="text-align: right;">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.scss
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.scss
@@ -23,6 +23,11 @@
   border-color: #1568C9;
   white-space: normal;
 }
+.tab-cell {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  text-align: left;
+}
 
 .category-sensor-info {
   font-weight: bold;


### PR DESCRIPTION
This PR adds a CSS class to align the `td` within the collapse buttons.
<img width="357" alt="Screen Shot 2020-01-17 at 1 42 57 PM" src="https://user-images.githubusercontent.com/47395902/72641265-52958c00-392f-11ea-8b61-e08f7fb315d5.png">
