### PR TITLE
task/DES-1508: Move future project systems from dtn01 to cloud.corral

### DIFF
--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -573,10 +573,10 @@ PROJECT_STORAGE_SYSTEM_TEMPLATE = {
     'type': 'STORAGE',
     'storage': {
         'mirror': False,
-        'port': 22,
+        'port': 2222,
         'homeDir': '/',
         'protocol': 'SFTP',
-        'host': 'dtn01.prod.agaveapi.co',
+        'host': 'cloud.corral.tacc.utexas.edu',
         'publicAppsDir': None,
         'proxy': None,
         'rootDir': '/corral-repl/tacc/NHERI/projects/{}',

--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -579,7 +579,7 @@ PROJECT_STORAGE_SYSTEM_TEMPLATE = {
         'host': 'cloud.corral.tacc.utexas.edu',
         'publicAppsDir': None,
         'proxy': None,
-        'rootDir': '/corral-repl/tacc/NHERI/projects/{}',
+        'rootDir': '/corral-repl/projects/NHERI/projects/{}',
         'auth': json.loads(os.environ.get('PROJECT_SYSTEM_STORAGE_CREDENTIALS', '{}'))
     }
 }

--- a/designsafe/settings/test_settings.py
+++ b/designsafe/settings/test_settings.py
@@ -544,7 +544,7 @@ PROJECT_STORAGE_SYSTEM_TEMPLATE = {
         'host': 'cloud.corral.tacc.utexas.edu',
         'publicAppsDir': None,
         'proxy': None,
-        'rootDir': '/corral-repl/tacc/NHERI/projects/{}',
+        'rootDir': '/corral-repl/projects/NHERI/projects/{}',
         'auth': json.loads(os.environ.get('PROJECT_SYSTEM_STORAGE_CREDENTIALS', '{}'))
     }
 }

--- a/designsafe/settings/test_settings.py
+++ b/designsafe/settings/test_settings.py
@@ -538,10 +538,10 @@ PROJECT_STORAGE_SYSTEM_TEMPLATE = {
     'type': 'STORAGE',
     'storage': {
         'mirror': False,
-        'port': 22,
+        'port': 2222,
         'homeDir': '/',
         'protocol': 'SFTP',
-        'host': 'dtn01.prod.agaveapi.co',
+        'host': 'cloud.corral.tacc.utexas.edu',
         'publicAppsDir': None,
         'proxy': None,
         'rootDir': '/corral-repl/tacc/NHERI/projects/{}',


### PR DESCRIPTION
With dtn01 going out of commission soon, we need to update our hosts on project systems going forward to point to cloud.corral.

Using the `tg458981` service account, the key pair in the [TACC Keys Service](https://github.com/TACC-Cloud/ssh-keys-client/tree/master/tacc-keys) can auth against cloud.corral on behalf of `tg458981`

To test:
Create a new project, and confirm all file operations succeed.