### PR TITLE
Bug/DES-1551: Delete button on filter in recon portal does not appear to work

### DIFF
--- a/designsafe/static/scripts/rapid/controllers/rapid-main-ctrl.js
+++ b/designsafe/static/scripts/rapid/controllers/rapid-main-ctrl.js
@@ -89,7 +89,4 @@ export default class RapidMainCtrl {
         this.search();
     }
 
-    clear_filter_text() {
-        this.filter_options.search_text = '';
-    }
 }

--- a/designsafe/static/scripts/rapid/controllers/rapid-main-ctrl.js
+++ b/designsafe/static/scripts/rapid/controllers/rapid-main-ctrl.js
@@ -88,4 +88,8 @@ export default class RapidMainCtrl {
         this.filter_options = {};
         this.search();
     }
+
+    clear_filter_text() {
+        this.filter_options.search_text = '';
+    }
 }

--- a/designsafe/static/scripts/rapid/html/index.html
+++ b/designsafe/static/scripts/rapid/html/index.html
@@ -31,7 +31,7 @@
           <div class="input-group">
             <input type="text" class="form-control" ng-model="vm.filter_options.search_text" ng-change="vm.search()"></input>
             <span class="input-group-btn">
-              <button class="btn btn-default"> <i class="fa fa-trash"></i></button>
+              <button class="btn btn-default"> <i class="fa fa-trash" ng-click="vm.clear_filter_text()"></i></button>
             </span>
           </div>
         </div>

--- a/designsafe/static/scripts/rapid/html/index.html
+++ b/designsafe/static/scripts/rapid/html/index.html
@@ -31,7 +31,7 @@
           <div class="input-group">
             <input type="text" class="form-control" ng-model="vm.filter_options.search_text" ng-change="vm.search()"></input>
             <span class="input-group-btn">
-              <button class="btn btn-default"> <i class="fa fa-trash" ng-click="vm.clear_filter_text()"></i></button>
+              <button class="btn btn-default"> <i class="fa fa-trash" ng-click="vm.clear_filters()"></i></button>
             </span>
           </div>
         </div>


### PR DESCRIPTION
This PR adds a method to clear filter text on click of the trash icon. It can be tested locally [here](https://designsafe.dev/recon-portal/).