### PR TITLE
Task/DES-1632: Create meta tags for publications with multiple DOIs

### DIFF
--- a/designsafe/apps/data/templates/data/data_depot.html
+++ b/designsafe/apps/data/templates/data/data_depot.html
@@ -41,6 +41,14 @@
     <meta name="citation_author_institution" content="{{ author.inst }}">{% endfor %}
     {% endfor %}{% endif %}
 
+    {% if reports %}<!-- Report Citation Tags -->{% for report in reports %}
+    <meta name="citation_title" content="{{ report.value.title }}">
+    <meta name="citation_doi" content="{{ report.doi }}">
+    <meta name="citation_description" content="{{ report.value.description }}">
+    {% for author in mission.authors %}<meta name="citation_author" content="{{ author.lname }}, {{ author.fname }}">
+    <meta name="citation_author_institution" content="{{ author.inst }}">{% endfor %}
+    {% endfor %}{% endif %}
+
     {% if simulations %}<!-- Simulation Citation Tags -->{% for simulation in simulations %}
     <meta name="citation_title" content="{{ simulation.value.title }}">
     <meta name="citation_doi" content="{{ simulation.doi }}">

--- a/designsafe/apps/data/views/base.py
+++ b/designsafe/apps/data/views/base.py
@@ -231,6 +231,7 @@ class DataDepotPublishedView(TemplateView):
         context['description'] = pub.project.value.description
         context['experiments'] = getattr(pub, 'experimentsList', [])
         context['missions'] = getattr(pub, 'missions', [])
+        context['reports'] = getattr(pub, 'reports', [])
         context['simulations'] = getattr(pub, 'simulations', [])
         context['hybrid_simulations'] = getattr(pub, 'hybrid_simulations',[])
 

--- a/designsafe/static/scripts/data-depot/components/nees-publication/nees-publication.component.js
+++ b/designsafe/static/scripts/data-depot/components/nees-publication/nees-publication.component.js
@@ -1,3 +1,4 @@
+import { has } from 'underscore';
 class NeesPublicationCtrl {
     constructor($stateParams, $state, PublishedService, DataBrowserService, $uibModal) {
         'ngInject';
@@ -30,6 +31,10 @@ class NeesPublicationCtrl {
         this.projectName = this.$stateParams.filePath.replace(/^\/+/, '').split('.')[0];
         this.PublishedService.getNeesPublished(this.projectName).then((res) => {
             this.project = res.data;
+            if (has(res.data, 'metadata')) {
+                this.PublishedService.updateNeesMetatags(res.data.metadata);
+            }
+            
         });
         this.browser = this.DataBrowserService.state();
         this.DataBrowserService.browse({ system: 'nees.public', path: this.$stateParams.filePath });

--- a/designsafe/static/scripts/data-depot/index.js
+++ b/designsafe/static/scripts/data-depot/index.js
@@ -898,25 +898,41 @@ function config(
             },
             onExit: ($window) => {
                 'ngInject';
-                [
-                    'description', 'citation_title', 'citation_publication_date',
-                    'citation_doi', 'citation_abstract_html_url', 'DC.identifier', 
-                    'DC.creator', 'DC.title', 'DC.date'
-                ].forEach(
+                const projectLevelTags = [
+                    'description',
+                    'citation_title',
+                    'citation_publication_date',
+                    'citation_doi',
+                    'citation_abstract_html_url',
+                    'DC.identifier',
+                    'DC.creator',
+                    'DC.title',
+                    'DC.date',
+                    'authors'
+                ];
+                projectLevelTags.forEach(
                     (name) => {
                         let el = $window.document.getElementsByName(name);
-                        el[0].content = '';
-                    }
-                );
-                ['citation_author', 'citation_author_institution',
-                    'citation_keywords'].forEach(
-                    (name) => {
-                        let els = $window.document.getElementsByName(name);
-                        while(els[0]){
-                            els[0].parentNode.removeChild(els[0]);
+                        if (el) {
+                            el[0].content = '';
+                            // citation_doi is also an entity tag
+                            while(el[1]) el[1].parentNode.removeChild(el[1]);
                         }
+                        
                     }
                 );
+                const entityTags = [
+                    'citation_author',
+                    'citation_author_institution',
+                    'citation_description',
+                    'citation_keywords',
+                ];
+                entityTags.forEach((name) => {
+                    let els = $window.document.getElementsByName(name);
+                    while (els[0]) {
+                        els[0].parentNode.removeChild(els[0]);
+                    }
+                });
             },
             resolve: {
                 listing: ($stateParams, DataBrowserService)=>{

--- a/designsafe/static/scripts/data-depot/index.js
+++ b/designsafe/static/scripts/data-depot/index.js
@@ -904,6 +904,7 @@ function config(
                     'citation_publication_date',
                     'citation_doi',
                     'citation_abstract_html_url',
+                    'identifier',
                     'DC.identifier',
                     'DC.creator',
                     'DC.title',

--- a/designsafe/static/scripts/data-depot/services/published.service.js
+++ b/designsafe/static/scripts/data-depot/services/published.service.js
@@ -18,7 +18,6 @@ export class PublishedService {
 
     updateNeesMetatags(data) {
         const header = this.$window.document.getElementsByTagName('head')[0];
-        console.log(data);
         // Project Level
         // Title
         this.$window.document.getElementsByName('citation_title')[0].content = data.project.title || '';

--- a/designsafe/static/scripts/data-depot/services/published.service.js
+++ b/designsafe/static/scripts/data-depot/services/published.service.js
@@ -16,8 +16,47 @@ export class PublishedService {
         return this.$http.get('/api/projects/nees-publication/' + neesId);
     }
 
+    updateNeesMetatags(data) {
+        const header = this.$window.document.getElementsByTagName('head')[0];
+        console.log(data);
+        // Project Level
+        // Title
+        this.$window.document.getElementsByName('citation_title')[0].content = data.project.title || '';
+        this.$window.document.getElementsByName('DC.title')[0].content = data.project.title || '';
+
+        // Description
+        const descTag = this.$window.document.createElement('meta');
+        descTag.name = 'citation_description';
+        descTag.content = data.project.description;
+        header.appendChild(descTag);
+        // Authors - PI
+        const prjAuthors = data.project.pis || [];
+        prjAuthors.forEach((author) => {
+            const authorTag = this.$window.document.createElement('meta');
+            authorTag.name = 'citation_author';
+            authorTag.content = `${author.lastName}, ${author.firstName}`;
+            header.appendChild(authorTag);
+        });
+
+
+        // Experiments
+        const experiments = data.experiments || [];
+        experiments.forEach((exp) => {
+            const titleTag = this.$window.document.createElement('meta');
+            titleTag.name = 'citation_title';
+            titleTag.content = exp.title || '';
+            header.appendChild(titleTag);
+
+            const descTag = this.$window.document.createElement('meta');
+            descTag.name = 'citation_description';
+            descTag.content = exp.description || '';
+            header.appendChild(descTag);
+        });
+
+    }
+    
     updateHeaderMetadata(projId, resp) {
-        this.$window.document.title = resp.data.project.value.title + " | DesignSafe-CI";
+        this.$window.document.title = resp.data.project.value.title + ' | DesignSafe-CI';
         this.$window.document.getElementsByName('keywords')[0].content = resp.data.project.value.keywords;
         this.$window.document.getElementsByName('description')[0].content = resp.data.project.value.description;
 
@@ -128,19 +167,19 @@ export class PublishedService {
             // Title
             const entTitleTag = this.$window.document.createElement('meta');
             entTitleTag.name = 'citation_title';
-            entTitleTag.content = entity.value.title;
+            entTitleTag.content = entity.value.title || '';
             this.$window.document.getElementsByTagName('head')[0].appendChild(entTitleTag);
            
             // Doi
             const entDoiTag = this.$window.document.createElement('meta');
             entDoiTag.name = 'citation_doi';
-            entDoiTag.content = entity.doi;
+            entDoiTag.content = entity.doi || '';
             this.$window.document.getElementsByTagName('head')[0].appendChild(entDoiTag);
 
             // Description
             const entDescTag = this.$window.document.createElement('meta');
             entDescTag.name = 'citation_description';
-            entDescTag.content = entity.value.description;
+            entDescTag.content = entity.value.description || '';
             this.$window.document.getElementsByTagName('head')[0].appendChild(entDescTag);
 
             // Authors (with Institutions)
@@ -159,5 +198,6 @@ export class PublishedService {
                     this.$window.document.getElementsByTagName('head')[0].appendChild(authorInstTag);
                 });
         });
+        
     }
 }


### PR DESCRIPTION
In this PR, metatags for project sub entities are populated from the client side (`PublishedService`) and back-end templates. 

From the back-end, Reports were added to the template and on the front-end, metatags can be populated between `ui-router `state changes.