### PR TITLE
Task/DES-1286: Send user email immediately after clicking Request DOI & Publish

### DIFF
--- a/designsafe/apps/api/projects/views.py
+++ b/designsafe/apps/api/projects/views.py
@@ -61,18 +61,19 @@ class PublicationView(BaseApiView):
         else:
             data = request.POST
 
-        #logger.debug('publication: %s', json.dumps(data, indent=2))
+        # logger.debug('publication: %s', json.dumps(data, indent=2))
         status = data.get('status', 'saved')
         pub = PublicationsManager(None).save_publication(
             data['publication'],
             status
         )
+        
         if data.get('status', 'save').startswith('publish'):
             (
                 tasks.freeze_publication_meta.s(
                     pub.projectId,
                     data.get('mainEntityUuids')
-                ).set(queue='api') |
+                ).set(queue='api') | 
                 group(
                     tasks.save_publication.si(
                         pub.projectId,
@@ -93,7 +94,8 @@ class PublicationView(BaseApiView):
                     pub.projectId,
                     data.get('mainEntityUuids')
                 ) |
-                tasks.zip_publication_files.si(pub.projectId)
+                tasks.zip_publication_files.si(pub.projectId) | 
+                tasks.email_user_publication_request_confirmation(request.user.username)
             ).apply_async()
 
         return JsonResponse({'status': 200,

--- a/designsafe/apps/api/tasks.py
+++ b/designsafe/apps/api/tasks.py
@@ -1012,7 +1012,7 @@ def email_user_publication_request_confirmation(self, username):
     If your publication does not appear, is incomplete, or does not have a DOI, <a href=\"{ticket_url}\">please submit a ticket.</a></p>
     <p><strong>Do not</strong> attempt to republish by clicking Request DOI & Publish again.</p>
     <p>This is a programmatically generated message. <strong>Do NOT</strong> reply to this message. 
-    If you have any feedback or questions, please feel free to <a href=\"{ticket_url}\">please submit a ticket.</a></p>
+    If you have any feedback or questions, please feel free to <a href=\"{ticket_url}\">submit a ticket.</a></p>
     """.format(pub_url="https://www.designsafe-ci.org/data/browser/public/", ticket_url="https://www.designsafe-ci.org/help/new-ticket/")
     try:
         user.profile.send_mail(email_subject, email_body)

--- a/designsafe/apps/api/tasks.py
+++ b/designsafe/apps/api/tasks.py
@@ -1011,6 +1011,8 @@ def email_user_publication_request_confirmation(self, username):
     <p>During this time, check-in to see if your publication appears. 
     If your publication does not appear, is incomplete, or does not have a DOI, <a href=\"{ticket_url}\">please submit a ticket.</a></p>
     <p><strong>Do not</strong> attempt to republish by clicking Request DOI & Publish again.</p>
+    <p>This is a programmatically generated message. <strong>Do NOT</strong> reply to this message. 
+    If you have any feedback or questions, please feel free to <a href=\"{ticket_url}\">please submit a ticket.</a></p>
     """.format(pub_url="https://www.designsafe-ci.org/data/browser/public/", ticket_url="https://www.designsafe-ci.org/help/new-ticket/")
     try:
         user.profile.send_mail(email_subject, email_body)

--- a/designsafe/apps/api/tasks.py
+++ b/designsafe/apps/api/tasks.py
@@ -1001,3 +1001,25 @@ def email_collaborator_added_to_project(self, project_id, project_uuid, project_
                         settings.DEFAULT_FROM_EMAIL,
                         [collab_user.email],
                         html_message=body)
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def email_user_publication_request_confirmation(self, username):
+    user = get_user_model().objects.get(username=username)
+    email_subject = 'Your DesignSafe Publication Request Has Been Issued'
+    email_body = """
+    <p>Depending on the size of your data, the publication might take a few minutes or a couple of hours to appear in the <a href=\"{pub_url}\">Published Directory.</a></p>
+    <p>During this time, check-in to see if your publication appears. 
+    If your publication does not appear, is incomplete, or does not have a DOI, <a href=\"{ticket_url}\">please submit a ticket.</a></p>
+    <p><strong>Do not</strong> attempt to republish by clicking Request DOI & Publish again.</p>
+    """.format(pub_url="https://www.designsafe-ci.org/data/browser/public/", ticket_url="https://www.designsafe-ci.org/help/new-ticket/")
+    try:
+        user.profile.send_mail(email_subject, email_body)
+    except Exception as e:
+        logger.info("Could not send email to user {}".format(user))
+        send_mail(
+            email_subject,
+            email_body,
+            settings.DEFAULT_FROM_EMAIL,
+            [user.email],
+            html_message=email_body
+        )


### PR DESCRIPTION
When the user clicks Request DOI & Publish, an additional task has been added to the publish chain that notifies the user that the project is being prepared for publication.
<img width="820" alt="Screen Shot 2020-08-26 at 4 06 01 PM" src="https://user-images.githubusercontent.com/47395902/91356938-11633580-e7b6-11ea-9ce8-28ab1bbd655f.png">
