### PR TITLE
Bug/DES-1603 - Fix ui elements and issue with publication submission

### DIFF
--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-publish/pipeline-agreement.html
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-publish/pipeline-agreement.html
@@ -29,12 +29,12 @@
             publication that cannot be changed. If I have revisions this will result in a new
             version of the publication including a new DOI.
         </p>
-        <div ng-if="!$ctrl.ui.submitted && !$ctrl.ui.published">
+        <div class="prj-agree-select" ng-if="!$ctrl.ui.submitted && !$ctrl.ui.published">
             <span style="display:inline-block; width:75%;">
                 <input type="checkbox" id="agreement" name="agreement" ng-model="$ctrl.agreed">
                 <label for="agreement"> I agree </label>
             </span>
-            <button class="btn btn-add prj-agree-publish"
+            <button class="btn btn-add"
                     ng-click="$ctrl.publish()"
                     ng-disabled="!$ctrl.agreed || $ctrl.busy">
                 <i class="fa fa-globe">&nbsp;</i> Request DOI & Publish
@@ -47,7 +47,7 @@
                 You will find your published project in the "Published" ared of the Data Depot soon.
             </div>
             <div style="text-align: center">
-                    <button class="btn btn-add prj-agree-publish"
+                    <button class="btn btn-add"
                             ng-click="$ctrl.return()"
                     >
                         Complete Submission

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-publish/pipeline-agreement.html
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-publish/pipeline-agreement.html
@@ -1,73 +1,75 @@
 <div class="modal-header" style="background: #e6e6e6;">
     <h4 class="modal-title" style="border:none;">
         <span>Agreement</span>
-        <span class="pull-right" data-ng-click="$ctrl.close()">
+        <span class="pull-right" ng-click="$ctrl.close()">
             <i class="fa fa-times">&nbsp;</i>
         </span>
     </h4>
 </div>
 <div class="modal-body" style="padding: 30px;">
-    <h3>
-        Publishing Agreement
-    </h3>
-    <hr>
-    <p class="prj-agree-body">
-        This submission represents my original work. The submission meets the requirements
-        established by DesignSafe-CI available at the
-        <a href="/rw/user-guides/data-publication-guidelines/" target="_blank">
-            Curation and Publication Guidelines.
-        </a>
-        I understand the type of license I choose to distribute my data and guarantee that
-        I am entitled to grant the rights contained in them. I agree that when this submission
-        is made public with a unique digital object identifier (DOI), this will result in a
-        publication that cannot be changed. If I have revisions this will result in a new
-        version of the publication including a new DOI.
-    </p>
-    <div ng-show="$ctrl.existingPub === null">
+    <div ng-if="$ctrl.ui.loading">
         <h3 class="text-center">
             <i class="fa fa-spinner fa-spin"></i> Loading...
         </h3>
     </div>
-    <div ng-if="!$ctrl.published && $ctrl.existingPub === false">
-        <span style="display:inline-block; width:75%;">
-            <input type="checkbox" id="agreement" name="agreement" data-ng-model="$ctrl.agreed">
-            <label for="agreement"> I agree </label>
-        </span>
-        <button class="btn btn-add prj-agree-publish"
-                data-ng-click="$ctrl.publish()"
-                data-ng-disabled="!$ctrl.agreed || $ctrl.busy">
-            <i class="fa fa-globe">&nbsp;</i> Request DOI & Publish
-        </button>
-    </div>
-    <div data-ng-if="$ctrl.published">
-        <div class="alert alert-warning">
-            Your project is being published. <strong>Do not attempt to publish your project again.</strong>
-            Please wait until the project has finished publishing to edit or add anything in the project.
-            You will find your published project in the "Published" ared of the Data Depot soon.
+    <div ng-if="!$ctrl.ui.loading">
+        <h3>
+            Publishing Agreement
+        </h3>
+        <hr>
+        <p class="prj-agree-body">
+            This submission represents my original work. The submission meets the requirements
+            established by DesignSafe-CI available at the
+            <a href="/rw/user-guides/data-publication-guidelines/" target="_blank">
+                Curation and Publication Guidelines.
+            </a>
+            I understand the type of license I choose to distribute my data and guarantee that
+            I am entitled to grant the rights contained in them. I agree that when this submission
+            is made public with a unique digital object identifier (DOI), this will result in a
+            publication that cannot be changed. If I have revisions this will result in a new
+            version of the publication including a new DOI.
+        </p>
+        <div ng-if="!$ctrl.ui.submitted && !$ctrl.ui.published">
+            <span style="display:inline-block; width:75%;">
+                <input type="checkbox" id="agreement" name="agreement" ng-model="$ctrl.agreed">
+                <label for="agreement"> I agree </label>
+            </span>
+            <button class="btn btn-add prj-agree-publish"
+                    ng-click="$ctrl.publish()"
+                    ng-disabled="!$ctrl.agreed || $ctrl.busy">
+                <i class="fa fa-globe">&nbsp;</i> Request DOI & Publish
+            </button>
         </div>
-        <div style="text-align: center">
-                <button class="btn btn-add prj-agree-publish"
-                        data-ng-click="$ctrl.return()"
-                >
-                    Complete Submission
-                </button>
+        <div ng-if="$ctrl.ui.submitted">
+            <div class="alert alert-warning">
+                Your project is being published. <strong>Do not attempt to publish your project again.</strong>
+                Please wait until the project has finished publishing to edit or add anything in the project.
+                You will find your published project in the "Published" ared of the Data Depot soon.
+            </div>
+            <div style="text-align: center">
+                    <button class="btn btn-add prj-agree-publish"
+                            ng-click="$ctrl.return()"
+                    >
+                        Complete Submission
+                    </button>
+            </div>
         </div>
-    </div>
-    <div data-ng-if="$ctrl.existingPub === true">
-        <div class="alert alert-warning">
-            This project has already been published.
-            If you would like to update your existing publication or
-            if you are having trouble viewing your publication please
-            <a href="/help/new-ticket/?category=DATA_CURATION_PUBLICATION&subject=Requesting+update+to+existing+publication:+{{$ctrl.project.value.projectId}}"
-               target="_blank">submit a ticket</a>.
-        </div>
-        <div style="text-align: center">
-                <button class="btn btn-add"
-                        style="width:24%;"
-                        data-ng-click="$ctrl.return()"
-                >
-                    Return to Project
-                </button>
+        <div ng-if="$ctrl.ui.published">
+            <div class="alert alert-warning">
+                This project has already been published.
+                If you would like to update your existing publication or
+                if you are having trouble viewing your publication please
+                <a href="/help/new-ticket/?category=DATA_CURATION_PUBLICATION&subject=Requesting+update+to+existing+publication:+{{$ctrl.project.value.projectId}}"
+                target="_blank">submit a ticket</a>.
+            </div>
+            <div style="text-align: center">
+                    <button class="btn btn-add"
+                            style="width:24%;"
+                            ng-click="$ctrl.return()"
+                    >
+                        Return to Project
+                    </button>
+            </div>
         </div>
     </div>
 </div>

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-publish/pipeline-privacy-agreement.html
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-publish/pipeline-privacy-agreement.html
@@ -1,106 +1,113 @@
 <div class="modal-header" style="background: #e6e6e6;">
     <h4 class="modal-title" style="border:none;">
         <span>Agreement</span>
-        <span class="pull-right" data-ng-click="$ctrl.close()">
+        <span class="pull-right" ng-click="$ctrl.close()">
             <i class="fa fa-times">&nbsp;</i>
         </span>
     </h4>
 </div>
 <div class="modal-body" style="padding: 30px;">
-    <div class="prj-agree-body">
-        <h3>
-            Privacy Guidelines Regarding the Storage and Publication of Human Subjects Data
+    <div ng-if="$ctrl.ui.loading">
+        <h3 class="text-center">
+            <i class="fa fa-spinner fa-spin"></i> Loading...
         </h3>
-        <hr>
-        <p>
-            To publish protected data researchers should adhere to the following procedures:
-        </p>
-        <p>
-            a)	Do not publish HIPPA, FERPA, PII data or other sensitive information in DesignSafe.
-        </p>
-        <p>
-            b)	To publish protected data and any related documentation (reports, planning documents,
-            field notes, etc.) it must be properly anonymized. No direct identifiers are allowed.
-            These include items such as participant names, participant initials, facial photographs
-            unless expressly authorized by participants), home addresses, social security numbers and
-            dates of birth. Up to three indirect identifiers are allowed in a published dataset. These
-            are identifiers that, taken together, could be used to deduce someone’s identity. Examples
-            include gender, household and family compositions, occupation, places of birth, or year of
-            birth/age.
-        </p>
-        <p>
-            c)	If a researcher needs to restrict public access to data because it includes highly
-            sensitive personal information, or because removing the indirect identifiers will impair
-            the data understandability, you may only publish metadata and other documentation about
-            the data in DesignSafe. Users interested in the data will contact the PI (your email address
-            will be published) to request access to the data and to discuss the conditions for its reuse.
-            Please contact DesignSafe’s curator through a HELP ticket prior to preparing this type of
-            data publication.
-        </p>
-        <span class="prj-agree-select">
-            <input type="checkbox" id="agreement1" name="agreement1" data-ng-model="$ctrl.agreed1">
-            <label for="agreement1"> The data I am publishing adheres to the procedures listed above </label>
-        </span>
     </div>
-    <div class="prj-agree-body">
-        <h3>
-            Publishing Agreement
-        </h3>
-        <hr>
-        <p>
-            This submission represents my original work. The submission meets the requirements
-            established by DesignSafe-CI available at the
-            <a href="/rw/user-guides/data-publication-guidelines/" target="_blank">
-                Curation and Publication Guidelines.
-            </a>
-            I understand the type of license I choose to distribute my data and guarantee that
-            I am entitled to grant the rights contained in them. I agree that when this submission
-            is made public with a unique digital object identifier (DOI), this will result in a
-            publication that cannot be changed. If I have revisions this will result in a new
-            version of the publication including a new DOI.
-        </p>
-        <div ng-if="!$ctrl.published && !$ctrl.existingPub">
-            <span class="prj-agree-select">
-                <input type="checkbox" id="agreement2" name="agreement2" data-ng-model="$ctrl.agreed2">
-                <label for="agreement2"> I agree </label>
+    <div ng-if="!$ctrl.ui.loading">
+        <div class="prj-agree-body">
+            <h3>
+                Privacy Guidelines Regarding the Storage and Publication of Human Subjects Data
+            </h3>
+            <hr>
+            <p>
+                To publish protected data researchers should adhere to the following procedures:
+            </p>
+            <p>
+                a)	Do not publish HIPPA, FERPA, PII data or other sensitive information in DesignSafe.
+            </p>
+            <p>
+                b)	To publish protected data and any related documentation (reports, planning documents,
+                field notes, etc.) it must be properly anonymized. No direct identifiers are allowed.
+                These include items such as participant names, participant initials, facial photographs
+                unless expressly authorized by participants), home addresses, social security numbers and
+                dates of birth. Up to three indirect identifiers are allowed in a published dataset. These
+                are identifiers that, taken together, could be used to deduce someone’s identity. Examples
+                include gender, household and family compositions, occupation, places of birth, or year of
+                birth/age.
+            </p>
+            <p>
+                c)	If a researcher needs to restrict public access to data because it includes highly
+                sensitive personal information, or because removing the indirect identifiers will impair
+                the data understandability, you may only publish metadata and other documentation about
+                the data in DesignSafe. Users interested in the data will contact the PI (your email address
+                will be published) to request access to the data and to discuss the conditions for its reuse.
+                Please contact DesignSafe’s curator through a HELP ticket prior to preparing this type of
+                data publication.
+            </p>
+            <span class="prj-agree-select" ng-if="!$ctrl.ui.submitted && !$ctrl.ui.published">
+                <input type="checkbox" id="agreement1" name="agreement1" ng-model="$ctrl.agreed1">
+                <label for="agreement1"> The data I am publishing adheres to the procedures listed above </label>
             </span>
-            <button class="btn btn-add prj-agree-publish"
-                    data-ng-click="$ctrl.publish()"
-                    data-ng-disabled="!$ctrl.agreed1 || !$ctrl.agreed2 || $ctrl.busy">
-                <i class="fa fa-globe">&nbsp;</i> Request DOI & Publish
-            </button>
         </div>
-    </div>
-    <div data-ng-if="$ctrl.published">
-        <div class="alert alert-warning">
-            Your project is being published. <strong>Do not attempt to publish your project again.</strong>
-            Please wait until the project has finished publishing to edit or add anything in the project.
-            You will find your published project in the "Published" ared of the Data Depot soon.
-        </div>
-        <div style="text-align: center">
-                <button class="btn btn-add"
-                        style="width:24%;"
-                        data-ng-click="$ctrl.return()"
-                >
-                    Complete Submission
+        <div class="prj-agree-body">
+            <h3>
+                Publishing Agreement
+            </h3>
+            <hr>
+            <p>
+                This submission represents my original work. The submission meets the requirements
+                established by DesignSafe-CI available at the
+                <a href="/rw/user-guides/data-publication-guidelines/" target="_blank">
+                    Curation and Publication Guidelines.
+                </a>
+                I understand the type of license I choose to distribute my data and guarantee that
+                I am entitled to grant the rights contained in them. I agree that when this submission
+                is made public with a unique digital object identifier (DOI), this will result in a
+                publication that cannot be changed. If I have revisions this will result in a new
+                version of the publication including a new DOI.
+            </p>
+            <div ng-if="!$ctrl.ui.submitted && !$ctrl.ui.published">
+                <span class="prj-agree-select">
+                    <input type="checkbox" id="agreement2" name="agreement2" ng-model="$ctrl.agreed2">
+                    <label for="agreement2"> I agree </label>
+                </span>
+                <button class="btn btn-add prj-agree-publish"
+                        ng-click="$ctrl.publish()"
+                        ng-disabled="!$ctrl.agreed1 || !$ctrl.agreed2 || $ctrl.busy">
+                    <i class="fa fa-globe">&nbsp;</i> Request DOI & Publish
                 </button>
+            </div>
         </div>
-    </div>
-    <div data-ng-if="$ctrl.existingPub">
-        <div class="alert alert-warning">
-            This project has already been published.
-            If you would like to update your existing publication or
-            if you are having trouble viewing your publication please
-            <a href="/help/new-ticket/?category=DATA_CURATION_PUBLICATION&subject=Requesting+update+to+existing+publication:+{{$ctrl.project.value.projectId}}"
-               target="_blank">submit a ticket</a>.
+        <div ng-if="$ctrl.ui.submitted">
+            <div class="alert alert-warning">
+                Your project is being published. <strong>Do not attempt to publish your project again.</strong>
+                Please wait until the project has finished publishing to edit or add anything in the project.
+                You will find your published project in the "Published" ared of the Data Depot soon.
+            </div>
+            <div style="text-align: center">
+                    <button class="btn btn-add"
+                            style="width:24%;"
+                            ng-click="$ctrl.return()"
+                    >
+                        Complete Submission
+                    </button>
+            </div>
         </div>
-        <div style="text-align: center">
-                <button class="btn btn-add"
-                        style="width:24%;"
-                        data-ng-click="$ctrl.return()"
-                >
-                    Return to Project
-                </button>
+        <div ng-if="$ctrl.ui.published">
+            <div class="alert alert-warning">
+                This project has already been published.
+                If you would like to update your existing publication or
+                if you are having trouble viewing your publication please
+                <a href="/help/new-ticket/?category=DATA_CURATION_PUBLICATION&subject=Requesting+update+to+existing+publication:+{{$ctrl.project.value.projectId}}"
+                target="_blank">submit a ticket</a>.
+            </div>
+            <div style="text-align: center">
+                    <button class="btn btn-add"
+                            style="width:24%;"
+                            ng-click="$ctrl.return()"
+                    >
+                        Return to Project
+                    </button>
+            </div>
         </div>
     </div>
 </div>

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-publish/pipeline-privacy-agreement.html
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-publish/pipeline-privacy-agreement.html
@@ -44,8 +44,10 @@
                 data publication.
             </p>
             <span class="prj-agree-select" ng-if="!$ctrl.ui.submitted && !$ctrl.ui.published">
-                <input type="checkbox" id="agreement1" name="agreement1" ng-model="$ctrl.agreed1">
-                <label for="agreement1"> The data I am publishing adheres to the procedures listed above </label>
+                <span>
+                    <input type="checkbox" id="agreement1" name="agreement1" ng-model="$ctrl.agreed1">
+                    <label for="agreement1"> The data I am publishing adheres to the procedures listed above </label>
+                </span>
             </span>
         </div>
         <div class="prj-agree-body">
@@ -65,12 +67,12 @@
                 publication that cannot be changed. If I have revisions this will result in a new
                 version of the publication including a new DOI.
             </p>
-            <div ng-if="!$ctrl.ui.submitted && !$ctrl.ui.published">
-                <span class="prj-agree-select">
+            <div class="prj-agree-select" ng-if="!$ctrl.ui.submitted && !$ctrl.ui.published">
+                <span>
                     <input type="checkbox" id="agreement2" name="agreement2" ng-model="$ctrl.agreed2">
                     <label for="agreement2"> I agree </label>
                 </span>
-                <button class="btn btn-add prj-agree-publish"
+                <button class="btn btn-add"
                         ng-click="$ctrl.publish()"
                         ng-disabled="!$ctrl.agreed1 || !$ctrl.agreed2 || $ctrl.busy">
                     <i class="fa fa-globe">&nbsp;</i> Request DOI & Publish

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-publish/pipeline-publish.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-publish/pipeline-publish.component.js
@@ -41,7 +41,11 @@ class PipelinePublishCtrl {
     $onInit() {
         this.project = this.resolve.project;
         this.selectedListings = this.resolve.resolveParams.selectedListings;
-        this.existingPub = null;
+        this.ui = {
+            published: null,
+            submitted: null,
+            loading: true,
+        }
 
         let publication = {
             project: { uuid: this.project.uuid, value: { projectId: this.project.value.projectId } },
@@ -97,10 +101,11 @@ class PipelinePublishCtrl {
         this.PublishedService.getPublished(this.project.value.projectId).then((resp) => {
             let data = resp.data;
             if (data.project) {
-                this.existingPub = true;
+                this.ui.published = true;
             } else {
-                this.existingPub = false;
+                this.ui.published = false;
             }
+            this.ui.loading = false;
         });
     }
 
@@ -125,7 +130,7 @@ class PipelinePublishCtrl {
             }
         ).then((resp) => {
             this.DataBrowserService.state().publicationStatus = resp.data.response.status;
-            this.published = true;
+            this.ui.submitted = true;
         }).finally( () => {
             this.busy = false;
         });

--- a/designsafe/static/scripts/projects/components/manage-categories/manage-categories.component.html
+++ b/designsafe/static/scripts/projects/components/manage-categories/manage-categories.component.html
@@ -183,8 +183,9 @@
             </div>
             <!-- Add Category Btn -->
             <div class="text-right">
-                <button class="btn btn-add" type="submit" ng-click="addForm.$valid && $ctrl.addCategory($event)"
-                    style="width:18%;"><i class="fa fa-plus"></i> Add Category</button>
+                <button class="btn btn-add" type="submit" ng-click="addForm.$valid && $ctrl.addCategory($event)">
+                    <i class="fa fa-plus"></i> Add Category
+                </button>
             </div>
         </form>
         <!-- Edit Category Form -->
@@ -362,8 +363,9 @@
             </div>
             <!-- Edit Category Btn -->
             <div class="text-right">
-                <button class="btn btn-add" type="submit" ng-click="editForm.$valid && $ctrl.updateCategory($event)"
-                    style="width:18%;">Update</button>
+                <button class="btn btn-add" type="submit" ng-click="editForm.$valid && $ctrl.updateCategory($event)">
+                    Update
+                </button>
             </div>
         </form>
     </div>

--- a/designsafe/static/scripts/projects/components/manage-experiments/manage-experiments.component.html
+++ b/designsafe/static/scripts/projects/components/manage-experiments/manage-experiments.component.html
@@ -174,7 +174,9 @@
         </div>
         <!-- Add Exp Btn -->
         <div class="text-right">
-          <button class="btn btn-add" type="submit" ng-click="addForm.$valid && $ctrl.saveExperiment($event)" style="width:18%;"><i class="fa fa-plus"></i> Add Experiment</button>
+          <button class="btn btn-add" type="submit" ng-click="addForm.$valid && $ctrl.saveExperiment($event)">
+            <i class="fa fa-plus"></i> Add Experiment
+          </button>
         </div>
       </div>
     </form>
@@ -372,7 +374,9 @@
           </table>
           <!-- Update Exp Btn -->
           <div class="text-right">
-            <button class="btn btn-add" type="submit" ng-click="editForm.$valid && $ctrl.saveEditExperiment($event)" style="width:18%;">Update</button>
+            <button class="btn btn-add" type="submit" ng-click="editForm.$valid && $ctrl.saveEditExperiment($event)">
+              Update
+            </button>
           </div>
         </div>
       </form>

--- a/designsafe/static/scripts/projects/components/manage-field-recon/collections/manage-field-recon-collections.component.html
+++ b/designsafe/static/scripts/projects/components/manage-field-recon/collections/manage-field-recon-collections.component.html
@@ -439,20 +439,22 @@
             </div>
             <div ng-if="$ctrl.form.collectionType">
                 <div class="text-right">
-                    <button class="btn btn-add"
-                            type="submit"
-                            data-ng-click="addForm.$valid &&
-                                            $ctrl.updateCollection($event)"
-                            data-ng-if="$ctrl.data.editCollection"
-                            style="width:18%;">Update</button>
+                    <button 
+                        class="btn btn-add"
+                        type="submit"
+                        data-ng-click="addForm.$valid && $ctrl.updateCollection($event)"
+                        data-ng-if="$ctrl.data.editCollection"
+                    >
+                        Update
+                    </button>
                 </div>
                 <div class="text-right">
-                    <button class="btn btn-add"
-                            data-ng-click="addForm.$valid &&
-                                            $ctrl.saveCollection($event)"
-                            data-ng-if="!$ctrl.data.editCollection"
-                            style="width:18%;"
-                            type="submit">
+                    <button
+                        class="btn btn-add"
+                        data-ng-click="addForm.$valid && $ctrl.saveCollection($event)"
+                        data-ng-if="!$ctrl.data.editCollection"
+                        type="submit"
+                    >
                         <i class="fa fa-plus">&nbsp;</i>
                         Add Collection
                     </button>

--- a/designsafe/static/scripts/projects/components/manage-field-recon/missions/manage-field-recon-missions.component.html
+++ b/designsafe/static/scripts/projects/components/manage-field-recon/missions/manage-field-recon-missions.component.html
@@ -196,14 +196,16 @@
                         type="submit"
                         data-ng-if="$ctrl.data.editMission"
                         data-ng-click="addForm.$valid && $ctrl.updateMission($event)"
-                        style="width:18%;">Update</button>
+                >
+                    Update
+                </button>
             </div>
             <div class="text-right">
             <button class="btn btn-add"
                     data-ng-click="addForm.$valid && $ctrl.saveMission($event)"
                     data-ng-if="!$ctrl.data.editMission"
-                    style="width:18%;"
-                    type="submit">
+                    type="submit"
+            >
                 <i class="fa fa-plus">&nbsp;</i>
                 Add Mission
             </button>

--- a/designsafe/static/scripts/projects/components/manage-hybrid-simulations/manage-hybrid-simulations.component.html
+++ b/designsafe/static/scripts/projects/components/manage-hybrid-simulations/manage-hybrid-simulations.component.html
@@ -77,7 +77,9 @@
         </div>
         <!-- Add HybSim Btn -->
         <div class="text-right">
-          <button class="btn btn-add" type="submit" ng-click="addForm.$valid && $ctrl.saveSimulation($event)" style="width:18%;"><i class="fa fa-plus"></i> Add Hybrid Sim</button>
+          <button class="btn btn-add" type="submit" ng-click="addForm.$valid && $ctrl.saveSimulation($event)">
+            <i class="fa fa-plus"></i> Add Hybrid Sim
+          </button>
         </div>
       </div>
     </form>
@@ -187,7 +189,9 @@
           </table>
           <!-- Update HybSim Btn -->
           <div class="text-right">
-            <button class="btn btn-add" type="submit" ng-click="editForm.$valid && $ctrl.saveEditSimulation($event)" style="width:18%;">Update</button>
+            <button class="btn btn-add" type="submit" ng-click="editForm.$valid && $ctrl.saveEditSimulation($event)">
+              Update
+            </button>
           </div>
         </div>
       </form>

--- a/designsafe/static/scripts/projects/components/manage-simulations/manage-simulations.component.html
+++ b/designsafe/static/scripts/projects/components/manage-simulations/manage-simulations.component.html
@@ -77,7 +77,9 @@
         </div>
         <!-- Add Sim Btn -->
         <div class="text-right">
-          <button class="btn btn-add" type="submit" ng-click="addForm.$valid && $ctrl.saveSimulation($event)" style="width:18%;"><i class="fa fa-plus"></i> Add Simulation</button>
+          <button class="btn btn-add" type="submit" ng-click="addForm.$valid && $ctrl.saveSimulation($event)">
+            <i class="fa fa-plus"></i> Add Simulation
+          </button>
         </div>
       </div>
     </form>
@@ -187,7 +189,9 @@
           </table>
           <!-- Update Sim Btn -->
           <div class="text-right">
-            <button class="btn btn-add" type="submit" ng-click="editForm.$valid && $ctrl.saveEditSimulation($event)" style="width:18%;">Update</button>
+            <button class="btn btn-add" type="submit" ng-click="editForm.$valid && $ctrl.saveEditSimulation($event)">
+              Update
+            </button>
           </div>
         </div>
       </form>

--- a/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css
+++ b/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css
@@ -1333,13 +1333,10 @@ mark,
   padding-bottom: 10px;
 }
 .prj-agree-select {
-  padding-top: 15px;
-  display:inline-block;
-  width:75%;
-}
-.prj-agree-publish {
-  display:inline-block;
-  width:24%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
 }
 .overview-body {
   padding-bottom: 40px;


### PR DESCRIPTION
**Issue:**
Added a loading spinner and adjusted the publication submission modal so that users could not publish their project if it was already published.
Fixed some smashed submission buttons for entity modals and publication submission modal
**To Test:**

- Within each project (except other) in the **Curation Directory** we have modals for adding experiments, collections, simulations etc. The green buttons there appear smashed to one side currently. You should see that those are no longer smashed.

- If you would like to test the publication submission modal you can use any of the "walk" projects (if you don't see them I can invite you to them). Go to publication preview>continue>select a publishable entity (there should be at least one in each set) continue all the way down the pipeline to select a license> click the "Request DOI and Publish" button... You should see either a loading spinner or an instantly loaded modal (any sort of visible change or transition within the modal aside from the loading spinner is not supposed to happen. (PS do not click the publish button)