### PR TITLE
removing call to custom script from rapid initial migration

### DIFF
--- a/designsafe/apps/rapid/migrations/0001_initial.py
+++ b/designsafe/apps/rapid/migrations/0001_initial.py
@@ -32,5 +32,4 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(add_rapid_event_types)
     ]


### PR DESCRIPTION
Rapid initial migration failing locally, and is unneeded, so removing the call to custom script form the migration.