### PR TITLE
Bug/DES-1662 - Fix issue with project file listings overloading agave with requests

### DIFF
--- a/designsafe/static/scripts/data-depot/components/projects/curation-directory/curation-directory.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/curation-directory/curation-directory.component.js
@@ -91,15 +91,15 @@ class CurationDirectoryCtrl {
 
     goPreview() {
         if (this.browser.project.value.projectType === 'experimental') {
-            this.$state.go('projects.preview', {projectId: this.browser.project.uuid, data: this.browser});
+            this.$state.go('projects.preview', {projectId: this.browser.project.uuid});
         } else if (this.browser.project.value.projectType === 'simulation') {
-            this.$state.go('projects.previewSim', {projectId: this.browser.project.uuid, data: this.browser});
+            this.$state.go('projects.previewSim', {projectId: this.browser.project.uuid});
         } else if (this.browser.project.value.projectType === 'hybrid_simulation') {
-            this.$state.go('projects.previewHybSim', {projectId: this.browser.project.uuid, data: this.browser});
+            this.$state.go('projects.previewHybSim', {projectId: this.browser.project.uuid});
         } else if (this.browser.project.value.projectType === 'other') {
-            this.$state.go('projects.previewOther', {projectId: this.browser.project.uuid, data: this.browser});
+            this.$state.go('projects.previewOther', {projectId: this.browser.project.uuid});
         } else if (this.browser.project.value.projectType === 'field_recon') {
-            this.$state.go('projects.previewFieldRecon', {projectId: this.browser.project.uuid, data: this.browser});
+            this.$state.go('projects.previewFieldRecon', {projectId: this.browser.project.uuid});
         }
     }
 

--- a/designsafe/static/scripts/data-depot/components/projects/project-view/project-view.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/project-view/project-view.component.js
@@ -109,25 +109,15 @@ class ProjectViewCtrl {
 
   publicationPreview() {
     if (this.browser.project.value.projectType === 'experimental') {
-      this.$state.go('projects.preview', { projectId: this.browser.project.uuid, data: this.browser}).then(() => {
-        this.checkState();
-      });
+      this.$state.go('projects.preview', { projectId: this.browser.project.uuid});
     } else if (this.browser.project.value.projectType === 'simulation') {
-      this.$state.go('projects.previewSim', { projectId: this.browser.project.uuid, data: this.browser}).then(() => {
-        this.checkState();
-      });
+      this.$state.go('projects.previewSim', { projectId: this.browser.project.uuid});
     } else if (this.browser.project.value.projectType === 'hybrid_simulation') {
-      this.$state.go('projects.previewHybSim', { projectId: this.browser.project.uuid, data: this.browser}).then(() => {
-        this.checkState();
-      });
+      this.$state.go('projects.previewHybSim', {projectId: this.browser.project.uuid});
     } else if (this.browser.project.value.projectType === 'other') {
-      this.$state.go('projects.previewOther', { projectId: this.browser.project.uuid, data: this.browser}).then(() => {
-        this.checkState();
-      });
+      this.$state.go('projects.previewOther', { projectId: this.browser.project.uuid});
     } else if (this.browser.project.value.projectType === 'field_recon') {
-      this.$state.go('projects.previewFieldRecon', { projectId: this.browser.project.uuid, data: this.browser}).then(() => {
-        this.checkState();
-      });
+      this.$state.go('projects.previewFieldRecon', { projectId: this.browser.project.uuid});
     } else {
       this.manageProjectType();
     }

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
@@ -159,7 +159,7 @@
     <div ng-if="$ctrl.ui.fileNav && !$ctrl.ui.loading">
         <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listing" params="$ctrl.fl"></files-listing>
     </div>
-    <div ng-if="!$ctrl.ui.fileNav">
+    <div ng-if="!$ctrl.ui.fileNav && !$ctrl.ui.loading">
         <!-- Root Sets -->
         <!-- <div ng-repeat="mission in $ctrl.ordered($ctrl.browser.project, $ctrl.primaryEnts)"> -->
         <div ng-repeat="mission in $ctrl.orderedPrimary">
@@ -259,7 +259,7 @@
                 </div>
             </div>
             <!-- Missions -->
-            <div ng-if="!$ctrl.ui.fileNav && mission.name == 'designsafe.project.field_recon.mission' && !$ctrl.ui.loading">
+            <div ng-if="!$ctrl.ui.fileNav && !$ctrl.ui.loading && mission.name == 'designsafe.project.field_recon.mission'">
                 <div class="dropdown dropdown-spacer-sm" id="details-{{hybsim.uuid}}">
                     <button class="btn tab-experiment collapsed" data-toggle="collapse" data-target="#data-{{mission.uuid}}" style="width:100%;">
                         <table style="width:100%" id="anchor-{{ mission.uuid }}">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.js
@@ -20,7 +20,6 @@ class PublicationPreviewFieldReconCtrl {
         this.readOnly = this.$state.current.name.indexOf('publishedData') === 0;
         this.projectId = this.ProjectService.resolveParams.projectId;
         this.filePath = this.ProjectService.resolveParams.filePath;
-        this.data = this.ProjectService.resolveParams.data;
         this.ui = {
             fileNav: true,
             loading: true
@@ -47,7 +46,7 @@ class PublicationPreviewFieldReconCtrl {
             this.browser.project = project;
             this.browser.project.appendEntitiesRel(ents);
             this.browser.listing = listing;
-            this.createListing(ents);
+            this.createAbstractListing(ents);
             this.primaryEnts = [].concat(
                 this.browser.project.mission_set || [],
                 this.browser.project.report_set || []
@@ -66,7 +65,14 @@ class PublicationPreviewFieldReconCtrl {
             });
         });
 
-        this.createListing = (entities) => {
+        this.createAbstractListing = (entities) => {
+            /*
+            Create Abstract Listing:
+            Since we need to list x number of files from anywhere within the project's directory,
+            we need to try to list the minimum amount of paths within the project to get the file details.
+            Once we have the listed files we can create the abstracted file listings (this.browser.listings).
+            */
+            this.browser.listings = {};
             this.browser.listing.href = this.$state.href('projects.view.data', {
                 projectId: this.projectId,
                 filePath: this.browser.listing.path,
@@ -80,79 +86,52 @@ class PublicationPreviewFieldReconCtrl {
                 });
                 child.setEntities(this.projectId, entities);
             });
-            if (typeof this.browser.listings === 'undefined') {
-                var allFilePaths = [];
-                this.browser.listings = {};
-                var apiParams = {
-                    fileMgr: 'agave',
-                    baseUrl: '/api/agave/files',
-                    searchState: 'projects.view.data',
+
+            let listingPaths = [];
+            let allPaths = [];
+            entities.forEach((entity) => {
+                this.browser.listings[entity.uuid] = {
+                    name: this.browser.listing.name,
+                    path: this.browser.listing.path,
+                    system: this.browser.listing.system,
+                    trail: this.browser.listing.trail,
+                    children: [],
                 };
-                entities.forEach((entity) => {
-                    this.browser.listings[entity.uuid] = {
-                        name: this.browser.listing.name,
-                        path: this.browser.listing.path,
-                        system: this.browser.listing.system,
-                        trail: this.browser.listing.trail,
-                        children: [],
-                    };
-                    allFilePaths = allFilePaths.concat(entity._filePaths);
-                });
-                this.setFilesDetails = (paths) => {
-                    let filePaths = [...new Set(paths)];
-                    var p = this.$q((resolve, reject) => {
-                        var results = [];
-                        var index = 0;
-                        var size = 5;
-                        var fileCalls = filePaths.map(filePath => {
-                            return this.FileListing.get(
-                                { system: 'project-' + this.browser.project.uuid, path: filePath }, apiParams
-                            ).then((resp) => {
-                                if (!resp) {
-                                    return;
+                allPaths = allPaths.concat(entity._filePaths);
+            });
+            allPaths.forEach((path) => {
+                listingPaths = listingPaths.concat(path.match(`.*\/`)[0]);
+            });
+            let reducedPaths = { files: [...new Set(allPaths)], directories: [...new Set(listingPaths)] };
+
+            this.populateListings = (paths, ents) => {
+                let apiParams = this.DataBrowserService.apiParameters();
+                var dirListings = paths.directories.map((dir) => {
+                    return this.FileListing.get(
+                        { system: 'project-' + this.browser.project.uuid, path: dir },
+                        apiParams
+                    ).then((resp) => {
+                        if (!resp) {
+                            return;
+                        }
+                        let files = resp.children;
+                        ents.forEach((e) => {
+                            files.forEach((f) => {
+                                if (e._filePaths.indexOf(f.path) > -1) {
+                                    f._entities.push(e);
+                                    this.browser.listings[e.uuid].children.push(f);
                                 }
-                                var allEntities = this.browser.project.getAllRelatedObjects();
-                                var entities = allEntities.filter((entity) => {
-                                    return entity._filePaths.includes(resp.path);
-                                });
-                                entities.forEach((entity) => {
-                                    resp._entities.push(entity);
-                                    this.browser.listings[entity.uuid].children.push(resp);
-                                });
-                                return resp;
                             });
                         });
-
-                        var step = () => {
-                            var calls = fileCalls.slice(index, (index += size));
-                            if (calls.length) {
-                                this.$q.all(calls)
-                                    .then((res) => {
-                                        results.concat(res);
-                                        step();
-                                        return res;
-                                    })
-                                    .catch(reject);
-                            } else {
-                                resolve(results);
-                            }
-                        };
-                        step();
+                        return resp;
                     });
-                    return p.then(
-                        (results) => {
-                            this.ui.loading = false;
-                            return results;
-                        },
-                        (err) => {
-                            this.ui.loading = false;
-                            this.browser.ui.error = err;
-                        });
-                };
-                this.setFilesDetails(allFilePaths);
-            } else {
-                this.ui.loading = false;
-            }
+                });
+
+                this.$q.all(dirListings).then(() => {
+                    this.ui.loading = false;
+                });
+            };
+            this.populateListings(reducedPaths, entities);
         };
     }
 
@@ -183,12 +162,11 @@ class PublicationPreviewFieldReconCtrl {
     }
     
     goWork() {
-        this.$state.go('projects.view.data', {projectId: this.browser.project.uuid, data: this.browser});
+        this.$state.go('projects.view.data', {projectId: this.browser.project.uuid});
     }
 
     goCuration() {
-        window.sessionStorage.setItem('projectId', JSON.stringify(this.browser.project.uuid));
-        this.$state.go('projects.curation', {projectId: this.browser.project.uuid, data: this.browser});
+        this.$state.go('projects.curation', {projectId: this.browser.project.uuid});
     }
 
     editProject() {

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
@@ -132,10 +132,7 @@
         </h3>
     </div>
     <!-- Project Reports -->
-    <div ng-hide="$ctrl.ui.loading"
-         ng-repeat="report in $ctrl.browser.project.report_set | orderBy: 'value.title'"
-         ng-if="$ctrl.matchingGroup(hybsim, report)"
-    >
+    <div ng-if="$ctrl.matchingGroup(hybsim, report) && !$ctrl.ui.fileNav && !$ctrl.ui.loading" ng-repeat="report in $ctrl.browser.project.report_set | orderBy: 'value.title'">
         <div class="dropdown dropdown-spacer-sm" id="details-{{report.uuid}}">
             <button class="btn collapsed tab-report" data-toggle="collapse" data-target="#files-{{report.uuid}}" style="width:100%;">
                 <div class="collapse-tab">
@@ -154,7 +151,7 @@
     <div ng-if="$ctrl.ui.fileNav && !$ctrl.ui.loading">
         <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listing" params="$ctrl.fl"></files-listing>
     </div>
-    <div ng-if="!$ctrl.ui.fileNav" ng-hide="$ctrl.ui.loading" ng-repeat="hybsim in $ctrl.browser.project.hybridsimulation_set">
+    <div ng-if="!$ctrl.ui.fileNav && !$ctrl.ui.loading" ng-repeat="hybsim in $ctrl.browser.project.hybridsimulation_set">
         <div class="dropdown dropdown-spacer-sm" id="details-{{hybsim.uuid}}">
             <button class="btn tab-experiment collapsed" data-toggle="collapse" data-target="#data-{{hybsim.uuid}}" style="width:100%;">
                 <div class="collapse-tab">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.js
@@ -20,7 +20,6 @@ class PublicationPreviewHybSimCtrl {
         this.readOnly = this.$state.current.name.indexOf('publishedData') === 0;
         this.projectId = this.ProjectService.resolveParams.projectId;
         this.filePath = this.ProjectService.resolveParams.filePath;
-        this.data = this.ProjectService.resolveParams.data;
         this.ui = {
             fileNav: true,
             loading: true
@@ -32,34 +31,32 @@ class PublicationPreviewHybSimCtrl {
             editTags: false,
         };
 
-        window.sessionStorage.clear();
-
         if (this.filePath === '/') {
             this.ui.fileNav = false;
         }
 
-        if (this.data && this.data.listing.path == this.filePath) {
-            this.browser = this.data;
-            this.ProjectEntitiesService.listEntities({ uuid: this.projectId, name: 'all' }).then((ents) => {
-                this.createListing(ents);
-            });
-        } else {
-            this.$q.all([
-                this.ProjectService.get({ uuid: this.projectId }),
-                this.DataBrowserService.browse(
-                    { system: 'project-' + this.projectId, path: this.filePath },
-                    { query_string: this.$state.params.query_string }
-                ),
-                this.ProjectEntitiesService.listEntities({ uuid: this.projectId, name: 'all' })
-            ]).then(([project, listing, ents]) => {
-                this.browser.project = project;
-                this.browser.project.appendEntitiesRel(ents);
-                this.browser.listing = listing;
-                this.createListing(ents);
-            });
-        }
+        this.$q.all([
+            this.ProjectService.get({ uuid: this.projectId }),
+            this.DataBrowserService.browse(
+                { system: 'project-' + this.projectId, path: this.filePath },
+                { query_string: this.$state.params.query_string }
+            ),
+            this.ProjectEntitiesService.listEntities({ uuid: this.projectId, name: 'all' })
+        ]).then(([project, listing, ents]) => {
+            this.browser.project = project;
+            this.browser.project.appendEntitiesRel(ents);
+            this.browser.listing = listing;
+            this.createAbstractListing(ents);
+        });
 
-        this.createListing = (entities) => {
+        this.createAbstractListing = (entities) => {
+            /*
+            Create Abstract Listing:
+            Since we need to list x number of files from anywhere within the project's directory,
+            we need to try to list the minimum amount of paths within the project to get the file details.
+            Once we have the listed files we can create the abstracted file listings (this.browser.listings).
+            */
+            this.browser.listings = {};
             this.browser.listing.href = this.$state.href('projects.view.data', {
                 projectId: this.projectId,
                 filePath: this.browser.listing.path,
@@ -73,79 +70,52 @@ class PublicationPreviewHybSimCtrl {
                 });
                 child.setEntities(this.projectId, entities);
             });
-            if (typeof this.browser.listings === 'undefined') {
-                var allFilePaths = [];
-                this.browser.listings = {};
-                var apiParams = {
-                    fileMgr: 'agave',
-                    baseUrl: '/api/agave/files',
-                    searchState: 'projects.view.data',
+
+            let listingPaths = [];
+            let allPaths = [];
+            entities.forEach((entity) => {
+                this.browser.listings[entity.uuid] = {
+                    name: this.browser.listing.name,
+                    path: this.browser.listing.path,
+                    system: this.browser.listing.system,
+                    trail: this.browser.listing.trail,
+                    children: [],
                 };
-                entities.forEach((entity) => {
-                    this.browser.listings[entity.uuid] = {
-                        name: this.browser.listing.name,
-                        path: this.browser.listing.path,
-                        system: this.browser.listing.system,
-                        trail: this.browser.listing.trail,
-                        children: [],
-                    };
-                    allFilePaths = allFilePaths.concat(entity._filePaths);
-                });
-                this.setFilesDetails = (paths) => {
-                    let filePaths = [...new Set(paths)];
-                    var p = this.$q((resolve, reject) => {
-                        var results = [];
-                        var index = 0;
-                        var size = 5;
-                        var fileCalls = filePaths.map(filePath => {
-                            return this.FileListing.get(
-                                { system: 'project-' + this.browser.project.uuid, path: filePath }, apiParams
-                            ).then((resp) => {
-                                if (!resp) {
-                                    return;
+                allPaths = allPaths.concat(entity._filePaths);
+            });
+            allPaths.forEach((path) => {
+                listingPaths = listingPaths.concat(path.match(`.*\/`)[0]);
+            });
+            let reducedPaths = { files: [...new Set(allPaths)], directories: [...new Set(listingPaths)] };
+
+            this.populateListings = (paths, ents) => {
+                let apiParams = this.DataBrowserService.apiParameters();
+                var dirListings = paths.directories.map((dir) => {
+                    return this.FileListing.get(
+                        { system: 'project-' + this.browser.project.uuid, path: dir },
+                        apiParams
+                    ).then((resp) => {
+                        if (!resp) {
+                            return;
+                        }
+                        let files = resp.children;
+                        ents.forEach((e) => {
+                            files.forEach((f) => {
+                                if (e._filePaths.indexOf(f.path) > -1) {
+                                    f._entities.push(e);
+                                    this.browser.listings[e.uuid].children.push(f);
                                 }
-                                var allEntities = this.browser.project.getAllRelatedObjects();
-                                var entities = allEntities.filter((entity) => {
-                                    return entity._filePaths.includes(resp.path);
-                                });
-                                entities.forEach((entity) => {
-                                    resp._entities.push(entity);
-                                    this.browser.listings[entity.uuid].children.push(resp);
-                                });
-                                return resp;
                             });
                         });
-
-                        var step = () => {
-                            var calls = fileCalls.slice(index, (index += size));
-                            if (calls.length) {
-                                this.$q.all(calls)
-                                    .then((res) => {
-                                        results.concat(res);
-                                        step();
-                                        return res;
-                                    })
-                                    .catch(reject);
-                            } else {
-                                resolve(results);
-                            }
-                        };
-                        step();
+                        return resp;
                     });
-                    return p.then(
-                        (results) => {
-                            this.ui.loading = false;
-                            return results;
-                        },
-                        (err) => {
-                            this.ui.loading = false;
-                            this.browser.ui.error = err;
-                        });
-                };
-                this.setFilesDetails(allFilePaths);
-            } else {
-                this.ui.loading = false;
-            }
+                });
+
+                this.$q.all(dirListings).then(() => {
+                    this.ui.loading = false;
+                });
+            };
+            this.populateListings(reducedPaths, entities);
         };
     }
 
@@ -167,11 +137,11 @@ class PublicationPreviewHybSimCtrl {
     }
     
     goWork() {
-        this.$state.go('projects.view.data', {projectId: this.browser.project.uuid, data: this.browser});
+        this.$state.go('projects.view.data', {projectId: this.browser.project.uuid});
     }
 
     goCuration() {
-        this.$state.go('projects.curation', {projectId: this.browser.project.uuid, data: this.browser});
+        this.$state.go('projects.curation', {projectId: this.browser.project.uuid});
     }
 
     editProject() {

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
@@ -138,8 +138,8 @@
         </h3>
     </div>
     <!-- Project Reports -->
-    <div ng-hide="$ctrl.ui.loading" ng-repeat="report in $ctrl.browser.project.report_set | orderBy: 'value.title'"
-         ng-if="$ctrl.matchingGroup(simulation, report)"
+    <div ng-if="$ctrl.matchingGroup(simulation, report) && !$ctrl.ui.fileNav && !$ctrl.ui.loading" 
+         ng-repeat="report in $ctrl.browser.project.report_set | orderBy: 'value.title'"
     >
         <div class="dropdown dropdown-spacer-sm" id="details-{{report.uuid}}">
             <button class="btn collapsed tab-report" data-toggle="collapse" data-target="#files-{{report.uuid}}" style="width:100%;">
@@ -159,7 +159,7 @@
     <div ng-if="$ctrl.ui.fileNav && !$ctrl.ui.loading">
         <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listing" params="$ctrl.fl"></files-listing>
     </div>
-    <div ng-if="!$ctrl.ui.fileNav" ng-hide="$ctrl.ui.loading" ng-repeat="simulation in $ctrl.browser.project.simulation_set">
+    <div ng-if="!$ctrl.ui.fileNav && !$ctrl.ui.loading" ng-repeat="simulation in $ctrl.browser.project.simulation_set">
         <div class="dropdown dropdown-spacer-sm" id="details-{{simulation.uuid}}">
             <button class="btn tab-experiment collapsed" data-toggle="collapse" data-target="#data-{{simulation.uuid}}" style="width:100%;">
                 <table style="width:100%" id="anchor-{{ simulation.uuid }}">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
@@ -140,7 +140,7 @@
         </h3>
     </div>
     <!-- Project Reports -->
-    <div ng-hide="$ctrl.ui.loading" ng-repeat="report in $ctrl.browser.project.report_set | orderBy: 'value.title'" ng-if="$ctrl.matchingGroup(experiment, report)">
+    <div ng-if="$ctrl.matchingGroup(experiment, report) && !$ctrl.ui.fileNav && !$ctrl.ui.loading" ng-repeat="report in $ctrl.browser.project.report_set | orderBy: 'value.title'">
         <div class="dropdown dropdown-spacer-sm" id="details-{{report.uuid}}">
             <button class="btn tab-report" data-toggle="collapse" data-target="#files-{{report.uuid}}" style="width:100%;">
                 <div class="collapse-tab">
@@ -159,7 +159,7 @@
     <div ng-if="$ctrl.ui.fileNav && !$ctrl.ui.loading">
         <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listing" params="$ctrl.fl"></files-listing>
     </div>
-    <div ng-if="!$ctrl.ui.fileNav" ng-hide="$ctrl.ui.loading" ng-repeat="experiment in $ctrl.browser.project.experiment_set">
+    <div ng-if="!$ctrl.ui.fileNav && !$ctrl.ui.loading" ng-repeat="experiment in $ctrl.browser.project.experiment_set">
         <div class="dropdown dropdown-spacer-sm" id="details-{{experiment.uuid}}">
             <button class="btn tab-experiment collapsed" data-toggle="collapse" data-target="#data-{{experiment.uuid}}" style="width:100%;">
                 <table style="width:100%" id="anchor-{{ experiment.uuid }}">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.js
@@ -21,7 +21,6 @@ class PublicationPreviewCtrl {
         this.readOnly = this.$state.current.name.indexOf('publishedData') === 0;
         this.projectId = this.ProjectService.resolveParams.projectId;
         this.filePath = this.ProjectService.resolveParams.filePath;
-        this.data = this.ProjectService.resolveParams.data;
         this.ui = {
             efs: experimentalData.experimentalFacility,
             equipmentTypes: experimentalData.equipmentTypes,
@@ -40,28 +39,28 @@ class PublicationPreviewCtrl {
             this.ui.fileNav = false;
         }
 
-        if (this.data && this.data.listing.path == this.filePath) {
-            this.browser = this.data;
-            this.ProjectEntitiesService.listEntities({ uuid: this.projectId, name: 'all' }).then((ents) => {
-                this.createListing(ents);
-            });
-        } else {
-            this.$q.all([
-                this.ProjectService.get({ uuid: this.projectId }),
-                this.DataBrowserService.browse(
-                    { system: 'project-' + this.projectId, path: this.filePath },
-                    { query_string: this.$state.params.query_string }
-                ),
-                this.ProjectEntitiesService.listEntities({ uuid: this.projectId, name: 'all' })
-            ]).then(([project, listing, ents]) => {
-                this.browser.project = project;
-                this.browser.project.appendEntitiesRel(ents);
-                this.browser.listing = listing;
-                this.createListing(ents);
-            });
-        }
+        this.$q.all([
+            this.ProjectService.get({ uuid: this.projectId }),
+            this.DataBrowserService.browse(
+                { system: 'project-' + this.projectId, path: this.filePath },
+                { query_string: this.$state.params.query_string }
+            ),
+            this.ProjectEntitiesService.listEntities({ uuid: this.projectId, name: 'all' })
+        ]).then(([project, listing, ents]) => {
+            this.browser.project = project;
+            this.browser.project.appendEntitiesRel(ents);
+            this.browser.listing = listing;
+            this.createAbstractListing(ents);
+        });
 
-        this.createListing = (entities) => {
+        this.createAbstractListing = (entities) => {
+            /*
+            Create Abstract Listing:
+            Since we need to list x number of files from anywhere within the project's directory,
+            we need to try to list the minimum amount of paths within the project to get the file details.
+            Once we have the listed files we can create the abstracted file listings (this.browser.listings).
+            */
+            this.browser.listings = {};
             this.browser.listing.href = this.$state.href('projects.view.data', {
                 projectId: this.projectId,
                 filePath: this.browser.listing.path,
@@ -75,79 +74,55 @@ class PublicationPreviewCtrl {
                 });
                 child.setEntities(this.projectId, entities);
             });
-            if (typeof this.browser.listings === 'undefined') {
-                var allFilePaths = [];
-                this.browser.listings = {};
-                var apiParams = {
-                    fileMgr: 'agave',
-                    baseUrl: '/api/agave/files',
-                    searchState: 'projects.view.data',
+
+            let listingPaths = [];
+            let allPaths = [];
+            entities.forEach((entity) => {
+                this.browser.listings[entity.uuid] = {
+                    name: this.browser.listing.name,
+                    path: this.browser.listing.path,
+                    system: this.browser.listing.system,
+                    trail: this.browser.listing.trail,
+                    children: [],
                 };
-                entities.forEach((entity) => {
-                    this.browser.listings[entity.uuid] = {
-                        name: this.browser.listing.name,
-                        path: this.browser.listing.path,
-                        system: this.browser.listing.system,
-                        trail: this.browser.listing.trail,
-                        children: [],
-                    };
-                    allFilePaths = allFilePaths.concat(entity._filePaths);
-                });
-                this.setFilesDetails = (paths) => {
-                    let filePaths = [...new Set(paths)];
-                    var p = this.$q((resolve, reject) => {
-                        var results = [];
-                        var index = 0;
-                        var size = 5;
-                        var fileCalls = filePaths.map(filePath => {
-                            return this.FileListing.get(
-                                { system: 'project-' + this.browser.project.uuid, path: filePath }, apiParams
-                            ).then((resp) => {
-                                if (!resp) {
-                                    return;
+                allPaths = allPaths.concat(entity._filePaths);
+            });
+            allPaths.forEach((path) => {
+                listingPaths = listingPaths.concat(path.match(`.*\/`)[0]);
+            });
+            let reducedPaths = { files: [...new Set(allPaths)], directories: [...new Set(listingPaths)] };
+
+            this.populateListings = (paths, ents) => {
+                let apiParams = this.DataBrowserService.apiParameters();
+                var dirListings = paths.directories.map((dir) => {
+                    return this.FileListing.get(
+                        { system: 'project-' + this.browser.project.uuid, path: dir },
+                        apiParams
+                    ).then((resp) => {
+                        if (!resp) {
+                            return;
+                        }
+                        let files = resp.children;
+                        ents.forEach((e) => {
+                            files.forEach((f) => {
+                                if (e._filePaths.indexOf(f.path) > -1) {
+                                    e.value.fileTags.forEach((tag) => {
+                                        f._entityTags = (tag.path == f.path ? true : false)
+                                    });
+                                    f._entities.push(e);
+                                    this.browser.listings[e.uuid].children.push(f);
                                 }
-                                var allEntities = this.browser.project.getAllRelatedObjects();
-                                var entities = allEntities.filter((entity) => {
-                                    return entity._filePaths.includes(resp.path);
-                                });
-                                entities.forEach((entity) => {
-                                    resp._entities.push(entity);
-                                    this.browser.listings[entity.uuid].children.push(resp);
-                                });
-                                return resp;
                             });
                         });
-
-                        var step = () => {
-                            var calls = fileCalls.slice(index, (index += size));
-                            if (calls.length) {
-                                this.$q.all(calls)
-                                    .then((res) => {
-                                        results.concat(res);
-                                        step();
-                                        return res;
-                                    })
-                                    .catch(reject);
-                            } else {
-                                resolve(results);
-                            }
-                        };
-                        step();
+                        return resp;
                     });
-                    return p.then(
-                        (results) => {
-                            this.ui.loading = false;
-                            return results;
-                        },
-                        (err) => {
-                            this.ui.loading = false;
-                            this.browser.ui.error = err;
-                        });
-                };
-                this.setFilesDetails(allFilePaths);
-            } else {
-                this.ui.loading = false;
-            }
+                });
+
+                this.$q.all(dirListings).then(() => {
+                    this.ui.loading = false;
+                });
+            };
+            this.populateListings(reducedPaths, entities);
         };
     }
 
@@ -193,11 +168,11 @@ class PublicationPreviewCtrl {
     }
     
     goWork() {
-        this.$state.go('projects.view.data', {projectId: this.browser.project.uuid, data: this.browser});
+        this.$state.go('projects.view.data', {projectId: this.browser.project.uuid});
     }
 
     goCuration() {
-        this.$state.go('projects.curation', {projectId: this.browser.project.uuid, data: this.browser});
+        this.$state.go('projects.curation', {projectId: this.browser.project.uuid});
     }
 
     editProject() {

--- a/designsafe/static/scripts/ng-designsafe/services/file-listing.js
+++ b/designsafe/static/scripts/ng-designsafe/services/file-listing.js
@@ -35,25 +35,33 @@ export function FileListing($http, $q) {
         }
     }
 
-    FileListing.prototype.setEntities = function(projectId, entities){
+    FileListing.prototype.setEntities = function(projectUuid, entities){
+        /**
+         * Set Entity Metadata
+         * This method will set entity information on individual files within a project's listing.
+         * The entity metadata is used for categorization and tagging purposes on files within the listing
+         * 
+         * @param {string} projectUuid The uuid of the project
+         * @param {array} entities Array of entities within a project
+        **/
+
         var self = this;
         var path = self.path;
+
         self._entities = [];
-        _.each(entities, function(entity){
+        entities.forEach((entity) => {
             if (typeof entity !== 'undefined' &&
             typeof entity._links !== 'undefined' &&
             typeof entity._links.associationIds !== 'undefined') {
-                _.each(entity._links.associationIds, function (asc) {
+                entity._links.associationIds.forEach((asc) => {
                     if (asc.title === 'file') {
-                        var comps = asc.href.split('project-' + projectId, 2);
+                        var comps = asc.href.split('project-' + projectUuid, 2);
                         if (comps.length === 2 && path.replace(/^\/+/, '') === comps[1].replace(/^\/+/, '')) {
                             self._entities.push(entity);
                         }
-                        if (!comps[1].replace(/^\/+/, '').includes('.')) {
-                            if (comps.length === 2 && self._parent.path.replace(/^\/+/, '').startsWith(comps[1].replace(/^\/+/, ''))) {
-                                if (!self._parent._entities.includes(entity)) {
-                                    self._parent._entities.push(entity);
-                                }
+                        if (comps.length === 2 && self._parent.path.replace(/^\/+/, '').startsWith(comps[1].replace(/^\/+/, ''))) {
+                            if (!self._parent._entities.includes(entity)) {
+                                self._parent._entities.push(entity);
                             }
                         }
                     }
@@ -65,7 +73,7 @@ export function FileListing($http, $q) {
             var myAsoc = _.find(self._entities[0]._links.associationIds,
                 function(asc){
                     if (asc.title === 'file'){
-                        var comps = asc.href.split('project-' + projectId, 2);
+                        var comps = asc.href.split('project-' + projectUuid, 2);
                         return self.path.replace(/^\/+/, '') === comps[1].replace(/^\/+/, '');
                     }
                 });
@@ -242,7 +250,6 @@ export function FileListing($http, $q) {
         var self = this;
         // recreate a deferred timeout for the promise
         stopper = $q.defer();
-
         var req = $http.get(this.listingUrl(), { params: params, timeout: stopper.promise }).then(function (resp) {
             angular.extend(self, resp.data);
 

--- a/designsafe/static/scripts/projects/components/file-categories/file-categories.component.js
+++ b/designsafe/static/scripts/projects/components/file-categories/file-categories.component.js
@@ -1,31 +1,13 @@
-import _ from 'underscore';
-
 import FileCategoriesTemplate from './file-categories.template.html';
 import experimentalFileTags from './experimental-file-tags.json';
 import simulationFileTags from './simulation-file-tags.json';
 import hybridSimulationFileTags from './hybrid-simulation-file-tags.json';
 import fieldReconFileTags from './field-recon-file-tags.json';
 import otherFileTags from './other-file-tags.json';
-import { values } from '@uirouter/core';
 
-const getFileUuid = (file) => {
-    let promise;
-    if (_.isEmpty(file.uuid())) {
-        promise = file.fetch();
-    } else {
-        let my_promise = () => {
-            let prm = new Promise((resolve)=>{
-                resolve(file);
-            });
-            return prm;
-        };
-        promise = my_promise();
-    }
-    return promise;
-};
 
 class FileCategoriesCtrl {
-    constructor($q, Django, ProjectModel, ProjectService, ProjectEntitiesService, httpi, $scope){
+    constructor($q, Django, ProjectModel, ProjectService, ProjectEntitiesService, httpi, $scope) {
         'ngInject';
         this.Django = Django;
         this.ProjectModel = ProjectModel;
@@ -37,65 +19,78 @@ class FileCategoriesCtrl {
     }
 
     $onInit() {
-        this._ui = { 
-            busy: true,
+        this._ui = {
+            busy: false,
             error: false,
             isOther: this.project.value.projectType === 'other',
             showTags: this.showTags || false,
             editTags: this.editTags || false,
         };
         this.projectResource = this.httpi.resource('/api/projects/:uuid/').setKeepTrailingSlash(true);
-        getFileUuid(this.file).finally( ()=>{
-            this._ui.busy=false;
+    }
+
+    updateEntity(entity, file) {
+        this.ProjectEntitiesService.update({
+            data: { uuid: entity.uuid, entity: entity },
+        })
+            .then((updatedEnt) => {
+                let oldEnt = this.project.getRelatedByUuid(updatedEnt.uuid);
+                oldEnt.update(updatedEnt);
+                if (file) {
+                    file.setEntities(this.project.uuid, this.project.getAllRelatedObjects());
+                }
+            })
+            .finally(() => {
+                this._ui.busy = false;
+            });
+    };
+
+    savePrj(options) {
+        return this.projectResource.post({ data: options }).then((resp) => {
+            return new this.ProjectModel(resp.data);
         });
     }
 
     removeCategory(entity) {
         this._ui.busy = true;
-        getFileUuid(this.file).then((file)=>{
-            if (!_.contains(entity.associationIds, file.uuid())){
-                return undefined;
+
+        this.rmUuid = (allIds, idToRm) => {
+            let index = allIds.indexOf(idToRm);
+            if (index >= 0) {
+                allIds.splice(index, 1);
             }
-            entity.associationIds = _.difference(entity.associationIds, [this.file.uuid()]);
-            entity.value.files = _.difference(entity.value.files, [this.file.uuid()]);
-            return entity;
-        }).then( (ret) => {
-            if (!ret){
-                return undefined;
-            }
-            return this.ProjectEntitiesService.update({
-                data: {
-                    uuid: ret.uuid,
-                    entity: ret,
-                },
+            return allIds;
+        };
+
+        if (!this.file.uuid().length) {
+            this.file.fetch().then((file) => {
+                if (!entity.associationIds.includes(file.uuid())) {
+                    return undefined;
+                }
+                this.rmUuid(entity.associationIds, file.uuid());
+                this.rmUuid(entity.value.files, file.uuid());
+                this.updateEntity(entity, this.file);
             });
-        }).then( (ret) => {
-            if (!ret) {
-                return this.file;
+        } else {
+            if (!entity.associationIds.includes(this.file.uuid())) {
+                return undefined;
             }
-            let entity = this.project.getRelatedByUuid(ret.uuid);
-            entity.update(ret);
-            this.file.setEntities(this.project.uuid, this.project.getAllRelatedObjects());
-            return this.file;
-        }).finally(() => {
-            this._ui.busy = false;
-            this.$scope.$apply();
-        });
+            this.rmUuid(entity.associationIds, this.file.uuid());
+            this.rmUuid(entity.value.files, this.file.uuid());
+            this.updateEntity(entity, this.file);
+        }
     }
 
     removeProjectTag(tag) {
         this._ui.busy = true;
         let tagName = tag.tagName;
-        
-        this.project.value.fileTags = _.filter(
-            this.project.value.fileTags,
-            (ft) => {
-                if(ft.fileUuid === tag.fileUuid && ft.tagName === tagName){
-                    return false;
-                }
-                return true;
+
+        this.project.value.fileTags = this.project.value.fileTags.filter((ft) => {
+            if (ft.fileUuid === tag.fileUuid && ft.tagName === tagName) {
+                return false;
             }
-        );
+            return true;
+        });
 
         var projectData = {};
         projectData.uuid = this.project.uuid;
@@ -126,13 +121,39 @@ class FileCategoriesCtrl {
             tagName = this.selectedFileTag[this.project.uuid];
         }
 
-        getFileUuid(this.file).then((file) => {
+        if (!this.file.uuid().length) {
+            this.file.fetch()
+                .then((file) => {
+                    this.project.value.fileTags.push({
+                        fileUuid: file.uuid(),
+                        tagName: tagName,
+                        path: this.file.path,
+                    });
+                })
+                .then(() => {
+                    let projectData = {};
+                    projectData.uuid = this.project.uuid;
+                    projectData.fileTags = this.project.value.fileTags;
+                    projectData.title = this.project.value.title;
+                    projectData.pi = this.project.value.pi;
+                    projectData.coPis = this.project.value.coPis;
+                    projectData.projectType = this.project.value.projectType;
+                    projectData.projectId = this.project.value.projectId;
+                    projectData.description = this.project.value.description;
+                    projectData.keywords = this.project.value.keywords;
+                    projectData.teamMembers = this.project.value.teamMembers;
+                    projectData.associatedProjects = this.project.value.associatedProjects;
+                    projectData.awardNumber = this.project.value.awardNumber;
+                    this.savePrj(projectData);
+                    this.selectedFileTag[this.project.uuid] = null;
+                    this._ui.busy = false;
+                });
+        } else {
             this.project.value.fileTags.push({
-                fileUuid: file.uuid(),
+                fileUuid: this.file.uuid(),
                 tagName: tagName,
-                path: this.file.path
+                path: this.file.path,
             });
-        }).then(() => {
             let projectData = {};
             projectData.uuid = this.project.uuid;
             projectData.fileTags = this.project.value.fileTags;
@@ -146,17 +167,10 @@ class FileCategoriesCtrl {
             projectData.teamMembers = this.project.value.teamMembers;
             projectData.associatedProjects = this.project.value.associatedProjects;
             projectData.awardNumber = this.project.value.awardNumber;
-            this.savePrj(projectData).finally(() => {
-                this.selectedFileTag[this.project.uuid] = null;
-                this._ui.busy = false;
-            });
-        });
-    }
-
-    savePrj(options) {
-        return this.projectResource.post({ data: options }).then((resp) => {
-            return new this.ProjectModel(resp.data);
-        });
+            this.savePrj(projectData);
+            this.selectedFileTag[this.project.uuid] = null;
+            this._ui.busy = false;
+        }
     }
 
     addFileTag(entity) {
@@ -176,64 +190,47 @@ class FileCategoriesCtrl {
             return;
         }
 
-        getFileUuid(this.file).then((file)=>{
+        if (!this.file.uuid().length) {
+            this.file.fetch().then((file) => {
+                entity.value.fileTags.push({
+                    fileUuid: file.uuid(),
+                    tagName: tagName,
+                    path: this.file.path,
+                });
+                this.updateEntity(entity);
+                this.selectedFileTag[entity.uuid] = null;
+            });
+        } else {
             entity.value.fileTags.push({
-                fileUuid: file.uuid(),
+                fileUuid: this.file.uuid(),
                 tagName: tagName,
-                path: this.file.path
+                path: this.file.path,
             });
-        }).then(() => {
-            return this.ProjectEntitiesService.update({
-                data: {
-                    uuid: entity.uuid,
-                    entity: entity,
-                }
-            });
-        }).then((res) => {
-            let prjEntity = this.project.getRelatedByUuid(res.uuid);
-            prjEntity.update(res);
-        }).finally(() => {
-            this._ui.busy = false;
+            this.updateEntity(entity);
             this.selectedFileTag[entity.uuid] = null;
-            this.$scope.$apply();
-        });
+        }
     }
 
     removeFileTag(entity, tag) {
         this._ui.busy = true;
         let tagName = tag.tagName;
-        
-        entity.value.fileTags = _.filter(
-            entity.value.fileTags,
-            (ft) => {
-                if(ft.fileUuid === tag.fileUuid && ft.tagName === tagName){
-                    return false;
-                }
-                return true;
+        entity.value.fileTags = entity.value.fileTags.filter((ft) => {
+            if (ft.fileUuid === tag.fileUuid && ft.tagName === tagName) {
+                return false;
             }
-        );
-    
-        this.ProjectEntitiesService.update({
-            data: {
-                uuid: entity.uuid,
-                entity: entity,
-            }
-        }).then((res) => {
-            let prjEntity = this.project.getRelatedByUuid(res.uuid);
-            prjEntity.update(res);
-        }).finally(() => {
-            this._ui.busy = false;
+            return true;
         });
+        this.updateEntity(entity);
     }
 
     fileTagsForEntity(entity) {
-        if (this.project.value.projectType === 'experimental'){
+        if (this.project.value.projectType === 'experimental') {
             return experimentalFileTags[entity.name];
         } else if (this.project.value.projectType === 'simulation') {
             return simulationFileTags[entity.name];
         } else if (this.project.value.projectType === 'hybrid_simulation') {
             return hybridSimulationFileTags[entity.name];
-        } else if (this.project.value.projectType === 'other'){
+        } else if (this.project.value.projectType === 'other') {
             return otherFileTags['designsafe.project'];
         } else if (this.project.value.projectType === 'field_recon') {
             return fieldReconFileTags[entity.name];
@@ -242,7 +239,22 @@ class FileCategoriesCtrl {
     }
 
     tagsForFile(tags) {
-        return _.filter(tags, (tag) => { return tag.fileUuid == this.file.uuid(); });
+        /*
+        Get the file tags for a file.
+        If listing files for published projects, compare the filepath
+        without the projectId in the root path.
+        */
+        if (!tags) {
+            return;
+        }
+        if (this.file.apiParams.fileMgr == 'published') {
+            return tags.filter((tag) => {
+                return tag.path == this.file.path.replace(/^\/*PRJ-[0-9]{4}/g, '');
+            });
+        }
+        return tags.filter((tag) => {
+            return tag.path == this.file.path;
+        });
     }
 }
 

--- a/designsafe/static/scripts/projects/components/file-categories/file-categories.template.html
+++ b/designsafe/static/scripts/projects/components/file-categories/file-categories.template.html
@@ -1,8 +1,8 @@
 <div class="file-categories-content">
-    <div class="loading" data-ng-if="$ctrl._ui.busy">
+    <div class="loading" ng-if="$ctrl._ui.busy">
         <i class="fa fa-spinner fa-spin">&nbsp;</i> Loading...
     </div>
-    <div ng-if="!$ctrl._ui.isOther">
+    <div ng-if="!$ctrl._ui.isOther && !$ctrl._ui.busy">
         <div ng-if="$ctrl._ui.editTags">
             <div class="tag-item" data-ng-repeat="entityTag in $ctrl.file._entityTags">
                 {{entityTag}}

--- a/designsafe/static/scripts/projects/components/file-category-selector/file-category-selector.template.html
+++ b/designsafe/static/scripts/projects/components/file-category-selector/file-category-selector.template.html
@@ -1,4 +1,7 @@
-<form ng-if="$ctrl.selectMultiple() && $ctrl.project.value.projectType !== 'other'">
+<div class="loading" ng-if="$ctrl._ui.busy">
+    <i class="fa fa-spinner fa-spin">&nbsp;</i> Loading...
+</div>
+<form ng-if="$ctrl.selectMultiple() && $ctrl.project.value.projectType !== 'other'" ng-disabled="$ctrl._ui.busy">
     <select name="project-category"
             data-ng-model="$ctrl.selectedUuid"
             class="form-control">

--- a/designsafe/static/scripts/projects/components/manage-categories/manage-categories.component.html
+++ b/designsafe/static/scripts/projects/components/manage-categories/manage-categories.component.html
@@ -393,7 +393,9 @@
                                 <span ng-click="$ctrl.deleteCategory(modelConf)"><a>Delete </a></span>
                             </div>
                         </div>
+                        <div ng-if="$ctrl.browser.listings[modelConf.uuid]">
                             <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[modelConf.uuid]" params="$ctrl.fl"></files-listing>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -415,7 +417,9 @@
                                 <span ng-click="$ctrl.deleteCategory(sensorInfo)"><a>Delete </a></span>
                             </div>
                         </div>
-                        <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[sensorInfo.uuid]" params="$ctrl.fl"></files-listing>
+                        <div ng-if="$ctrl.browser.listings[sensorInfo.uuid]">
+                            <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[sensorInfo.uuid]" params="$ctrl.fl"></files-listing>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -437,7 +441,9 @@
                                 <span ng-click="$ctrl.deleteCategory(event)"><a>Delete </a></span>
                             </div>
                         </div>
-                        <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[event.uuid]" params="$ctrl.fl"></files-listing>
+                        <div ng-if="$ctrl.browser.listings[event.uuid]">
+                            <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[event.uuid]" params="$ctrl.fl"></files-listing>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -459,7 +465,9 @@
                                 <span ng-click="$ctrl.deleteCategory(model)"><a>Delete </a></span>
                             </div>
                         </div>
-                        <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[model.uuid]" params="$ctrl.fl"></files-listing>
+                        <div ng-if="$ctrl.browser.listings[model.uuid]">
+                            <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[model.uuid]" params="$ctrl.fl"></files-listing>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -481,7 +489,9 @@
                                 <span ng-click="$ctrl.deleteCategory(input)"><a>Delete </a></span>
                             </div>
                         </div>
-                        <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[input.uuid]" params="$ctrl.fl"></files-listing>
+                        <div ng-if="$ctrl.browser.listings[input.uuid]">
+                            <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[input.uuid]" params="$ctrl.fl"></files-listing>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -503,7 +513,9 @@
                                 <span ng-click="$ctrl.deleteCategory(output)"><a>Delete </a></span>
                             </div>
                         </div>
-                        <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[output.uuid]" params="$ctrl.fl"></files-listing>
+                        <div ng-if="$ctrl.browser.listings[output.uuid]">
+                            <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[output.uuid]" params="$ctrl.fl"></files-listing>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -525,7 +537,9 @@
                                 <span ng-click="$ctrl.deleteCategory(gm)"><a>Delete </a></span>
                             </div>
                         </div>
-                        <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[gm.uuid]" params="$ctrl.fl"></files-listing>
+                        <div ng-if="$ctrl.browser.listings[gm.uuid]">
+                            <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[gm.uuid]" params="$ctrl.fl"></files-listing>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -547,7 +561,9 @@
                                 <span ng-click="$ctrl.deleteCategory(coordinator)"><a>Delete </a></span>
                             </div>
                         </div>
-                        <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[coordinator.uuid]" params="$ctrl.fl"></files-listing>
+                        <div ng-if="$ctrl.browser.listings[coordinator.uuid]">
+                            <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[coordinator.uuid]" params="$ctrl.fl"></files-listing>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -569,7 +585,9 @@
                                 <span ng-click="$ctrl.deleteCategory(simsub)"><a>Delete </a></span>
                             </div>
                         </div>
-                        <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[simsub.uuid]" params="$ctrl.fl"></files-listing>
+                        <div ng-if="$ctrl.browser.listings[simsub.uuid]">
+                            <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[simsub.uuid]" params="$ctrl.fl"></files-listing>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -591,7 +609,9 @@
                                 <span ng-click="$ctrl.deleteCategory(expsub)"><a>Delete </a></span>
                             </div>
                         </div>
-                        <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[expsub.uuid]" params="$ctrl.fl"></files-listing>
+                        <div ng-if="$ctrl.browser.listings[expsub.uuid]">
+                            <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[expsub.uuid]" params="$ctrl.fl"></files-listing>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -613,7 +633,9 @@
                                 <span ng-click="$ctrl.deleteCategory(cout)"><a>Delete </a></span>
                             </div>
                         </div>
-                        <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[cout.uuid]" params="$ctrl.fl"></files-listing>
+                        <div ng-if="$ctrl.browser.listings[cout.uuid]">
+                            <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[cout.uuid]" params="$ctrl.fl"></files-listing>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -635,7 +657,9 @@
                                 <span ng-click="$ctrl.deleteCategory(eout)"><a>Delete </a></span>
                             </div>
                         </div>
-                        <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[eout.uuid]" params="$ctrl.fl"></files-listing>
+                        <div ng-if="$ctrl.browser.listings[eout.uuid]">
+                            <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[eout.uuid]" params="$ctrl.fl"></files-listing>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -657,7 +681,9 @@
                                 <span ng-click="$ctrl.deleteCategory(sout)"><a>Delete </a></span>
                             </div>
                         </div>
-                        <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[sout.uuid]" params="$ctrl.fl"></files-listing>
+                        <div ng-if="$ctrl.browser.listings[sout.uuid]">
+                            <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[sout.uuid]" params="$ctrl.fl"></files-listing>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -690,7 +716,9 @@
                                 <span ng-click="$ctrl.deleteCategory(analysis)"><a>Delete </a></span>
                             </div>
                         </div>
-                        <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[analysis.uuid]" params="$ctrl.fl"></files-listing>
+                        <div ng-if="$ctrl.browser.listings[analysis.uuid]">
+                            <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[analysis.uuid]" params="$ctrl.fl"></files-listing>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -712,7 +740,9 @@
                                 <span ng-click="$ctrl.deleteCategory(report)"><a>Delete </a></span>
                             </div>
                         </div>
-                        <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[report.uuid]" params="$ctrl.fl"></files-listing>
+                        <div ng-if="$ctrl.browser.listings[report.uuid]">
+                            <files-listing browser="$ctrl.browser" files-list="$ctrl.browser.listings[report.uuid]" params="$ctrl.fl"></files-listing>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Summary of Changes:
- **project-view.component.js** - Remove browser data from state transition
- **curation-directory.component.js** - Remove browser data from state transition...
- **publication-preview.component.js** - Clean up AbstractedListing function which builds the abstracted file listing for publication previews. No longer requires multiple requests for each file. Instead requests for necessary file information will be gathered on user interaction. (see file-categories.component.js)
- **publication-preview.template.html** - Merge` ng-if` and `ng-hide` directives
- **publication-preview-sim.component.js** - Clean up AbstractedListing function...
- **publication-preview-sim.template.html** - Merge `ng-if` and `ng-hide` directives...
- **publication-preview-hyb-sim.component.js** - Clean up AbstractedListing function...
- **publication-preview-hyb-sim.template.html** - Merge `ng-if` and `ng-hide` directives...
- **publication-preview-field-recon.component.js** - Clean up AbstractedListing function...
- **publication-preview-field-recon.template.html** - Merge `ng-if` and `ng-hide` directives…
- **pipeline-selection.component.js** - Clean up AbstractedListing function…
- **manage-categories.component.js** - Clean up AbstractedListing function...
- **manage-categories.template.html** - Do not show incomplete file listings in categories
- **file-listing** - Fixed issue where directory paths with periods `.` in the name would not render categories/tags for subsequent file listings. This was a result of an unnecessary check for a file extension on a parent directory.
- **file-category-selector.template.html** - Show loading spinner while busy
- **file-categories.component.js** - Refactor how we gather file information to manipulate and display tags on files. We will no longer gather the uuid of every file in the listing. Instead we will get the uuid when a user needs to change something on selected files. We will also render file tags based on the matching file path within the tag (instead of using the uuid). This will allow us to render tags without having to send requests for every single file (to get its uuid) in a project’s listing. Removed underscore `_.foo()` functions. Removed unnecessary `$scope.$apply()` functions.
- **file-categories.template.html** - Show loading spinner while busy


### Testing Changes:
These changes impact the working area for all project types (other, experimental, simulation, hybrid-sim, field-research), as well as published projects. In this PR you should notice improvements in loading times for the `Working Directory`, `Curation Directory`, `Publication Preview`, `Selection`(first step of publish pipeline), and the `Add Categories` modal. Any interactions with the file listings for projects should remain the same. This was pushed as a "Bug" because in larger projects/publications (like the one below) would often time out or have issues loading all of their files.

You should notice a _significant_ difference in load time between this PR and PROD for loading large projects/publications like this one:
https://designsafe.dev/data/browser/public/designsafe.storage.published//PRJ-2363
vs
https://www.designsafe-ci.org/data/browser/public/designsafe.storage.published//PRJ-2363