### PR TITLE
DES-1717 - Add multiple users to email notifications to add new users to Slack

### DIFF
--- a/conf/env_files/designsafe.sample.env
+++ b/conf/env_files/designsafe.sample.env
@@ -45,7 +45,7 @@ SMTP_PORT=
 SMTP_USER=
 SMTP_PASSWORD=
 DEFAULT_FROM_EMAIL=no-reply@designsafe-ci.org
-NEW_ACCOUNT_ALERT_EMAIL=
+NEW_ACCOUNT_ALERT_EMAIL= []
 
 ###
 # Google Analytics

--- a/conf/env_files/designsafe.sample.env
+++ b/conf/env_files/designsafe.sample.env
@@ -45,7 +45,7 @@ SMTP_PORT=
 SMTP_USER=
 SMTP_PASSWORD=
 DEFAULT_FROM_EMAIL=no-reply@designsafe-ci.org
-NEW_ACCOUNT_ALERT_EMAIL= []
+NEW_ACCOUNT_ALERT_EMAILS= []
 
 ###
 # Google Analytics

--- a/designsafe/apps/auth/tasks.py
+++ b/designsafe/apps/auth/tasks.py
@@ -78,4 +78,4 @@ def new_user_alert(username):
                                                     'Email: ' + user.email + '\n' +
                                                     'Name: ' + user.first_name + ' ' + user.last_name + '\n' +
                                                     'Id: ' + str(user.id) + '\n',
-              settings.DEFAULT_FROM_EMAIL, [settings.NEW_ACCOUNT_ALERT_EMAIL],)
+              settings.DEFAULT_FROM_EMAIL, settings.NEW_ACCOUNT_ALERT_EMAIL,)

--- a/designsafe/apps/auth/tasks.py
+++ b/designsafe/apps/auth/tasks.py
@@ -78,4 +78,4 @@ def new_user_alert(username):
                                                     'Email: ' + user.email + '\n' +
                                                     'Name: ' + user.first_name + ' ' + user.last_name + '\n' +
                                                     'Id: ' + str(user.id) + '\n',
-              settings.DEFAULT_FROM_EMAIL, settings.NEW_ACCOUNT_ALERT_EMAIL,)
+              settings.DEFAULT_FROM_EMAIL, settings.NEW_ACCOUNT_ALERT_EMAILS,)

--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -442,7 +442,7 @@ EMAIL_HOST_USER = os.environ.get('SMTP_USER', '')
 EMAIL_HOST_PASSWORD = os.environ.get('SMTP_PASSWORD', '')
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', 'no-reply@designsafe-ci.org')
 MEETING_REQUEST_EMAIL = os.environ.get('MEETING_REQUEST_EMAIL', 'info@designsafe-ci.org')
-NEW_ACCOUNT_ALERT_EMAILS = os.environ.get('NEW_ACCOUNT_ALERT_EMAILS', 'no-reply@designsafe-ci.org')
+NEW_ACCOUNT_ALERT_EMAILS = os.environ.get('NEW_ACCOUNT_ALERT_EMAILS', ['no-reply@designsafe-ci.org'])
 
 ###
 # Terms and Conditions

--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -442,7 +442,7 @@ EMAIL_HOST_USER = os.environ.get('SMTP_USER', '')
 EMAIL_HOST_PASSWORD = os.environ.get('SMTP_PASSWORD', '')
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', 'no-reply@designsafe-ci.org')
 MEETING_REQUEST_EMAIL = os.environ.get('MEETING_REQUEST_EMAIL', 'info@designsafe-ci.org')
-NEW_ACCOUNT_ALERT_EMAIL = os.environ.get('NEW_ACCOUNT_ALERT_EMAIL', 'no-reply@designsafe-ci.org')
+NEW_ACCOUNT_ALERT_EMAILS = os.environ.get('NEW_ACCOUNT_ALERT_EMAILS', 'no-reply@designsafe-ci.org')
 
 ###
 # Terms and Conditions

--- a/designsafe/settings/test_settings.py
+++ b/designsafe/settings/test_settings.py
@@ -418,7 +418,7 @@ EMAIL_HOST_USER = os.environ.get('SMTP_USER', '')
 EMAIL_HOST_PASSWORD = os.environ.get('SMTP_PASSWORD', '')
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', 'no-reply@designsafe-ci.org')
 MEETING_REQUEST_EMAIL = os.environ.get('MEETING_REQUEST_EMAIL', 'info@designsafe-ci.org')
-NEW_ACCOUNT_ALERT_EMAILS = os.environ.get('NEW_ACCOUNT_ALERT_EMAILS', 'no-reply@designsafe-ci.org')
+NEW_ACCOUNT_ALERT_EMAILS = os.environ.get('NEW_ACCOUNT_ALERT_EMAILS', ['no-reply@designsafe-ci.org'])
 
 ###
 # Terms and Conditions

--- a/designsafe/settings/test_settings.py
+++ b/designsafe/settings/test_settings.py
@@ -418,7 +418,7 @@ EMAIL_HOST_USER = os.environ.get('SMTP_USER', '')
 EMAIL_HOST_PASSWORD = os.environ.get('SMTP_PASSWORD', '')
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', 'no-reply@designsafe-ci.org')
 MEETING_REQUEST_EMAIL = os.environ.get('MEETING_REQUEST_EMAIL', 'info@designsafe-ci.org')
-NEW_ACCOUNT_ALERT_EMAIL = os.environ.get('NEW_ACCOUNT_ALERT_EMAIL', 'no-reply@designsafe-ci.org')
+NEW_ACCOUNT_ALERT_EMAILS = os.environ.get('NEW_ACCOUNT_ALERT_EMAILS', 'no-reply@designsafe-ci.org')
 
 ###
 # Terms and Conditions


### PR DESCRIPTION
removed list wrapping to send to new user alerts to multiple email addresses.