### PR TITLE
Fix alert email. Uses a string instead of a list, 'cause of env var fun

### DIFF
--- a/conf/env_files/designsafe.sample.env
+++ b/conf/env_files/designsafe.sample.env
@@ -45,7 +45,7 @@ SMTP_PORT=
 SMTP_USER=
 SMTP_PASSWORD=
 DEFAULT_FROM_EMAIL=no-reply@designsafe-ci.org
-NEW_ACCOUNT_ALERT_EMAILS= []
+NEW_ACCOUNT_ALERT_EMAILS= ""
 
 ###
 # Google Analytics

--- a/designsafe/apps/auth/tasks.py
+++ b/designsafe/apps/auth/tasks.py
@@ -5,7 +5,7 @@ from designsafe.apps.api.tasks import agave_indexer
 from celery import shared_task
 
 from requests import HTTPError
-from django.contrib.auth import get_user_model 
+from django.contrib.auth import get_user_model
 import logging
 
 
@@ -78,4 +78,4 @@ def new_user_alert(username):
                                                     'Email: ' + user.email + '\n' +
                                                     'Name: ' + user.first_name + ' ' + user.last_name + '\n' +
                                                     'Id: ' + str(user.id) + '\n',
-              settings.DEFAULT_FROM_EMAIL, settings.NEW_ACCOUNT_ALERT_EMAILS,)
+              settings.DEFAULT_FROM_EMAIL, settings.NEW_ACCOUNT_ALERT_EMAILS.split(","),)

--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -442,7 +442,7 @@ EMAIL_HOST_USER = os.environ.get('SMTP_USER', '')
 EMAIL_HOST_PASSWORD = os.environ.get('SMTP_PASSWORD', '')
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', 'no-reply@designsafe-ci.org')
 MEETING_REQUEST_EMAIL = os.environ.get('MEETING_REQUEST_EMAIL', 'info@designsafe-ci.org')
-NEW_ACCOUNT_ALERT_EMAILS = os.environ.get('NEW_ACCOUNT_ALERT_EMAILS', ['no-reply@designsafe-ci.org'])
+NEW_ACCOUNT_ALERT_EMAILS = os.environ.get('NEW_ACCOUNT_ALERT_EMAILS', 'no-reply@designsafe-ci.org,')
 
 ###
 # Terms and Conditions

--- a/designsafe/settings/test_settings.py
+++ b/designsafe/settings/test_settings.py
@@ -418,7 +418,7 @@ EMAIL_HOST_USER = os.environ.get('SMTP_USER', '')
 EMAIL_HOST_PASSWORD = os.environ.get('SMTP_PASSWORD', '')
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', 'no-reply@designsafe-ci.org')
 MEETING_REQUEST_EMAIL = os.environ.get('MEETING_REQUEST_EMAIL', 'info@designsafe-ci.org')
-NEW_ACCOUNT_ALERT_EMAILS = os.environ.get('NEW_ACCOUNT_ALERT_EMAILS', ['no-reply@designsafe-ci.org'])
+NEW_ACCOUNT_ALERT_EMAILS = os.environ.get('NEW_ACCOUNT_ALERT_EMAILS', 'no-reply@designsafe-ci.org,')
 
 ###
 # Terms and Conditions


### PR DESCRIPTION
The `NEW_ACCOUNT_ALERT_EMAILS` environment variable was being cast as a string, so we do away with the array and use commas to separate the emails.