### PR TITLE
Task/DES-1596 Add download publication button to v1 publications

### DIFF
--- a/designsafe/static/scripts/data-depot/components/published/published.component.html
+++ b/designsafe/static/scripts/data-depot/components/published/published.component.html
@@ -6,7 +6,14 @@
 <!-- Published View -->
 <div class="project">
   <div class="project-detail" style="background:white;" ng-if="!$ctrl.ui.loadingProjectMeta">
-    <h2>{{$ctrl.project.value.projectId}}: {{ $ctrl.project.value.title }}</h2>
+    <div class="prj-head-container">
+      <span class="prj-head-title">
+        <strong>{{$ctrl.project.value.projectId}}: {{ $ctrl.project.value.title }}</strong>
+      </span>
+      <span class="prj-head-download">
+          <a class="curation-download" ng-click="$ctrl.download()"> <strong>Download Dataset</strong></a>
+      </span>
+    </div>
     <div class="table-responsive">
       <table class="table" style="margin-bottom:0;">
         <thead>

--- a/designsafe/static/scripts/data-depot/components/published/published.component.js
+++ b/designsafe/static/scripts/data-depot/components/published/published.component.js
@@ -503,6 +503,17 @@ export class PublishedDataCtrl {
         this.DataBrowserService.showCitation(publication, project);
     }
 
+    download() {
+        this.$uibModal.open({
+            component: 'publicationDownloadModal',
+            resolve: {
+                publication: () => {return this.browser.publication;},
+                mediaUrl: () => {return this.browser.listing.mediaUrl();},
+            },
+            size: 'lg'
+        });
+    }
+
 }
 
 export const PublishedComponent = {

--- a/designsafe/static/scripts/projects/components/publication-download/publication-download.template.html
+++ b/designsafe/static/scripts/projects/components/publication-download/publication-download.template.html
@@ -28,6 +28,13 @@
     <p>
         The files are licensed by the following:
         <br>
+        <div class="btn-container" ng-if="!$ctrl.publication.licenses">
+            <span class="curation-odc" style="font-size:32px;"></span>
+            &ensp;
+            <strong>Open Data Commons Attribution</strong>
+            &ensp;
+            (<a href="https://opendatacommons.org/licenses/by/" target="_blank">License Website</a>)
+        </div>
         <div class="btn-container" ng-if="$ctrl.publication.licenses.datasets">
             <span class="curation-odc" style="font-size:32px;"></span>
             &ensp;


### PR DESCRIPTION
You can test these changes here:
https://designsafe.dev/data/browser/public/designsafe.storage.published//PRJ-1640

Changes Include:
Added download publication modal to v1 publications (publications older than v2, but not NEES)
The download button is in the same position as v2 publications, It should have the same functionality. I do not have archives created for the rest of the v1 publications, but they can be easily added to corral.