### PR TITLE
Bug/DES-1404 - Remove field from experimental-data.json

### DIFF
--- a/designsafe/static/scripts/projects/components/manage-experiments/experimental-data.json
+++ b/designsafe/static/scripts/projects/components/manage-experiments/experimental-data.json
@@ -16,7 +16,6 @@
     },
     "equipmentTypes": {
         "atlss": [
-            { "name": "hybrid_simulation", "label": "Hybrid Simulation" },
             {"name": "lsrthcshas", "label": "Large-Scale, Real-Time/Hybrid Capable Servo-Hydraulic Actuator System"},
             {"name": "ssrthcshas", "label": "Small-Scale, Real-Time/Hybrid Capable Servo-Hydraulic Actuator System "},
             {"name": "rssb", "label": "Reduced-Scale Soil Box"},
@@ -70,7 +69,6 @@
     },
     "experimentTypes": {
         "atlss": [
-            { "name": "hybrid_simulation", "label": "Hybrid Simulation" },
             { "name": "large", "label": "Large-Scale" },
             { "name": "small", "label": "Small-Scale" },
             { "name": "char", "label": "Characterization" },

--- a/designsafe/static/scripts/projects/components/manage-experiments/experimental-data.json
+++ b/designsafe/static/scripts/projects/components/manage-experiments/experimental-data.json
@@ -16,6 +16,7 @@
     },
     "equipmentTypes": {
         "atlss": [
+            { "name": "hybrid_simulation", "label": "Hybrid Simulation" },
             {"name": "lsrthcshas", "label": "Large-Scale, Real-Time/Hybrid Capable Servo-Hydraulic Actuator System"},
             {"name": "ssrthcshas", "label": "Small-Scale, Real-Time/Hybrid Capable Servo-Hydraulic Actuator System "},
             {"name": "rssb", "label": "Reduced-Scale Soil Box"},
@@ -69,6 +70,7 @@
     },
     "experimentTypes": {
         "atlss": [
+            { "name": "hybrid_simulation", "label": "Hybrid Simulation" },
             { "name": "large", "label": "Large-Scale" },
             { "name": "small", "label": "Small-Scale" },
             { "name": "char", "label": "Characterization" },

--- a/designsafe/static/scripts/projects/components/manage-experiments/manage-experiments.component.js
+++ b/designsafe/static/scripts/projects/components/manage-experiments/manage-experiments.component.js
@@ -16,10 +16,15 @@ class ManageExperimentsCtrl {
     $onInit() {
         this.project = this.resolve.project;
         this.edit = this.resolve.edit;
-        
+
+        let remData = (data) => {
+            data.atlss = data.atlss.filter(a => a.name != "hybrid_simulation"); 
+            return data;
+        };
+
         this.efs = experimentalData.experimentalFacility;
-        this.experimentTypes = experimentalData.experimentTypes;
-        this.equipmentTypes = experimentalData.equipmentTypes;
+        this.experimentTypes = remData(experimentalData.experimentTypes);
+        this.equipmentTypes = remData(experimentalData.equipmentTypes);
 
         var members = [this.project.value.pi].concat(
             this.project.value.coPis,


### PR DESCRIPTION
This is a hack to remove two dropdown options defined in a .json form. We can't delete the field from the .json because the existing published Experiments which selected this option will break. This .json file is referenced by both published and non published projects... Fixing this correctly will require updating all previously published experiments, as well as updating the way these fields are saved (so we don't reference a .json for both published and non published projects). At the time I've submitted this, I do not have access to modify published metadata locally, and there is an important user waiting for this change. I'll be making a ticket to fix the underlying issue.