### PR TITLE
Bug/DES-1582 - Filter conditionally required field from error message

### DIFF
--- a/designsafe/static/scripts/ng-designsafe/services/project-service.js
+++ b/designsafe/static/scripts/ng-designsafe/services/project-service.js
@@ -294,6 +294,9 @@ export function ProjectService(httpi, $interpolate, $q, $state, $uibModal, Loggi
                     if (data.missing.length < 2 && (data.missing.includes('Social Sciences Collection') || data.missing.includes('Engineering/Geosciences Collection'))) {
                         return false;
                     }
+                    if (data.missing.length < 3 && data.missing.includes('Research Planning Collection')) {
+                        data.missing = ['Research Planning Collection'];
+                    }
                     return true;
                 });
             }


### PR DESCRIPTION
A conditionally required entity type (social science or geoscience) was being returned incorrectly in an error message sent back to users even if they had the minimum requirements.

If a mission is published it must have:
- Planning Set
- Social Science OR Geoscience Set
- Files within all Sets