### PR TITLE
Bug/DES-1529 - Fix data type issue causing v1 publications to 500 error

### DIFF
--- a/designsafe/apps/projects/models/agave/base.py
+++ b/designsafe/apps/projects/models/agave/base.py
@@ -318,6 +318,8 @@ class Project(MetadataModel):
                 'identifier': self.project_id,
             }
         ]
+        if type(self.award_number[0]) is not dict:
+            self.award_number = [{'order': 0, 'name': ''.join(self.award_number)}]
         awards = sorted(
             self.award_number,
             key=lambda x: (x.get('order', 0), x.get('name', ''))

--- a/designsafe/apps/projects/models/agave/base.py
+++ b/designsafe/apps/projects/models/agave/base.py
@@ -318,7 +318,7 @@ class Project(MetadataModel):
                 'identifier': self.project_id,
             }
         ]
-        if type(self.award_number[0]) is not dict:
+        if len(self.award_number) and type(self.award_number[0]) is not dict:
             self.award_number = [{'order': 0, 'name': ''.join(self.award_number)}]
         awards = sorted(
             self.award_number,


### PR DESCRIPTION
A quick fix for v1 projects. The larger issue has been moved into Task/DES-1456

The early v1 projects are sharing the same project class with the v2 projects. The old and new versions of the projects metadata schema are almost the same except for the `award_numbers` field:
```
v1_award_numbers = 'ABC_123'
v2_award_numbers = [{'order': 0, 'name': 'ABC_123'}]
```
The `award_number` (character field) from v1 has been adapted in a few places to fit to the newer v2 project schema of `award_numbers` (list of objects) when it's needed.

This will fix the 500 error causing the v1 publications not to load, but I feel like this should be resolved at the same time as this issue:
https://jira.tacc.utexas.edu/browse/DES-1465
Getting the `award_numbers` fields to match between the old and new project types shouldn't be that difficult, but tracking down all of the places on the back end where these differences have been manually reformed to fit the new project model will take some digging. We will possibly need to reindex des_publications and des_projects as well as update the UI to fully resolve this issue.