### PR TITLE
Task/DES-1708(1714, 1581) - Project Overview Updates and updated PII Policy Guidelines

### DIFF
--- a/designsafe/apps/api/projects/urls.py
+++ b/designsafe/apps/api/projects/urls.py
@@ -17,6 +17,7 @@ from designsafe.apps.api.projects.views import (ProjectListingView,
                                                 ProjectCollaboratorsView,
                                                 ProjectInstanceView,
                                                 ProjectMetaView,
+                                                ProjectNotificationView,
                                                 PublicationView,
                                                 NeesPublicationView)
 
@@ -60,4 +61,7 @@ urlpatterns = [
 
     url(r'^(?P<project_id>[a-z0-9\-]+)/data/(?P<file_path>.*)/$',
         ProjectDataView.as_view(), name='project_data'),
+
+    url(r'^(?P<project_uuid>[a-z0-9\-]+)/notification/$',
+        ProjectNotificationView.as_view(), name='project_notification'),
 ]

--- a/designsafe/apps/api/tasks.py
+++ b/designsafe/apps/api/tasks.py
@@ -969,7 +969,7 @@ def email_project_admins(self, project_id, project_uuid, project_title, project_
             """.format(name=user.get_full_name(), email=user.email, title=project_title, prjID=project_id, url=project_url)
 
         send_mail(
-            "DesignSafe PID Alert",
+            "DesignSafe PII Alert",
             email_body,
             settings.DEFAULT_FROM_EMAIL,
             [admin],

--- a/designsafe/apps/api/tasks.py
+++ b/designsafe/apps/api/tasks.py
@@ -941,6 +941,41 @@ def set_facl_project(self, project_uuid, usernames):
         logger.debug('set facl project: {}'.format(res))
 
 @shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def email_project_admins(self, project_id, project_uuid, project_title, project_url, username):
+    #contact project admins regarding publication of sensitive information
+    service = get_service_account_client()
+    admins = settings.PROJECT_ADMINS_EMAIL
+    user = get_user_model().objects.get(username=username)
+
+    for admin in admins:
+        email_body = """
+            <p>Hello,</p>
+            <p>
+                The following Field Research project has been created with the intent of publishing sensitive information:
+                <br>
+                <b>{prjID} - {title}</b>
+            </p>
+            <p>
+                Contact PI:
+                <br>
+                {name} - {email}
+            </p>
+            <p>
+                Link to Project:
+                <br>
+                <a href=\"{url}\">{url}</a>.
+            </p>
+            This is a programmatically generated message. Do NOT reply to this message.
+            """.format(name=user.get_full_name(), email=user.email, title=project_title, prjID=project_id, url=project_url)
+
+        send_mail(
+            "DesignSafe PID Alert",
+            email_body,
+            settings.DEFAULT_FROM_EMAIL,
+            [admin],
+            html_message=email_body)
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
 def email_collaborator_added_to_project(self, project_id, project_uuid, project_title, project_url, team_members_to_add, co_pis_to_add):
     service = get_service_account_client()
     for username in team_members_to_add + co_pis_to_add:

--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -443,6 +443,7 @@ EMAIL_HOST_PASSWORD = os.environ.get('SMTP_PASSWORD', '')
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', 'no-reply@designsafe-ci.org')
 MEETING_REQUEST_EMAIL = os.environ.get('MEETING_REQUEST_EMAIL', 'info@designsafe-ci.org')
 NEW_ACCOUNT_ALERT_EMAIL = os.environ.get('NEW_ACCOUNT_ALERT_EMAIL', 'no-reply@designsafe-ci.org')
+PROJECT_ADMINS_EMAIL = ['maria@tacc.utexas.edu', 'gendlerk@tacc.utexas.edu']
 
 ###
 # Terms and Conditions

--- a/designsafe/static/scripts/data-depot/components/projects/curation-directory/curation-directory.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/curation-directory/curation-directory.component.html
@@ -27,14 +27,16 @@
             <tr class="prj-row" ng-hide="$ctrl.browser.project.value.projectType === 'other' && $ctrl.browser.project.value.dataType">
                 <td>Project Type</td>
                 <td class="prj-data" ng-if="$ctrl.browser.project.value.projectType !== 'field_recon'">
-                    {{ $ctrl.browser.project.value.projectType.replace('_', ' ') }}
-                    <a ng-if="$ctrl.browser.project.value.projectType == 'experimental' || $ctrl.browser.project.value.projectType == 'simulation'"
-                        ng-click="$ctrl.overview()"
-                    >
-                        View Curation Overview for {{ $ctrl.browser.project.value.projectType.replace('_', ' ') }} Projects
+                    {{ $ctrl.browser.project.value.projectType.replace('_', ' ') }} &nbsp;
+                    <a ng-if="['experimental', 'simulation'].includes($ctrl.browser.project.value.projectType)"
+                        ng-click="$ctrl.overview()">
+                        View Overview
                     </a>
                 </td>
-                <td class="prj-data" ng-if="$ctrl.browser.project.value.projectType === 'field_recon'">Field Research</td>
+                <td class="prj-data" ng-if="$ctrl.browser.project.value.projectType === 'field_recon'">
+                    Field Research &nbsp;
+                    <a ng-click="$ctrl.overview()">View Overview</a>
+                </td>
             </tr>
             <tr class="prj-row" ng-if="$ctrl.browser.project.value.projectType === 'other' && $ctrl.browser.project.value.dataType">
                 <td>Data Type</td>

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-publish/pipeline-privacy-agreement.html
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-publish/pipeline-privacy-agreement.html
@@ -84,43 +84,6 @@
                 </span>
             </span>
         </div>
-        <!-- <div class="prj-agree-body">
-            <h3>
-                Privacy Guidelines Regarding the Storage and Publication of Human Subjects Data
-            </h3>
-            <hr>
-            <p>
-                To publish protected data researchers should adhere to the following procedures:
-            </p>
-            <p>
-                a)	Do not publish HIPPA, FERPA, PII data or other sensitive information in DesignSafe.
-            </p>
-            <p>
-                b)	To publish protected data and any related documentation (reports, planning documents,
-                field notes, etc.) it must be properly anonymized. No direct identifiers are allowed.
-                These include items such as participant names, participant initials, facial photographs
-                unless expressly authorized by participants), home addresses, social security numbers and
-                dates of birth. Up to three indirect identifiers are allowed in a published dataset. These
-                are identifiers that, taken together, could be used to deduce someone’s identity. Examples
-                include gender, household and family compositions, occupation, places of birth, or year of
-                birth/age.
-            </p>
-            <p>
-                c)	If a researcher needs to restrict public access to data because it includes highly
-                sensitive personal information, or because removing the indirect identifiers will impair
-                the data understandability, you may only publish metadata and other documentation about
-                the data in DesignSafe. Users interested in the data will contact the PI (your email address
-                will be published) to request access to the data and to discuss the conditions for its reuse.
-                Please contact DesignSafe’s curator through a HELP ticket prior to preparing this type of
-                data publication.
-            </p>
-            <span class="prj-agree-select" ng-if="!$ctrl.ui.submitted && !$ctrl.ui.published">
-                <span>
-                    <input type="checkbox" id="agreement1" name="agreement1" ng-model="$ctrl.agreed1">
-                    <label for="agreement1"> The data I am publishing adheres to the procedures listed above </label>
-                </span>
-            </span>
-        </div> -->
         <div class="prj-agree-body">
             <h3>
                 Publishing Agreement

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-publish/pipeline-privacy-agreement.html
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-publish/pipeline-privacy-agreement.html
@@ -15,6 +15,77 @@
     <div ng-if="!$ctrl.ui.loading">
         <div class="prj-agree-body">
             <h3>
+                Guidelines Regarding the Storage and Publication of Protected Data in DesignSafe-CI
+            </h3>
+            <hr>
+            <p>
+                Researchers should always comply with the requirements, norms and procedures approved 
+                by the Institutional Review Board (IRB) or equivalent body, regarding human subjects’
+                data storage and publication.
+            </p>
+            <p>
+                <i>Protected data</i> includes human subjects data with Personal Identifiable Information (PII),
+                data that is protected under
+                <a href="https://www.hhs.gov/hipaa/for-professionals/privacy/laws-regulations/index.html" target="_blank">HIPPA</a>,
+                <a href="https://studentprivacy.ed.gov/faq/what-ferpa" target="_blank">FERPA</a> and
+                <a href="https://csrc.nist.gov/projects/risk-management/detailed-overview" target="_blank">FISMA</a>
+                regulations, as well as data that involves vulnerable populations and that contains
+                <a href="https://en.wikipedia.org/wiki/Information_sensitivity" target="_blank">sensitive information</a>.
+            </p>
+            <div class="overview-heading">Storing Protected Data</div>
+            <p>
+                DesignSafe My Data and My Projects are secure spaces to store raw protected data as
+                long as it is not under HIPPA, FERPA or FISMA regulations. If data needs to comply with
+                these regulations, researchers must contact DesignSafe through a
+                <a href="/help/new-ticket/" target="_blank">help ticket</a>
+                to evaluate the case and use
+                <a href="https://www.tacc.utexas.edu/protected-data-service" target="_blank">TACC‘s Protected Data Service</a>.
+                Researchers with doubts are welcome to send a
+                <a href="/help/new-ticket/" target="_blank">ticket</a> or join
+                <a href="/learning-center/training/" target="_blank">curation office hours</a>.
+            </p>
+            <div class="overview-heading">Publishing Protected Data</div>
+            <p>
+                To publish protected data researchers should adhere to the following procedures:
+            </p>
+            <p>
+                1.  Do not publish HIPPA, FERPA, FISMA, PII data or other sensitive information in DesignSafe.
+            </p>
+            <p>
+                2.  To publish protected data and any related documentation (reports, planning documents,
+                field notes, etc.) it must be properly anonymized. No <i>direct identifiers</i> and up to
+                three <i>indirect identifiers</i> are allowed. <i>Direct identifiers</i> include items such
+                as participant names, participant initials, facial photographs (unless expressly authorized
+                by participants), home addresses, social security numbers and dates of birth. <i>Indirect identifiers</i>
+                are identifiers that, taken together, could be used to deduce someone’s identity. Examples of
+                <i>indirect identifiers</i> include gender, household and family compositions, occupation,
+                places of birth, or year of birth/age.
+            </p>
+            <p>
+                3.  If a researcher needs to restrict public access to data because it includes HIPPA, FERPA,
+                PII data or other sensitive information, consider publishing metadata and other documentation
+                about the data.
+            </p>
+            <p>
+                4.  Users of DesignSafe interested in the data will be directed to contact the project PI or
+                designated point of contact through a published email address to request access to the data
+                and to discuss the conditions for its reuse.
+            </p>
+            <p>
+                5.  Please contact DesignSafe through a
+                <a href="/help/new-ticket/" target="_blank">help ticket</a> or join
+                <a href="/learning-center/training/" target="_blank">curation office hours</a>
+                prior to preparing this type of data publication.
+            </p>
+            <span class="prj-agree-select" ng-if="!$ctrl.ui.submitted && !$ctrl.ui.published">
+                <span>
+                    <input type="checkbox" id="agreement1" name="agreement1" ng-model="$ctrl.agreed1">
+                    <label for="agreement1"> The data I am publishing adheres to the procedures listed above </label>
+                </span>
+            </span>
+        </div>
+        <!-- <div class="prj-agree-body">
+            <h3>
                 Privacy Guidelines Regarding the Storage and Publication of Human Subjects Data
             </h3>
             <hr>
@@ -49,7 +120,7 @@
                     <label for="agreement1"> The data I am publishing adheres to the procedures listed above </label>
                 </span>
             </span>
-        </div>
+        </div> -->
         <div class="prj-agree-body">
             <h3>
                 Publishing Agreement

--- a/designsafe/static/scripts/data-depot/components/projects/project-view/project-view.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/project-view/project-view.component.html
@@ -28,9 +28,16 @@
         <tr class="prj-row" ng-hide="$ctrl.browser.project.value.projectType === 'other' && $ctrl.browser.project.value.dataType">
           <td>Project Type</td>
           <td class="prj-data" ng-if="$ctrl.browser.project.value.projectType !== 'field_recon'">
-              {{ $ctrl.browser.project.value.projectType.replace('_', ' ') }}
+              {{ $ctrl.browser.project.value.projectType.replace('_', ' ') }} &nbsp;
+              <a ng-if="['experimental', 'simulation'].includes($ctrl.browser.project.value.projectType)"
+                  ng-click="$ctrl.overview()">
+                  View Overview
+              </a>
           </td>
-          <td class="prj-data" ng-if="$ctrl.browser.project.value.projectType === 'field_recon'">Field Research</td>
+          <td class="prj-data" ng-if="$ctrl.browser.project.value.projectType === 'field_recon'">
+              Field Research &nbsp;
+              <a ng-click="$ctrl.overview()">View Overview</a>
+          </td>
         </tr>
         <tr class="prj-row" ng-if="$ctrl.browser.project.value.projectType === 'other' && $ctrl.browser.project.value.dataType">
           <td>Data Type</td>

--- a/designsafe/static/scripts/data-depot/components/projects/project-view/project-view.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/project-view/project-view.component.js
@@ -81,16 +81,13 @@ class ProjectViewCtrl {
     this.ProjectService.editProject(this.browser.project);
   }
 
-  manageProjectType($event) {
-    if ($event) {
-      $event.preventDefault();
-    }
+  overview() {
     this.$uibModal.open({
-      component: 'manageProjectType',
-      resolve: {
-        options: () => { return { 'project': this.browser.project, 'warning': false }; },
-      },
-      size: 'lg',
+        component: 'manageProjectType',
+        resolve: {
+            options: () => { return {'project': this.browser.project, 'preview': true, 'warning': false}; },
+        },
+        size: 'lg',
     });
   }
 

--- a/designsafe/static/scripts/ng-designsafe/services/project-service.js
+++ b/designsafe/static/scripts/ng-designsafe/services/project-service.js
@@ -16,6 +16,7 @@ export function ProjectService(httpi, $interpolate, $q, $state, $uibModal, Loggi
     let projectResource = httpi.resource('/api/projects/:uuid/').setKeepTrailingSlash(true);
     let collabResource = httpi.resource('/api/projects/:uuid/collaborators/').setKeepTrailingSlash(true);
     let dataResource = httpi.resource('/api/projects/:uuid/data/:fileId').setKeepTrailingSlash(true);
+    let notificationResource = httpi.resource('/api/projects/:uuid/notification/').setKeepTrailingSlash(true);
     //var entitiesResource = httpi.resource('/api/projects/:uuid/meta/:name/').setKeepTrailingSlash(true);
     //var entityResource = httpi.resource('/api/projects/meta/:uuid/').setKeepTrailingSlash(true);
 
@@ -315,6 +316,17 @@ export function ProjectService(httpi, $interpolate, $q, $state, $uibModal, Loggi
             },
             size: 'lg',
         });
+    };
+
+    /**
+     *
+     * @param options
+     * @param {string} options.uuid The Project uuid
+     * @param {string} options.username The username of the collaborator to add
+     * @returns {Promise}
+     */
+    service.notifyPersonalData = (options) => {
+        return notificationResource.post({ data: options });
     };
 
     /**

--- a/designsafe/static/scripts/projects/components/manage-project-type/manage-project-type.component.js
+++ b/designsafe/static/scripts/projects/components/manage-project-type/manage-project-type.component.js
@@ -1,5 +1,4 @@
-import ManageProjectTypeTemplate from './manage-project-type.component.html';
-import _ from 'underscore';
+import ManageProjectTypeTemplate from './manage-project-type.template.html';
 
 class ManageProjectTypeCtrl {
 
@@ -17,9 +16,10 @@ class ManageProjectTypeCtrl {
         this.project = this.resolve.options.project;
         this.warning = this.resolve.options.warning;
         this.preview = this.resolve.options.preview;
-        this.prjType = '';
         this.projectResource = this.httpi.resource('/api/projects/:uuid/').setKeepTrailingSlash(true);
+        this.prjType = '';
         this.slide = 'type';
+        this.protectedData = -1;
         if (this.preview) {
             this.prjType = this.project.value.projectType;
             this.slide = 'overview';
@@ -44,6 +44,10 @@ class ManageProjectTypeCtrl {
             projectData.projectId = this.project.value.projectId;
             projectData.uuid = this.project.uuid;
 
+            if (this.prjType === 'field_recon' && this.protectedData > 0) {
+                this.sendNotificationEmail();
+            }
+
             this.savePrj(projectData).then((project) => {
                 this.DataBrowserService.state().project.value.projectType = project.value.projectType;
                 this.close({$value: project});
@@ -53,6 +57,14 @@ class ManageProjectTypeCtrl {
                 });
             });
         }
+    }
+
+    sendNotificationEmail() {
+        console.log('component');
+        this.ProjectService.notifyPersonalData({
+            uuid: this.project.uuid,
+            username: this.project.value.pi
+        })
     }
 
     savePrj(options) {

--- a/designsafe/static/scripts/projects/components/manage-project-type/manage-project-type.template.html
+++ b/designsafe/static/scripts/projects/components/manage-project-type/manage-project-type.template.html
@@ -625,7 +625,7 @@
                     <i class="fa fa-arrow-left">&nbsp;</i> <strong>Back</strong>
                 </a>
                 <button class="btn btn-add pull-right"
-                        data-ng-click="$ctrl.continue('finish')">
+                        data-ng-click="$ctrl.continue('protected_data')">
                     Continue
                 </button>
             </div>
@@ -651,6 +651,89 @@
             </table>
         </div>
         <!-- Project Overview -->
+    </div>
+    <!-- Project Protected Data Check -->
+    <div ng-if="$ctrl.slide === 'protected_data'">
+        <div ng-if="$ctrl.prjType === 'field_recon'">
+            <div class="overview-body">
+                <h3 style="text-align: center;">
+                    Will you or other team members upload protected data to this project?
+                </h3>
+                <div>
+                    <!-- format radio buttons and test e-mail options -->
+                    <!-- send user info and type of information chosen -->
+                    <input type="radio"
+                            name="protected-data-option"
+                            id="no-protected-data"
+                            ng-model="$ctrl.protectedData"
+                            value="0"
+                            class="overview-radio-btn"
+                    >
+                    <strong>No, we will upload only non-confidential and/or non-personal information:</strong>
+                    <ul>
+                        <li>
+                            The data has been de-identified and/or there is no Personally Identifiable
+                            Information (PII), or you received approval to publish PII from the research
+                            subjects.
+                        </li>
+                        <li>
+                            For an example of the type of data that fits category and has been published
+                            on DesignSafe, see: https://doi.org/10.17603/e9wq-gz57
+                        </li>
+                    </ul>
+                </div>
+                <hr>
+                <div>
+                    <input type="radio"
+                            name="protected-data-option"
+                            id="protected-data"
+                            ng-model="$ctrl.protectedData"
+                            value="1"
+                            class="overview-radio-btn"
+                    >
+                    <strong>Yes, we will upload sensitive personal information</strong>
+                    <ul>
+                        <li>
+                            Includes any of these types of confidential information that may pose a risk if disclosed to non-authorized
+                            individuals.
+                        </li>
+                        <li>
+                            See examples of this type of data
+                        </li>
+                    </ul>
+                </div>
+                <hr>
+                <div>
+                    <input type="radio"
+                            name="protected-data-option"
+                            id="very-protected-data"
+                            ng-model="$ctrl.protectedData"
+                            value="2"
+                            class="overview-radio-btn"
+                    >
+                    <strong>Yes, we will upload very sensitive confidential information</strong>
+                    <ul>
+                        <li>
+                            Examples include any type of confidential information that would cause harm to individuals if not
+                            accessed only by authorized individuals. For example, medical diagnoses records, very sensitive
+                            financial records, criminal records, data involved in issues of national security, etc.
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <table style="width: 100%;">
+                <tr>
+                    <td class="overview-back-long">
+                        <a ng-click="$ctrl.continue('overview')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
+                    </td>
+                    <td class="overview-continue">
+                        <button class="btn btn-add" style="width: 100%;" ng-click="$ctrl.continue('finish')" ng-disabled="$ctrl.protectedData==-1">
+                            Continue
+                        </button>
+                    </td>
+                </tr>
+            </table>
+        </div>
     </div>
     <!-- Project Finish -->
     <div ng-if="$ctrl.slide === 'finish'">
@@ -722,7 +805,7 @@
                 <td class="overview-back-long">
                     <a ng-if="$ctrl.prjType === 'experimental' || $ctrl.prjType === 'simulation'" ng-click="$ctrl.continue('tags')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
                     <a ng-if="$ctrl.prjType === 'hybrid_simulation' || $ctrl.prjType == 'other'" ng-click="$ctrl.continue('type')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
-                    <a ng-if="$ctrl.prjType === 'field_recon'" ng-click="$ctrl.continue('overview')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
+                    <a ng-if="$ctrl.prjType === 'field_recon'" ng-click="$ctrl.continue('protected_data')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
                 </td>
                 <td class="overview-continue">
                     <button class="btn btn-add" style="width: 100%;" ng-click="$ctrl.finish()">

--- a/designsafe/static/scripts/projects/components/manage-project-type/manage-project-type.template.html
+++ b/designsafe/static/scripts/projects/components/manage-project-type/manage-project-type.template.html
@@ -579,56 +579,288 @@
         <!-- Project Overview -->
     </div>
     <div ng-if="$ctrl.prjType === 'field_recon'">
-        <!-- Project Overview -->
+        <!-- Field Research - Overview -->
         <div ng-if="$ctrl.slide === 'overview'">
-            <div>
+            <div class="overview-body">
+                <h3>Field Research</h3>
+                <hr>
                 <p>
-                    DesignSafe offers an interactive interface to curate and publish data with other project members.
-                    Curation is important so your data can be <strong>organized</strong>, <strong>discovered</strong>, and <strong>understood</strong> for years to come.
+                    Field research projects allow engineers and social scientists to curate and publish together or independently.
                 </p>
                 <p>
-                    The four components of curation:
-                    <div style="margin-left: 18px;">
-                        <div>
-                            <strong>Missions</strong> group collections of data representing different visits to a site, field teams, field experiments,
-                            or research topics (e.g., liquefaction, structural performance, wave inundation, etc.). Some researchers refer to missions using
-                            terms such as "time 1", "wave 1", etc.
-                        </div>
-                        <div>
-                            <strong>Collections</strong> group related data gathered in a mission. Sub-collections are organized within folders.
-                        </div>
-                        <div>
-                            <strong>Relate</strong> relates collections to missions and allows hierarchical organization.
-                        </div>
-                        <div>
-                            <strong>Reports</strong> group virtual reconnaissance, field assessments, or preliminary virtual assessments that can be published
-                            before the missions or as a final report.
-                        </div>
-                        <div>
-                            <strong>File Tags</strong> are agreed upon terms from the community that describe individual files.
-                        </div>
-                    </div>
+                    Curation is important so your data can be
+                    <strong>organized</strong>, <strong>discovered</strong>, and <strong>understood</strong>
+                    for years to come.
                 </p>
+                <p>
+                    The four components of curating field research projects:
+                </p>
+                <div style="margin-left: 18px;">
+                    <p>
+                        <strong>Missions</strong><br>
+                        Missions group collections of data representing different visits to a site, field teams,
+                        field experiments, or research topics (e.g., liquefaction, structural performance, wave
+                        inundation, etc.). Some researchers refer to missions using terms such as “time 1”, “wave 1”, etc.
+                    </p>
+                    <p>
+                        <strong>Collections</strong><br>
+                        Collections group files together based on a shared purpose in a mission.
+                    </p>
+                    <p>
+                        <strong>Relating Data</strong><br>
+                        Relating data organizes missions and their respective collections.
+                    </p>
+                    <p>
+                        <strong>File Tags</strong><br>
+                        File tags are agreed upon terms that the community contributes for describing files and directories.
+                    </p>
+                </div>
+                <br>
                 <p>
                     For further help with curation, DesignSafe has the following resources:
-                    <li> <a href="/rw/user-guides/data-curation-publication/" target="_blank">Data Curation and Publication user guide</a></li>
-                    <li> <a href="/rw/user-guides/data-publication-guidelines/" target="_blank">Data Publication Guidelines</a></li>
-                    <li> <a href="https://www.youtube.com/playlist?list=PL2GxvrdFrBlkwHBgQ47pZO-77ZLrJKYHV" target="_blank">YouTube video instruction series</a></li>
-                    <!-- <li> <a href="______" target="_blank">Example projects that highlight best practices</a> (recommended)</li> -->
-                    <li> <a href="/learning-center/training/" target="_blank">Curation office hours</a></li>
-                    <li> <a href="/learning-center/training/" target="_blank">Webinars</a></li>
+                    <ul>
+                        <li><a href="/rw/user-guides/data-curation-publication/" target="_blank">Data Curation and Publication user guide</a></li>
+                        <li> <a href="/rw/user-guides/data-publication-guidelines/" target="_blank">Data publication guidelines</a></li>
+                        <li> <a href="/learning-center/training/" target="_blank">Curation office hours</a></li>
+                    </ul>
                 </p>
-                <br> 
             </div>
-            <div class="btn-group" style="overflow: auto; width:100%;">
-                <a data-ng-click="$ctrl.continue('type')" class="pull-left">
-                    <i class="fa fa-arrow-left">&nbsp;</i> <strong>Back</strong>
-                </a>
-                <button class="btn btn-add pull-right"
-                        data-ng-click="$ctrl.continue('protected_data')">
-                    Continue
-                </button>
+            <table style="width: 100%;">
+                <tr>
+                    <td class="overview-skip">
+                        <a ng-click="$ctrl.continue('protected_data')"><strong>Skip Overview</strong></a> (not recommended)
+                    </td>
+                    <td class="overview-back-short">
+                        <a ng-click="$ctrl.continue('type')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
+                    </td>
+                    <td class="overview-continue">
+                        <button class="btn btn-add" style="width: 100%;" ng-click="$ctrl.continue('missions')">
+                            Continue
+                        </button> 
+                    </td>
+                </tr>
+            </table>
+        </div>
+        <!-- Field Research - Missions -->
+        <div ng-if="$ctrl.slide === 'missions'">
+            <div class="overview-body">
+                <h3>Missions</h3>
+                <hr>
+                <p>
+                    Missions group collections of data representing different visits to a site,
+                    field teams, field experiments, or research topics (e.g., liquefaction, structural
+                    performance, wave inundation, etc.). Some researchers refer to missions using terms
+                    such as “time 1”, “wave 1”, etc.
+                </p>
+                <ul>
+                    <li>A mission is a self-contained component within a project.</li>
+                    <li>You can publish subsequent missions over the lifespan of the project.</li>
+                    <li>Each mission receives its own DOI.</li>
+                    <li>Missions are all related under a single project.</li>
+                </ul>
+                <br>
+                <h3>Research Planning Collections</h3>
+                <hr>
+                <p>
+                    Research planning collections group files related to planning and logistics,
+                    administration, design, institutional review board (IRB), or permits.
+                </p>
+                <ul>
+                    <li>Users find these files very helpful for understanding projects and planning new ones.</li>
+                    <li>
+                        File types: Consent forms, data management plans, IRB applications, letters of support,
+                        planning documents, permits, protocols, quality assurance plans, reports, reflexivity
+                        reports (also called reflections or best practices), and team trainings.
+                    </li>
+                </ul>
             </div>
+            <table style="width: 100%;">
+                <tr>
+                    <td class="overview-skip">
+                        <a ng-click="$ctrl.continue('protected_data')"><strong>Skip Overview</strong></a> (not recommended)
+                    </td>
+                    <td class="overview-back-short">
+                        <a ng-click="$ctrl.continue('overview')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
+                    </td>
+                    <td class="overview-continue">
+                        <button class="btn btn-add" style="width: 100%;" ng-click="$ctrl.continue('collections1')">
+                            Continue
+                        </button> 
+                    </td>
+                </tr>
+            </table>
+        </div>
+        <!-- Field Research - Collections pt1 -->
+        <div ng-if="$ctrl.slide === 'collections1'">
+            <div class="overview-body">
+                <h3>Engineering/Geosciences Collections</h3>
+                <hr>
+                <p>
+                    Engineering/geosciences collections group related data from the
+                    engineering/geosciences domain.
+                </p>
+                <ul>
+                    <li>
+                        File types: 3D models, audio, building codes, data processing methods, images, lidar, 
+                        point clouds, notes, scans, tracks, videos, reports, and virtual reconnaissance.
+                    </li>
+                </ul>
+                <br>
+                <h3>Social Sciences Collections</h3>
+                <hr>
+                <p>Social sciences collections group related data from the social sciences domain.</p>
+                <ul>
+                    <li>
+                        File types: audio, data documentation, images, instruments, raw data,
+                        reports, transcripts, and variables.
+                    </li>
+                </ul>
+            </div>
+            <table style="width: 100%;">
+                <tr>
+                    <td class="overview-skip">
+                        <a ng-click="$ctrl.continue('protected_data')"><strong>Skip Overview</strong></a> (not recommended)
+                    </td>
+                    <td class="overview-back-short">
+                        <a ng-click="$ctrl.continue('missions')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
+                    </td>
+                    <td class="overview-continue">
+                        <button class="btn btn-add" style="width: 100%;" ng-click="$ctrl.continue('collections2')">
+                            Continue
+                        </button> 
+                    </td>
+                </tr>
+            </table>
+        </div>
+        <!-- Field Research - Collections pt2 -->
+        <div ng-if="$ctrl.slide === 'collections2'">
+            <div class="overview-body">
+                <h3>Documents Collections</h3>
+                <hr>
+                <p>
+                    Documents collections include instruments, protocols, and different
+                    reports (virtual reconnaissance, field assessment, preliminary virtual
+                    assessment, etc). These collections are published separately, each with
+                    their own DOI.
+                </p>
+                <ul>
+                    <li>
+                        Use this collection to publish files outside the mission, especially
+                        for planning and reporting files that encompass the entire project.
+                        You can publish more than one documents collections over time.
+                    </li>
+                </ul>
+                <br>
+                <h3>Relating Data</h3>
+                <hr>
+                <p>Relating data organizes missions and their respective collections.</p>
+                <ul>
+                    <li>
+                        Organize the missions and collections such that another user
+                        can easily understand the project.
+                    </li>
+                    <li>
+                        If a collection is across multiple missions (example: a survey
+                        instrument or other planning files), you can put the same collection
+                        in multiple missions.
+                    </li>
+                </ul>
+            </div>
+            <table style="width: 100%;">
+                <tr>
+                    <td class="overview-skip">
+                        <a ng-click="$ctrl.continue('protected_data')"><strong>Skip Overview</strong></a> (not recommended)
+                    </td>
+                    <td class="overview-back-short">
+                        <a ng-click="$ctrl.continue('collections1')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
+                    </td>
+                    <td class="overview-continue">
+                        <button class="btn btn-add" style="width: 100%;" ng-click="$ctrl.continue('file_tags')">
+                            Continue
+                        </button> 
+                    </td>
+                </tr>
+            </table>
+        </div>
+        <!-- Field Research - File Tags -->
+        <div ng-if="$ctrl.slide === 'file_tags'">
+            <div class="overview-body">
+                <h3>File Tags</h3>
+                <hr>
+                <p>File tags are agreed upon terms that the community contributes for describing files and directories.</p>
+                <ul>
+                    <li>The option to tag a file appears after you’ve put files in collections.</li>
+                    <li>The tags available for a file depend on the collection you have put the file into.</li>
+                    <li>If you can’t find a tag that describes your file, select ‘other’ to type in a custom tag.</li>
+                    <li>You can add multiple tags to one file.</li>
+                    <li>The natural hazards community has contributed to creating the agreed-upon terms.</li>
+                    <li>
+                        Using agreed-upon terms helps other researchers refine their search and discover specific files
+                        in your publication.
+                    </li>
+                    <li>These tags are optional, but strongly recommended.</li>
+                </ul>
+            </div>
+            <table style="width: 100%;">
+                <tr>
+                    <td class="overview-skip">
+                        <a ng-click="$ctrl.continue('protected_data')"><strong>Skip Overview</strong></a> (not recommended)
+                    </td>
+                    <td class="overview-back-short">
+                        <a ng-click="$ctrl.continue('collections2')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
+                    </td>
+                    <td class="overview-continue">
+                        <button class="btn btn-add" style="width: 100%;" ng-click="$ctrl.continue('best_practice')">
+                            Continue
+                        </button> 
+                    </td>
+                </tr>
+            </table>
+        </div>
+        <!-- Field Research - Best Practices -->
+        <div ng-if="$ctrl.slide === 'best_practice'">
+            <div class="overview-body">
+                <h3>Best Practices</h3>
+                <hr>
+                <ul>
+                    <li>
+                        Publish data files in a format that is interoperable and open.
+                        Example: CSV instead of SAS files
+                    </li>
+                    <li>
+                        Before publishing raw data that has not been processed, consider
+                        why it is necessary. If so, explain how others can use the raw data.
+                    </li>
+                    <li>
+                        Be selective with any images you choose. Use file tags to describe them.
+                        Make sure they have a purpose or a function.
+                    </li>
+                    <li>
+                        Do not publish ZIP files. ZIP files prevent others from viewing and
+                        understanding your data.
+                    </li>
+                    <li>Use applicable software to review for any errors in your data before you publish.</li>
+                    <li>
+                        Avoid publishing data within folders. Instead, provide a direct view
+                        to the data within collections so others can understand your project at a glance.
+                    </li>
+                </ul>
+            </div>
+            <table style="width: 100%;">
+                <tr>
+                    <td class="overview-skip">
+                        <a ng-click="$ctrl.continue('protected_data')"><strong>Skip Overview</strong></a> (not recommended)
+                    </td>
+                    <td class="overview-back-short">
+                        <a ng-click="$ctrl.continue('file_tags')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
+                    </td>
+                    <td class="overview-continue">
+                        <button class="btn btn-add" style="width: 100%;" ng-click="$ctrl.continue('protected_data')">
+                            Continue
+                        </button> 
+                    </td>
+                </tr>
+            </table>
         </div>
     </div>
     <div ng-if="$ctrl.prjType === 'other'">
@@ -724,7 +956,7 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-back-long">
-                        <a ng-click="$ctrl.continue('overview')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
+                        <a ng-click="$ctrl.continue('best_practice')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
                     </td>
                     <td class="overview-continue">
                         <button class="btn btn-add" style="width: 100%;" ng-click="$ctrl.continue('finish')" ng-disabled="$ctrl.protectedData==-1">
@@ -740,6 +972,71 @@
         <div ng-if="$ctrl.prjType === 'field_recon'">
             <!-- Project Finish -->
             <div class="overview-body">
+                <h3>
+                    Guidelines Regarding the Storage and Publication of Protected Data in DesignSafe-CI
+                </h3>
+                <hr>
+                <p>
+                    Researchers should always comply with the requirements, norms and procedures approved 
+                    by the Institutional Review Board (IRB) or equivalent body, regarding human subjects’
+                    data storage and publication.
+                </p>
+                <p>
+                    <i>Protected data</i> includes human subjects data with Personal Identifiable Information (PII),
+                    data that is protected under
+                    <a href="https://www.hhs.gov/hipaa/for-professionals/privacy/laws-regulations/index.html" target="_blank">HIPPA</a>,
+                    <a href="https://studentprivacy.ed.gov/faq/what-ferpa" target="_blank">FERPA</a> and
+                    <a href="https://csrc.nist.gov/projects/risk-management/detailed-overview" target="_blank">FISMA</a>
+                    regulations, as well as data that involves vulnerable populations and that contains
+                    <a href="https://en.wikipedia.org/wiki/Information_sensitivity" target="_blank">sensitive information</a>.
+                </p>
+                <div class="overview-heading">Storing Protected Data</div>
+                <p>
+                    DesignSafe My Data and My Projects are secure spaces to store raw protected data as
+                    long as it is not under HIPPA, FERPA or FISMA regulations. If data needs to comply with
+                    these regulations, researchers must contact DesignSafe through a
+                    <a href="/help/new-ticket/" target="_blank">help ticket</a>
+                    to evaluate the case and use
+                    <a href="https://www.tacc.utexas.edu/protected-data-service" target="_blank">TACC‘s Protected Data Service</a>.
+                    Researchers with doubts are welcome to send a
+                    <a href="/help/new-ticket/" target="_blank">ticket</a> or join
+                    <a href="/learning-center/training/" target="_blank">curation office hours</a>.
+                </p>
+                <div class="overview-heading">Publishing Protected Data</div>
+                <p>
+                    To publish protected data researchers should adhere to the following procedures:
+                </p>
+                <p>
+                    1.  Do not publish HIPPA, FERPA, FISMA, PII data or other sensitive information in DesignSafe.
+                </p>
+                <p>
+                    2.  To publish protected data and any related documentation (reports, planning documents,
+                    field notes, etc.) it must be properly anonymized. No <i>direct identifiers</i> and up to
+                    three <i>indirect identifiers</i> are allowed. <i>Direct identifiers</i> include items such
+                    as participant names, participant initials, facial photographs (unless expressly authorized
+                    by participants), home addresses, social security numbers and dates of birth. <i>Indirect identifiers</i>
+                    are identifiers that, taken together, could be used to deduce someone’s identity. Examples of
+                    <i>indirect identifiers</i> include gender, household and family compositions, occupation,
+                    places of birth, or year of birth/age.
+                </p>
+                <p>
+                    3.  If a researcher needs to restrict public access to data because it includes HIPPA, FERPA,
+                    PII data or other sensitive information, consider publishing metadata and other documentation
+                    about the data.
+                </p>
+                <p>
+                    4.  Users of DesignSafe interested in the data will be directed to contact the project PI or
+                    designated point of contact through a published email address to request access to the data
+                    and to discuss the conditions for its reuse.
+                </p>
+                <p>
+                    5.  Please contact DesignSafe through a
+                    <a href="/help/new-ticket/" target="_blank">help ticket</a> or join
+                    <a href="/learning-center/training/" target="_blank">curation office hours</a>
+                    prior to preparing this type of data publication.
+                </p>
+            </div>
+            <!-- <div class="overview-body">
                 <h3>
                     Guidelines Regarding the Storage and Publication of Human Subjects Data
                 </h3>
@@ -786,7 +1083,7 @@
                     Please contact DesignSafe’s curator through a HELP ticket prior to preparing this type of
                     data publication.
                 </p>
-            </div>
+            </div> -->
         </div>
         <div ng-if="$ctrl.prjType !== 'field_recon'">
             <p>

--- a/designsafe/static/scripts/projects/components/manage-project-type/manage-project-type.template.html
+++ b/designsafe/static/scripts/projects/components/manage-project-type/manage-project-type.template.html
@@ -205,10 +205,16 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-skip">
-                        <a ng-click="$ctrl.continue('finish')"><strong>Skip Overview</strong></a> (not recommended)
+                        <span ng-hide="$ctrl.preview">
+                            <a ng-click="$ctrl.continue('finish')">
+                                <strong>Skip Overview</strong>
+                            </a> (not recommended)
+                        </span>
                     </td>
                     <td class="overview-back-short">
-                        <a ng-if="!$ctrl.preview" ng-click="$ctrl.continue('type')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
+                        <a ng-hide="$ctrl.preview" ng-click="$ctrl.continue('type')">
+                            <i class="fa fa-arrow-left"></i> <strong>Back</strong>
+                        </a>
                     </td>
                     <td class="overview-continue">
                         <button class="btn btn-add" style="width: 100%;" ng-click="$ctrl.continue('experiment')">
@@ -239,7 +245,11 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-skip">
-                        <a ng-click="$ctrl.continue('finish')"><strong>Skip Overview</strong></a> (not recommended)
+                        <span ng-hide="$ctrl.preview">
+                            <a ng-click="$ctrl.continue('finish')">
+                                <strong>Skip Overview</strong>
+                            </a> (not recommended)
+                        </span>
                     </td>
                     <td class="overview-back-short">
                         <a ng-click="$ctrl.continue('overview')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
@@ -287,7 +297,11 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-skip">
-                        <a ng-click="$ctrl.continue('finish')"><strong>Skip Overview</strong></a> (not recommended)
+                        <span ng-hide="$ctrl.preview">
+                            <a ng-click="$ctrl.continue('finish')">
+                                <strong>Skip Overview</strong>
+                            </a> (not recommended)
+                        </span>
                     </td>
                     <td class="overview-back-short">
                         <a ng-click="$ctrl.continue('experiment')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
@@ -321,7 +335,11 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-skip">
-                        <a ng-click="$ctrl.continue('finish')"><strong>Skip Overview</strong></a> (not recommended)
+                        <span ng-hide="$ctrl.preview">
+                            <a ng-click="$ctrl.continue('finish')">
+                                <strong>Skip Overview</strong>
+                            </a> (not recommended)
+                        </span>
                     </td>
                     <td class="overview-back-short">
                         <a ng-click="$ctrl.continue('categories')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
@@ -352,7 +370,11 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-skip">
-                        <a ng-click="$ctrl.continue('finish')"><strong>Skip Overview</strong></a> (not recommended)
+                        <span ng-hide="$ctrl.preview">
+                            <a ng-click="$ctrl.continue('finish')">
+                                <strong>Skip Overview</strong>
+                            </a> (not recommended)
+                        </span>
                     </td>
                     <td class="overview-back-short">
                         <a ng-click="$ctrl.continue('tree')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
@@ -398,10 +420,16 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-skip">
-                        <a ng-click="$ctrl.continue('finish')"><strong>Skip Overview</strong></a> (not recommended)
+                        <span ng-hide="$ctrl.preview">
+                            <a ng-click="$ctrl.continue('finish')">
+                                <strong>Skip Overview</strong>
+                            </a> (not recommended)
+                        </span>
                     </td>
                     <td class="overview-back-short">
-                        <a ng-if="!$ctrl.preview" ng-click="$ctrl.continue('type')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
+                        <a ng-hide="$ctrl.preview" ng-click="$ctrl.continue('type')">
+                            <i class="fa fa-arrow-left"></i> <strong>Back</strong>
+                        </a>
                     </td>
                     <td class="overview-continue">
                         <button class="btn btn-add" style="width: 100%;" ng-click="$ctrl.continue('simulation')">
@@ -431,7 +459,11 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-skip">
-                        <a ng-click="$ctrl.continue('finish')"><strong>Skip Overview</strong></a> (not recommended)
+                        <span ng-hide="$ctrl.preview">
+                            <a ng-click="$ctrl.continue('finish')">
+                                <strong>Skip Overview</strong>
+                            </a> (not recommended)
+                        </span>
                     </td>
                     <td class="overview-back-short">
                         <a ng-click="$ctrl.continue('overview')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
@@ -477,7 +509,11 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-skip">
-                        <a ng-click="$ctrl.continue('finish')"><strong>Skip Overview</strong></a> (not recommended)
+                        <span ng-hide="$ctrl.preview">
+                            <a ng-click="$ctrl.continue('finish')">
+                                <strong>Skip Overview</strong>
+                            </a> (not recommended)
+                        </span>
                     </td>
                     <td class="overview-back-short">
                         <a ng-click="$ctrl.continue('simulation')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
@@ -511,7 +547,11 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-skip">
-                        <a ng-click="$ctrl.continue('finish')"><strong>Skip Overview</strong></a> (not recommended)
+                        <span ng-hide="$ctrl.preview">
+                            <a ng-click="$ctrl.continue('finish')">
+                                <strong>Skip Overview</strong>
+                            </a> (not recommended)
+                        </span>
                     </td>
                     <td class="overview-back-short">
                         <a ng-click="$ctrl.continue('categories')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
@@ -542,7 +582,11 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-skip">
-                        <a ng-click="$ctrl.continue('finish')"><strong>Skip Overview</strong></a> (not recommended)
+                        <span ng-hide="$ctrl.preview">
+                            <a ng-click="$ctrl.continue('finish')">
+                                <strong>Skip Overview</strong>
+                            </a> (not recommended)
+                        </span>
                     </td>
                     <td class="overview-back-short">
                         <a ng-click="$ctrl.continue('tree')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
@@ -628,10 +672,16 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-skip">
-                        <a ng-click="$ctrl.continue('protected_data')"><strong>Skip Overview</strong></a> (not recommended)
+                        <span ng-hide="$ctrl.preview">
+                            <a ng-click="$ctrl.continue('protected_data')">
+                                <strong>Skip Overview</strong>
+                            </a> (not recommended)
+                        </span>
                     </td>
                     <td class="overview-back-short">
-                        <a ng-click="$ctrl.continue('type')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
+                        <a ng-hide="$ctrl.preview" ng-click="$ctrl.continue('type')">
+                            <i class="fa fa-arrow-left"></i> <strong>Back</strong>
+                        </a>
                     </td>
                     <td class="overview-continue">
                         <button class="btn btn-add" style="width: 100%;" ng-click="$ctrl.continue('missions')">
@@ -677,7 +727,11 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-skip">
-                        <a ng-click="$ctrl.continue('protected_data')"><strong>Skip Overview</strong></a> (not recommended)
+                        <span ng-hide="$ctrl.preview">
+                            <a ng-click="$ctrl.continue('protected_data')">
+                                <strong>Skip Overview</strong>
+                            </a> (not recommended)
+                        </span>
                     </td>
                     <td class="overview-back-short">
                         <a ng-click="$ctrl.continue('overview')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
@@ -719,7 +773,11 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-skip">
-                        <a ng-click="$ctrl.continue('protected_data')"><strong>Skip Overview</strong></a> (not recommended)
+                        <span ng-hide="$ctrl.preview">
+                            <a ng-click="$ctrl.continue('protected_data')">
+                                <strong>Skip Overview</strong>
+                            </a> (not recommended)
+                        </span>
                     </td>
                     <td class="overview-back-short">
                         <a ng-click="$ctrl.continue('missions')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
@@ -769,7 +827,11 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-skip">
-                        <a ng-click="$ctrl.continue('protected_data')"><strong>Skip Overview</strong></a> (not recommended)
+                        <span ng-hide="$ctrl.preview">
+                            <a ng-click="$ctrl.continue('protected_data')">
+                                <strong>Skip Overview</strong>
+                            </a> (not recommended)
+                        </span>
                     </td>
                     <td class="overview-back-short">
                         <a ng-click="$ctrl.continue('collections1')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
@@ -804,7 +866,11 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-skip">
-                        <a ng-click="$ctrl.continue('protected_data')"><strong>Skip Overview</strong></a> (not recommended)
+                        <span ng-hide="$ctrl.preview">
+                            <a ng-click="$ctrl.continue('protected_data')">
+                                <strong>Skip Overview</strong>
+                            </a> (not recommended)
+                        </span>
                     </td>
                     <td class="overview-back-short">
                         <a ng-click="$ctrl.continue('collections2')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
@@ -849,13 +915,19 @@
             <table style="width: 100%;">
                 <tr>
                     <td class="overview-skip">
-                        <a ng-click="$ctrl.continue('protected_data')"><strong>Skip Overview</strong></a> (not recommended)
+                        <span ng-hide="$ctrl.preview">
+                            <a ng-click="$ctrl.continue('protected_data')">
+                                <strong>Skip Overview</strong>
+                            </a> (not recommended)
+                        </span>
                     </td>
                     <td class="overview-back-short">
                         <a ng-click="$ctrl.continue('file_tags')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
                     </td>
                     <td class="overview-continue">
-                        <button class="btn btn-add" style="width: 100%;" ng-click="$ctrl.continue('protected_data')">
+                        <button class="btn btn-add"
+                                style="width: 100%;"
+                                ng-click="$ctrl.preview ? $ctrl.continue('finish') : $ctrl.continue('protected_data')">
                             Continue
                         </button> 
                     </td>
@@ -1036,73 +1108,49 @@
                     prior to preparing this type of data publication.
                 </p>
             </div>
-            <!-- <div class="overview-body">
-                <h3>
-                    Guidelines Regarding the Storage and Publication of Human Subjects Data
-                </h3>
-                <hr>
-                <p>
-                    Researchers should always comply with the requirements, norms and procedures
-                    approved by the Institutional Review Board (IRB) or equivalent body, regarding
-                    human subjects’ data storage and publication.
-                </p>
-                <p>
-                    Protected data includes human subjects data with Personal Identifiable Information
-                    (PII), data that is protected under HIPPA and FERPA regulations, as well as data that
-                    involves vulnerable populations and that contains sensitive information. 
-                </p>
-                <div class="overview-heading">Storing Protected Data</div>
-                <p>
-                    Do not store raw protected data in DesignSafe. Before storing, the data should be
-                    processed with the same precautions outlined in the Publishing Protected Data section
-                    below.
-                </p>
-                <div class="overview-heading">Publishing Protected Data</div>
-                <p>
-                    To publish protected data researchers should adhere to the following procedures:
-                </p>
-                <p>
-                    a)	Do not publish HIPPA, FERPA, PII data or other sensitive information in DesignSafe.
-                </p>
-                <p>
-                    b)	To publish protected data and any related documentation (reports, planning documents,
-                    field notes, etc.) it must be properly anonymized. No direct identifiers are allowed.
-                    These include items such as participant names, participant initials, facial photographs
-                    unless expressly authorized by participants), home addresses, social security numbers and
-                    dates of birth. Up to three indirect identifiers are allowed in a published dataset. These
-                    are identifiers that, taken together, could be used to deduce someone’s identity. Examples
-                    include gender, household and family compositions, occupation, places of birth, or year of
-                    birth/age.
-                </p>
-                <p>
-                    c)	If a researcher needs to restrict public access to data because it includes highly
-                    sensitive personal information, or because removing the indirect identifiers will impair
-                    the data understandability, you may only publish metadata and other documentation about
-                    the data in DesignSafe. Users interested in the data will contact the PI (your email address
-                    will be published) to request access to the data and to discuss the conditions for its reuse.
-                    Please contact DesignSafe’s curator through a HELP ticket prior to preparing this type of
-                    data publication.
-                </p>
-            </div> -->
         </div>
         <div ng-if="$ctrl.prjType !== 'field_recon'">
-            <p>
-                <strong>We recommend you follow these best practices for curation:</strong>
-                <li>
-                    Publish data files in a format that is interoperable and open.
-                    Example: CSV files instead of Excel spreadsheet files
-                </li>
-                <li>Before publishing raw data, consider why it is necessary. If so, explain how other can use the raw data.</li>
-                <li>Be selective with any images you choose. Use file tags to describe them. Make sure they have a purpose or a function.</li>
-                <li>Use applicable software to review for any errors in your data before you publish.</li>
-            </p>
+            <div class="overview-body">
+                <h3>Best Practices</h3>
+                <hr>
+                <ul>
+                    <li>
+                        Publish data files in a format that is interoperable and open.
+                        Example: CSV instead of SAS files
+                    </li>
+                    <li>
+                        Before publishing raw data that has not been processed, consider
+                        why it is necessary. If so, explain how others can use the raw data.
+                    </li>
+                    <li>
+                        Be selective with any images you choose. Use file tags to describe them.
+                        Make sure they have a purpose or a function.
+                    </li>
+                    <li>
+                        Do not publish ZIP files. ZIP files prevent others from viewing and
+                        understanding your data.
+                    </li>
+                    <li>Use applicable software to review for any errors in your data before you publish.</li>
+                    <li>
+                        Avoid publishing data within folders. Instead, provide a direct view
+                        to the data within collections so others can understand your project at a glance.
+                    </li>
+                </ul>
+            </div>
         </div>
         <table style="width: 100%;">
             <tr>
                 <td class="overview-back-long">
-                    <a ng-if="$ctrl.prjType === 'experimental' || $ctrl.prjType === 'simulation'" ng-click="$ctrl.continue('tags')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
-                    <a ng-if="$ctrl.prjType === 'hybrid_simulation' || $ctrl.prjType == 'other'" ng-click="$ctrl.continue('type')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
-                    <a ng-if="$ctrl.prjType === 'field_recon'" ng-click="$ctrl.continue('protected_data')"><i class="fa fa-arrow-left"></i> <strong>Back</strong></a>
+                    <a ng-if="$ctrl.prjType === 'experimental' || $ctrl.prjType === 'simulation'" ng-click="$ctrl.continue('tags')">
+                        <i class="fa fa-arrow-left"></i> <strong>Back</strong>
+                    </a>
+                    <a ng-if="$ctrl.prjType === 'hybrid_simulation' || $ctrl.prjType == 'other'" ng-click="$ctrl.continue('type')">
+                        <i class="fa fa-arrow-left"></i> <strong>Back</strong>
+                    </a>
+                    <a ng-if="$ctrl.prjType === 'field_recon'"
+                       ng-click="$ctrl.preview ? $ctrl.continue('best_practice') : $ctrl.continue('protected_data')">
+                       <i class="fa fa-arrow-left"></i> <strong>Back</strong>
+                    </a>
                 </td>
                 <td class="overview-continue">
                     <button class="btn btn-add" style="width: 100%;" ng-click="$ctrl.finish()">


### PR DESCRIPTION
The **Project Overview** appears after creating a new project, editing a project's type, or visiting the project overview.

### Changes:
1. Updated the User Guidelines for storing and publishing Protected Data (PII)
2. Added additional overview slides for Field Research
3. Added task to generate notification email for project admins when PII is going to be published (part of overview)
4. Fix various bugs in the UI which prevented the Project Overview from appearing in the Working Directory and Curation Directory

### Testing:
1. Open an empty project (or one you do not care about completely erasing).
2. Click **Edit Project** at the top of the page.
3. Click **Edit Project Type** near the top of the modal. (this will load the Project Overview)
4. Select a radio button for a project type (note: Hybrid Simulation and Other do not have Overviews currently and should skip directly to the Best Practices page)
5. Check transition of slides...
6. Go back to the start and select the radio button for **Field Research**
7. There should be updated slides for the project type. Near the end you will reach another slide with radio buttons. This page will save the user's selection, and generate an email for the project admins when a user finishes and updates their project type to a **Field Research** model

This email be triggered when a user is selecting a project type for the first time or changing their project to a Field Research project that will have personally indefinable information (ex: clicking any of the options that say **yes**.)

To test, you can change the emails in **common_settings** to your own. Go into a new or empty project (or one you don't mind erasing) and open the "Edit Project" modal. From there click "Change Project Type" select "Field Research" and continue through the slides. You'll reach a slide with radio buttons and 3 choices any choices that say "YES" should send the email. Selecting "No" should allow the user to continue without an email being sent.

![Screen Shot 2020-07-27 at 5 31 56 PM](https://user-images.githubusercontent.com/29575979/88598538-1ace7600-d02f-11ea-8414-8921a340f17b.png)

8. Go to the Working Directory and Curation Directories and check that the **View Overview** hyperlink works (next to project type at the top of the projects area)
9. Loading the Project Overview like this should allow you to "preview" the project type's overview slides without being able to go back to the choices of selecting a project type or skip to the end.
