### PR TITLE
Fix Simulations Not Rendering

### DIFF
--- a/designsafe/static/scripts/data-depot/services/published.service.js
+++ b/designsafe/static/scripts/data-depot/services/published.service.js
@@ -149,18 +149,20 @@ export class PublishedService {
         this.$window.document.getElementsByName('DC.creator')[0].content = authors;
 
         const entities = [];
+        let isSimulation = false;
         if (has(resp.data, 'experimentsList')) {
             entities.push(...resp.data.experimentsList);
         } else if(has(resp.data, 'simulations')) {
             entities.push(...resp.data.simulations);
+            isSimulation = true;
         } else if(has(resp.data, 'missions')) {
             entities.push(...resp.data.missions);
         } else if (has(resp.data, 'hybrid_simulations')) {
             entities.push(...resp.data, 'hybrid_simulations');
+            isSimulation = true;
         }
 
         // Check for reports
-        const isSimulation = has(resp.data, 'simulations') || has(resp.data, 'hybrid_simulations');
         if(has(resp.data, 'reports') && !isSimulation) entities.push(...resp.data.reports);
 
         entities.forEach((entity) => {

--- a/designsafe/static/scripts/data-depot/services/published.service.js
+++ b/designsafe/static/scripts/data-depot/services/published.service.js
@@ -160,7 +160,8 @@ export class PublishedService {
         }
 
         // Check for reports
-        if(has(resp.data, 'reports')) entities.push(...resp.data.reports);
+        const isSimulation = has(resp.data, 'simulations') || has(resp.data, 'hybrid_simulations');
+        if(has(resp.data, 'reports') && !isSimulation) entities.push(...resp.data.reports);
 
         entities.forEach((entity) => {
             // Title


### PR DESCRIPTION
This can be tested using [this publication](https://designsafe.dev/data/browser/public/designsafe.storage.published//PRJ-2290) locally. The `updateHeaderMetadata` method now adds reports to the header if they are published. 

In prod, as seen [here](https://designsafe-ci.org/data/browser/public/designsafe.storage.published//PRJ-2290), the publication gets stuck on loading.