### PR TITLE
task/DES-1624: Add index for legacy NEES files

### DIFF
--- a/designsafe/apps/data/models/elasticsearch.py
+++ b/designsafe/apps/data/models/elasticsearch.py
@@ -116,6 +116,28 @@ class IndexedFile(Document):
     class Meta:
         dynamic = MetaField('strict')
 
+    
+class IndexedFileLegacy(Document):
+    name = Text(analyzer=file_analyzer, fields={
+        '_exact': Keyword(),
+        '_pattern': Text(analyzer=file_pattern_analyzer),
+        '_reverse': Text(analyzer=reverse_file_analyzer)
+    })
+    path = Text(fields={
+        '_exact': Keyword(),
+        '_path': Text(analyzer=path_analyzer)
+    })
+    deleted = Boolean()
+    length = Long()
+    format = Keyword()
+    type = Keyword()
+    systemId = Keyword()
+
+    class Index:
+        name = settings.ES_INDICES['files_legacy']['alias']
+    class Meta:
+        dynamic = MetaField('strict')
+
 @python_2_unicode_compatible
 class IndexedPublication(Document):
     analysisList = Nested(properties={

--- a/designsafe/settings/elasticsearch_settings.py
+++ b/designsafe/settings/elasticsearch_settings.py
@@ -33,6 +33,11 @@ ES_INDICES = {
         'document': 'designsafe.apps.data.models.elasticsearch.IndexedFile',
         'kwargs': {'number_of_shards': 3}
     },
+    'files_legacy': {
+        'alias': ES_INDEX_PREFIX.format('files-legacy'),
+        'document': 'designsafe.apps.data.models.elasticsearch.IndexedFileLegacy',
+        'kwargs': {'number_of_shards': 3}
+    },
     'publications': {
         'alias': ES_INDEX_PREFIX.format('publications'),
         'document': 'designsafe.apps.data.models.elasticsearch.IndexedPublication',


### PR DESCRIPTION
Legacy NEES files were indexed using their own schema and need their own index now. 
The call to `_reindex` should be formatted: 

```
 {
  "source": {
    "remote": {
      "host": "http://designsafe-es01.tacc.utexas.edu:9200"
    },
    "index": "des-files",
    "query": {"match": {"systemId": "nees.public"}}
  },
  "dest": {
    "index": "designsafe-production-files-legacy"
  }
}
```