### PR TITLE
Task/des 1480: Update CMS index non-destructively and only once per day.

### DIFF
--- a/designsafe/apps/data/apps.py
+++ b/designsafe/apps/data/apps.py
@@ -2,9 +2,10 @@ import logging
 from django.apps import AppConfig
 from designsafe.apps.signals.signals import ds_event, generic_event
 
-#pylint: disable=invalid-name
+# pylint: disable=invalid-name
 logger = logging.getLogger(__name__)
-#pylint: enable=invalid-name
+# pylint: enable=invalid-name
+
 
 class DataConfig(AppConfig):
     name = 'designsafe.apps.data'
@@ -14,16 +15,12 @@ class DataConfig(AppConfig):
         from elasticsearch_dsl.connections import connections
         from django.conf import settings
         try:
-            connections.configure(
-                default={'hosts': settings.ES_CONNECTIONS[settings.DESIGNSAFE_ENVIRONMENT]['hosts'],  "http_auth": settings.ES_AUTH},
-                request_timeout=60,
-                sniff_on_start=True,
-                sniffer_timeout=60,
-                sniff_on_connection_fail=True,
-                sniff_timeout=10,
-                max_retries=3,
-                retry_on_timeout=True
-            )
+            connections.create_connection('default',
+                                          hosts=settings.ES_CONNECTIONS[settings.DESIGNSAFE_ENVIRONMENT]['hosts'],
+                                          http_auth=settings.ES_AUTH,
+                                          max_retries=3,
+                                          retry_on_timeout=True,
+                                          )
         except AttributeError as exc:
             logger.error('Missing ElasticSearch config. %s', exc)
             raise

--- a/designsafe/apps/search/tasks.py
+++ b/designsafe/apps/search/tasks.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 def update_search_index():
     logger.info("Updating search index")
     if not settings.DEBUG:
-        call_command("rebuild_index", interactive=False)
+        call_command("update_index", interactive=False)
 
 @shared_task(bind=True)
 def index_community_data(self):

--- a/designsafe/celery.py
+++ b/designsafe/celery.py
@@ -25,7 +25,7 @@ app.conf.update(
     CELERYBEAT_SCHEDULE = {
         'update_user_storages': {
             'task': 'designsafe.apps.search.tasks.update_search_index',
-            'schedule': crontab(minute="*/15"),
+            'schedule': crontab(minute=0, hour=0),
         },
         'reindex_projects': {
             'task': 'designsafe.apps.api.tasks.reindex_projects',

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,8 +66,8 @@ docutils==0.14
 dropbox==7.1.1
 dumb-init==1.2.2
 easy-thumbnails==2.3
-elasticsearch==7.0.4
-elasticsearch-dsl==7.0.0
+elasticsearch==7.5.1
+elasticsearch-dsl==7.1.0
 enum34==1.1.6
 et-xmlfile==1.0.1
 flake8==3.5.0


### PR DESCRIPTION
This is another weird legacy choice that could be contributing to timeouts.