### PR TITLE
Bug/DES-1627 - Edit project modal fix for awards, works, and data type

### DIFF
--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.html
@@ -53,7 +53,9 @@
                 <td ng-if="!$first"></td>
                 <td><strong>{{ award.name }} - {{ award.number }}</strong></td>
             </tr>
-            <tr ng-repeat="work in $ctrl.browser.project.value.associatedProjects | orderBy:'order' track by $index">
+            <tr ng-if="!$ctrl.relatedWorkEmpty()"
+                ng-repeat="work in $ctrl.browser.project.value.associatedProjects | orderBy:'order' track by $index"
+            >
                 <td ng-if="$first">Related Work</td>
                 <td ng-if="!$first"></td>
                 <td><strong><a href="{{ work.href }}" rel="noopener noreferrer" target=”_blank”>{{ work.title }}</a></strong></td>

--- a/designsafe/static/scripts/data-depot/components/published/published-view.component.js
+++ b/designsafe/static/scripts/data-depot/components/published/published-view.component.js
@@ -335,7 +335,7 @@ class PublishedViewCtrl {
     relatedWorkEmpty() {
         const relatedWork = this.browser.project.value.associatedProjects.slice();
         const emptyArray = relatedWork.length === 0;
-        const emptyListing = isEqual(relatedWork.shift(),{ order: 0, title: '' });
+        const emptyListing = isEqual(relatedWork.shift(),{ order: 0, title: '', href: ''});
         return emptyArray || emptyListing;
     }
 

--- a/designsafe/static/scripts/projects/components/edit-project/edit-project.component.html
+++ b/designsafe/static/scripts/projects/components/edit-project/edit-project.component.html
@@ -300,9 +300,7 @@
                     </span>
                 </label>
                 <div>
-                    <select name="mySelect" 
-                            id="mySelect"
-                            ng-options="type as type for type in $ctrl.otherTypes"
+                    <select ng-options="type as type for type in $ctrl.otherTypes"
                             ng-model="$ctrl.form.dataType"
                             required
                     >

--- a/designsafe/static/scripts/projects/components/edit-project/edit-project.component.html
+++ b/designsafe/static/scripts/projects/components/edit-project/edit-project.component.html
@@ -290,19 +290,29 @@
         <div ng-if="$ctrl.form.uuid && $ctrl.form.projectType">
             <!-- Project Other Data Types -->
             <div class="form-group" style="width:100%; display:inline-block;" ng-if="$ctrl.project.value.projectType === 'other'">
-                <label for="id-project-data-types">
-                    <div class="label-form">
-                        <div>
-                            <span class="label-form-name">Data Type(s)</span>
-                        </div>
-                        <span class="label-form-desc">
-                            The nature or genre of the content.
-                        </span>
+                <label class="label-form">
+                    <div>
+                        <span class="label-form-name">Data Type(s)</span>
+                        <span class="label label-danger">Required</span>
                     </div>
+                    <span class="label-form-desc">
+                        The nature or genre of the content.
+                    </span>
                 </label>
                 <div>
-                    <select ng-model="$ctrl.form.dataType" ng-options="type for type in $ctrl.otherTypes"></select>
-                    <input class="project-form-input" ng-if="$ctrl.form.dataType === 'Custom'" ng-model="$ctrl.form.dataTypeCustom">
+                    <select name="mySelect" 
+                            id="mySelect"
+                            ng-options="type as type for type in $ctrl.otherTypes"
+                            ng-model="$ctrl.form.dataType"
+                            required
+                    >
+                        <option value="" disabled selected>--Data Type--</option>
+                    </select>
+                    <input type="text"
+                           class="project-form-input"
+                           ng-model="$ctrl.form.dataTypeCustom"
+                           ng-if="$ctrl.form.dataType === 'Custom'"
+                    />
                 </div>
             </div>
             <!-- Project Awards -->
@@ -353,12 +363,12 @@
                 </table>
                 <div>
                     <button class="btn-project-add-rm"
-                            ng-click="$ctrl.addField($ctrl.form.awardNumber)">
+                            ng-click="$ctrl.addAwardField($ctrl.form.awardNumber)">
                             &#x2b; Add another Award
                     </button>
                     |
                     <button class="btn-project-add-rm"
-                            ng-click="$ctrl.dropField($ctrl.form.awardNumber)"
+                            ng-click="$ctrl.dropField($ctrl.form.awardNumber, true)"
                             ng-disabled="$ctrl.checkEmpty($ctrl.form.awardNumber)">
                             &#x2212; Remove Award
                     </button>
@@ -412,7 +422,7 @@
                 </table>
                 <div>
                     <button class="btn-project-add-rm"
-                            ng-click="$ctrl.addWorkField($ctrl.form.associatedProjects, true)">
+                            ng-click="$ctrl.addWorkField($ctrl.form.associatedProjects)">
                             &#x2b; Add another Related Work
                     </button>
                     |

--- a/designsafe/static/scripts/projects/components/edit-project/edit-project.component.js
+++ b/designsafe/static/scripts/projects/components/edit-project/edit-project.component.js
@@ -96,7 +96,7 @@ class EditProjectCtrl {
             this.form.description = this.project.value.description || '';
             this.form.experimentalFacility = this.project.value.experimentalFacility || '';
             this.form.keywords = this.project.value.keywords || '';
-            this.form.dataType = this.project.value.dataType || '';
+            this.form.dataType = this.project.value.dataType || null;
             this.form.fileTags = this.project.value.fileTags || [];
             if (this.form.dataType && this.otherTypes.indexOf(this.form.dataType) === -1) {
                 this.form.dataTypeCustom = this.form.dataType;
@@ -386,10 +386,15 @@ class EditProjectCtrl {
             i = this.form.awardNumber.length;
             this.form.awardPrune = [];
             while(i--) {
+                console.log(i);
                 if (typeof this.form.awardNumber[i] === 'undefined') {
                     this.form.awardNumber.splice(i, 1);
                 } else if (typeof this.form.awardNumber[i].name === 'undefined' &&
                            typeof this.form.awardNumber[i].number === 'undefined' ) {
+                    this.form.awardNumber.splice(i, 1);
+                } else if (this.form.awardNumber[i].name === "" &&
+                           this.form.awardNumber[i].number === "" ) {
+                    console.log('this');
                     this.form.awardNumber.splice(i, 1);
                 } else {
                     this.form.awardPrune.push(this.form.awardNumber[i]);
@@ -402,6 +407,9 @@ class EditProjectCtrl {
                     this.form.associatedProjects.splice(i, 1);
                 } else if (typeof this.form.associatedProjects[i].title === 'undefined' &&
                            typeof this.form.associatedProjects[i].href === 'undefined' ) {
+                    this.form.associatedProjects.splice(i, 1);
+                } else if (this.form.associatedProjects[i].title === '' &&
+                           this.form.associatedProjects[i].href === '' ) {
                     this.form.associatedProjects.splice(i, 1);
                 } else {
                     this.form.workPrune.push(this.form.associatedProjects[i]);

--- a/designsafe/static/scripts/projects/components/edit-project/edit-project.component.js
+++ b/designsafe/static/scripts/projects/components/edit-project/edit-project.component.js
@@ -386,7 +386,6 @@ class EditProjectCtrl {
             i = this.form.awardNumber.length;
             this.form.awardPrune = [];
             while(i--) {
-                console.log(i);
                 if (typeof this.form.awardNumber[i] === 'undefined') {
                     this.form.awardNumber.splice(i, 1);
                 } else if (typeof this.form.awardNumber[i].name === 'undefined' &&
@@ -394,7 +393,6 @@ class EditProjectCtrl {
                     this.form.awardNumber.splice(i, 1);
                 } else if (this.form.awardNumber[i].name === "" &&
                            this.form.awardNumber[i].number === "" ) {
-                    console.log('this');
                     this.form.awardNumber.splice(i, 1);
                 } else {
                     this.form.awardPrune.push(this.form.awardNumber[i]);


### PR DESCRIPTION
This PR will fix bugs with the awards, related works, and data type (other projects) fields. There were several issues related to these fields:
- Could not add an additional awards field in the modal
- Could not remove awards/related works fields by deleting their contents (not using the remove button)
- Data Type for "Other" project types was not required and causing issues with the publication listing.
- Related Works field was not hiding properly when there were no related works for publications