### PR TITLE
Bug/DES-1674 - Fix bug with FR ordering in "Relate Data" modal

### DIFF
--- a/designsafe/static/scripts/projects/components/project-tree/project-tree.component.js
+++ b/designsafe/static/scripts/projects/components/project-tree/project-tree.component.js
@@ -18,7 +18,7 @@ class ProjectTreeCtrl {
         this.project = this.resolve.project;
         this.rootCategoryUuid = this.resolve.rootCategoryUuid;
         this.readOnly = this.resolve.readOnly || false;
-        if (this.project.mission_set) {
+        if (this.project.value.projectType === "field_recon") {
             this.initiateEntityOrder([].concat(this.project.mission_set || [], this.project.report_set || []));
         }
     }


### PR DESCRIPTION
Fixing a bug which prevents Field Research projects from being able to sort their entities in the "Relate Data" modal. If the project does not have any missions, the `initiateEntityOrder` function would not be triggered.