### PR TITLE
Hotfix: fix dropbox oauth flow and stop unnecessary decoding of external resources file paths

### DIFF
--- a/designsafe/apps/api/external_resources/box/filemanager/manager.py
+++ b/designsafe/apps/api/external_resources/box/filemanager/manager.py
@@ -292,7 +292,7 @@ class FileManager(object):
         """
         box_file = self.box_api.file(box_file_id).get()
         # convert utf-8 chars
-        safe_filename = box_file.name.encode(sys.getfilesystemencoding(), 'ignore')
+        safe_filename = box_file.name
         file_download_path = os.path.join(download_directory_path, safe_filename)
         logger.debug('Download file %s <= box://file/%s', file_download_path, box_file_id)
 
@@ -313,7 +313,7 @@ class FileManager(object):
         """
         box_folder = self.box_api.folder(box_folder_id).get()
         # convert utf-8 chars
-        safe_dirname = box_folder.name.encode(sys.getfilesystemencoding(), 'ignore')
+        safe_dirname = box_folder.name
         directory_path = os.path.join(download_path, safe_dirname)
         logger.debug('Creating directory %s <= box://folder/%s', directory_path, box_folder_id)
         try:

--- a/designsafe/apps/api/external_resources/dropbox/filemanager/manager.py
+++ b/designsafe/apps/api/external_resources/dropbox/filemanager/manager.py
@@ -277,7 +277,7 @@ class FileManager(object):
         dropbox_file = self.dropbox_api.files_get_metadata(dropbox_file_path)
 
         # convert utf-8 chars
-        safe_filename = dropbox_file.name.encode(sys.getfilesystemencoding(), 'ignore')
+        safe_filename = dropbox_file.name
         file_download_path = os.path.join(download_directory_path, safe_filename)
         logger.debug('Download file %s <= dropbox://file/%s', file_download_path, dropbox_file_path)
         self.dropbox_api.files_download_to_file(file_download_path,dropbox_file_path)
@@ -300,7 +300,7 @@ class FileManager(object):
         dropbox_folder_metadata = self.dropbox_api.files_alpha_get_metadata(path)
 
         # convert utf-8 chars
-        safe_dirname = dropbox_folder_metadata.name.encode(sys.getfilesystemencoding(), 'ignore')
+        safe_dirname = dropbox_folder_metadata.name
         directory_path = os.path.join(download_path, safe_dirname)
         logger.debug('Creating directory %s <= dropbox://folder/%s', directory_path, path)
         try:

--- a/designsafe/apps/api/external_resources/googledrive/filemanager/manager.py
+++ b/designsafe/apps/api/external_resources/googledrive/filemanager/manager.py
@@ -285,7 +285,7 @@ class FileManager(object):
         googledrive_file = self.googledrive_api.files().get(fileId=file_id, fields="name, mimeType").execute()
 
         # convert utf-8 chars
-        safe_filename = googledrive_file['name'].encode(sys.getfilesystemencoding(), 'ignore')
+        safe_filename = googledrive_file['name']
         file_download_path = os.path.join(download_directory_path, safe_filename)
         logger.debug('Download file %s <= googledrive://file/%s', file_download_path, file_id)
 
@@ -361,7 +361,7 @@ class FileManager(object):
         """
         googledrive_folder = self.googledrive_api.files().get(fileId=folder_id, fields="name").execute()
         # convert utf-8 chars
-        safe_dirname = googledrive_folder['name'].encode(sys.getfilesystemencoding(), 'ignore')
+        safe_dirname = googledrive_folder['name']
         directory_path = os.path.join(download_path, safe_dirname)
         logger.debug('Creating directory %s <= googledrive://folder/%s', directory_path, folder_id)
         try:

--- a/designsafe/apps/api/tasks.py
+++ b/designsafe/apps/api/tasks.py
@@ -116,7 +116,7 @@ def box_download_file(box_file_manager, box_file_id, download_directory_path):
     :return: the full path to the downloaded file
     """
     box_file = box_file_manager.box_api.file(box_file_id).get()
-    safe_filename = box_file.name.encode(sys.getfilesystemencoding(), 'ignore')  # convert utf-8 chars
+    safe_filename = box_file.name
     file_download_path = os.path.join(download_directory_path, safe_filename)
     logger.debug('Download file %s <= box://file/%s', file_download_path, box_file_id)
 
@@ -137,7 +137,7 @@ def box_download_folder(box_file_manager, box_folder_id, download_path):
     :return:
     """
     box_folder = box_file_manager.box_api.folder(box_folder_id).get()
-    safe_dirname = box_folder.name.encode(sys.getfilesystemencoding(), 'ignore')  # convert utf-8 chars
+    safe_dirname = box_folder.name
     directory_path = os.path.join(download_path, safe_dirname)
     logger.debug('Creating directory %s <= box://folder/%s', directory_path, box_folder_id)
     try:

--- a/designsafe/apps/dropbox_integration/models.py
+++ b/designsafe/apps/dropbox_integration/models.py
@@ -41,12 +41,4 @@ class DropboxUserToken(models.Model):
 
     @property
     def client(self, request):
-        redirect_uri = reverse('dropbox_integration:oauth2_callback')
-        oauth = DropboxOAuth2Flow(
-                    consumer_key = settings.DROPBOX_APP_KEY,
-                    consumer_secret = settings.DROPBOX_APP_SECRET,
-                    redirect_uri = request.build_absolute_uri(redirect_uri),
-                    session = request.session['dropbox'],
-                    csrf_token_session_key = 'state'
-                )
-        return Dropbox(oauth.access_token)
+        return Dropbox(self.access_token)

--- a/designsafe/apps/dropbox_integration/views.py
+++ b/designsafe/apps/dropbox_integration/views.py
@@ -30,7 +30,7 @@ def index(request):
             dropbox = Dropbox(dropbox_token.access_token)
             dropbox_user=dropbox.users_get_account(dropbox_token.account_id)
             context['dropbox_connection'] = dropbox_user
-        except BadRequestException or AuthError:
+        except (BadRequestException, AuthError):
             # authentication failed
             logger.warning('Dropbox oauth token for user=%s failed to authenticate' %
                            request.user.username)
@@ -98,7 +98,9 @@ def disconnect(request):
 
             dropbox_user_token = request.user.dropbox_user_token
             dropbox_user_token.delete()
-
+        except AuthError:
+            dropbox_user_token = request.user.dropbox_user_token
+            dropbox_user_token.delete()
         except DropboxUserToken.DoesNotExist:
             logger.warn('Disconnect Dropbox; DropboxUserToken does not exist.',
                         extra={'user': request.user})


### PR DESCRIPTION
This is at least one of the things that's breaking transfers in External Resources. These operations depend on having Corral mounted so they can't be tested locally.