### PR TITLE
Task/DES-1540 & Bug/DES-1597: Author Modal Fixes

### DIFF
--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.component.js
@@ -14,18 +14,18 @@ class AuthorInformationModalCtrl {
         this.institution = this.author.inst;
         this.username = this.author.name;
         this.loading = true;
-        this.getOrcid(this.username, this);
+        this.getOrcid(this.username);
     }
 
-    getOrcid(username, self) {
-        return self.UserService.get(username)
+    getOrcid(username) {
+        return this.UserService.get(username)
             .then((res) => {
                 if (res.orcid_id) {
-                    self.orcid = res.orcid_id;
+                    this.orcid = res.orcid_id;
                 }
             })
             .finally(() => {
-                self.loading = false;
+                this.loading = false;
             });
     }
 

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.component.js
@@ -1,18 +1,32 @@
 import AuthorInformationModalTemplate from './author-information-modal.template.html';
 
 class AuthorInformationModalCtrl {
-    constructor() { }
+    constructor(UserService) {
+        'ngInject';
+        this.UserService = UserService;
+    }
 
-    $onInit() { 
+    $onInit() {
         this.author = this.resolve.author;
         this.first = this.author.fname;
         this.last = this.author.lname;
         this.email = this.author.email;
         this.institution = this.author.inst;
         this.username = this.author.name;
-        if (this.author.orcid) {
-            this.orcid = this.author.orcid;
-        }
+        this.loading = true;
+        this.getOrcid(this.username, this);
+    }
+
+    getOrcid(username, self) {
+        return self.UserService.get(username)
+            .then((res) => {
+                if (res.orcid_id) {
+                    self.orcid = res.orcid_id;
+                }
+            })
+            .finally(() => {
+                self.loading = false;
+            });
     }
 
     close() {
@@ -27,6 +41,6 @@ export const AuthorInformationModalComponent = {
     bindings: {
         resolve: '<',
         close: '&',
-        dismiss: '&'
+        dismiss: '&',
     },
 };

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.template.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.template.html
@@ -3,7 +3,10 @@
     <strong ng-click="$ctrl.close()" class="fa fa-times"></strong>
 </div>
 <div class="modal-body">
-    <table style="width: 95%">
+    <div data-ng-if="$ctrl.loading">
+        <i class="fa fa-spinner fa-spin">&nbsp;</i> Loading ...
+    </div>
+    <table ng-if="!$ctrl.loading" style="width: 95%">
         <tbody>
             <tr>
                 <td style="width: 45%"><p>Name</p></td>

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
@@ -188,7 +188,7 @@
                                 <div class="entity-meta-data" data-ng-if="mission.value.authors.length">
                                     <span ng-if="$ctrl.readOnly">
                                         <span ng-repeat="author in $ctrl.sortAuthors(mission.authors) | filter: { authorship: true }">
-                                            <a href="#" ng-click="$ctrl.showAuthor(author)">{{ author.lname }}, {{ author.fname }}</a><span ng-if="!$last">;</span>
+                                            <a href="javascript:;" ng-click="$ctrl.showAuthor(author)">{{ author.lname }}, {{ author.fname }}</a><span ng-if="!$last">;</span>
                                         </span>
                                     </span>
                                     <span ng-if="!$ctrl.readOnly">
@@ -288,7 +288,7 @@
                                 <div class="entity-meta-data" data-ng-if="mission.value.authors.length">
                                     <span ng-if="$ctrl.readOnly">
                                         <span ng-repeat="author in mission.authors | filter: { authorship: true }">
-                                            <a href="#" ng-click="$ctrl.showAuthor(author)">{{ author.lname }}, {{ author.fname }}</a><span ng-if="!$last">;</span>
+                                            <a href="javascript:;" ng-click="$ctrl.showAuthor(author)">{{ author.lname }}, {{ author.fname }}</a><span ng-if="!$last">;</span>
                                         </span>
                                     </span>
                                     <span ng-if="!$ctrl.readOnly">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.js
@@ -239,17 +239,12 @@ class PublicationPreviewFieldReconCtrl {
     }
 
     showAuthor(author) {
-        this.UserService.get(author.name).then((res) => {
-            if (res.orcid_id) {
-                author.orcid = res.orcid_id;
-            }
-            this.$uibModal.open({
-                component: 'authorInformationModal',
-                resolve: {
-                    author
-                },
-                size: 'author'
-            });
+        this.$uibModal.open({
+            component: 'authorInformationModal',
+            resolve: {
+                author,
+            },
+            size: 'author'
         });
     }
 

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
@@ -178,7 +178,7 @@
                         <div class="entity-meta-data">
                             <span ng-if="$ctrl.readOnly">
                                 <span ng-repeat="author in $ctrl.sortAuthors(hybsim.authors) | filter: { authorship: true }">
-                                    <a href="#" ng-click="$ctrl.showAuthor(author)">{{ author.lname }}, {{ author.fname }}</a><span ng-if="!$last">;</span>
+                                    <a href="javascript:;" ng-click="$ctrl.showAuthor(author)">{{ author.lname }}, {{ author.fname }}</a><span ng-if="!$last">;</span>
                                 </span>
                             </span>
                             <span ng-if="!$ctrl.readOnly">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.js
@@ -214,6 +214,17 @@ class PublicationPreviewHybSimCtrl {
             size: 'lg'
         });
     }
+
+    showAuthor(author) {
+        this.$uibModal.open({
+            component: 'authorInformationModal',
+            resolve: {
+                author,
+            },
+            size: 'author',
+        });
+    }
+
 }
 
 export const PublicationPreviewHybSimComponent = {

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.js
@@ -121,6 +121,17 @@ class PublicationPreviewOtherCtrl {
             size: 'lg'
         });
     }
+
+    showAuthor(author) {
+        this.$uibModal.open({
+            component: 'authorInformationModal',
+            resolve: {
+                author,
+            },
+            size: 'author',
+        });
+    }
+
 }
 
 PublicationPreviewOtherCtrl.$inject = ['ProjectEntitiesService', 'ProjectService', 'DataBrowserService', 'FileListing', '$uibModal', '$state', '$q'];

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
@@ -189,7 +189,7 @@
                         <div class="entity-meta-data">
                             <span ng-if="$ctrl.readOnly">
                                 <span ng-repeat="author in $ctrl.sortAuthors(simulation.authors) | filter: { authorship: true }">
-                                    <a href="#" ng-click="$ctrl.showAuthor(author)">{{ author.lname }}, {{ author.fname }}</a><span ng-if="!$last">;</span>
+                                    <a href="javascript:;" ng-click="$ctrl.showAuthor(author)">{{ author.lname }}, {{ author.fname }}</a><span ng-if="!$last">;</span>
                                 </span>
                             </span>
                             <span ng-if="!$ctrl.readOnly">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.js
@@ -212,6 +212,17 @@ class PublicationPreviewSimCtrl {
             size: 'lg'
         });
     }
+
+    showAuthor(author) {
+        this.$uibModal.open({
+            component: 'authorInformationModal',
+            resolve: {
+                author,
+            },
+            size: 'author',
+        });
+    }
+
 }
 
 PublicationPreviewSimCtrl.$inject = ['ProjectEntitiesService', 'ProjectService', 'DataBrowserService', 'FileListing', '$uibModal', '$state', '$q'];

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
@@ -189,7 +189,7 @@
                         <div class="entity-meta-data">
                             <span ng-if="$ctrl.readOnly">
                                 <span ng-repeat="author in $ctrl.sortAuthors(experiment.authors) | filter: { authorship: true }">
-                                    <a href="#" ng-click="$ctrl.showAuthor(author)">{{ author.lname }}, {{ author.fname }}</a><span ng-if="!$last">;</span> 
+                                    <a href="javascript:;" ng-click="$ctrl.showAuthor(author)">{{ author.lname }}, {{ author.fname }}</a><span ng-if="!$last">;</span> 
                                 </span>
                             </span>
                             <span ng-if="!$ctrl.readOnly">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.js
@@ -240,6 +240,17 @@ class PublicationPreviewCtrl {
             size: 'lg'
         });
     }
+
+    showAuthor(author) {
+        this.$uibModal.open({
+            component: 'authorInformationModal',
+            resolve: {
+                author,
+            },
+            size: 'author',
+        });
+    }
+
 }
 
 PublicationPreviewCtrl.$inject = ['ProjectEntitiesService', 'ProjectService', 'DataBrowserService', 'FileListing', '$uibModal', '$state', '$q'];

--- a/designsafe/static/scripts/data-depot/components/published/published-view.component.js
+++ b/designsafe/static/scripts/data-depot/components/published/published-view.component.js
@@ -291,17 +291,12 @@ class PublishedViewCtrl {
     }
 
     showAuthor(author) {
-        this.UserService.get(author.name).then((res) => {
-            if (res.orcid_id) {
-                author.orcid = res.orcid_id;
-            }
-            this.$uibModal.open({
-                component: 'authorInformationModal',
-                resolve: {
-                    author
-                },
-                size: 'author'
-            });
+        this.$uibModal.open({
+            component: 'authorInformationModal',
+            resolve: {
+                author,
+            },
+            size: 'author',
         });
     }
 


### PR DESCRIPTION
This PR fixes two bugs.
1) DES-1540: The `author` data is passed in to the modal component and then the orcid id is fetched from the back-end. Prior to this, the modal was only opened once the `UserService` promise was resolved.
2) DES-1597: Since the modal is triggered by an `ng-click` directive with '#' inside the href tag, the page was scrolling to the top. `href="javascript;;"` keeps the tag valid and stops the issue