### PR TITLE
Bug/DES-1737 - Prevent move and rename of files containing categorized data in projects

### DIFF
--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-move/data-browser-service-move.component.html
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-move/data-browser-service-move.component.html
@@ -6,50 +6,47 @@
     <div ng-if="$ctrl.hasEntities">
         <div class="alert alert-warning">
             <p class="lead">Associated Entities Detected</p>
-            <p>This file cannot be renamed until its tags or associated entities have been removed using the Curation Directory tab.</p>
+            <p>
+                This file or folder cannot be moved until its tags or associated entities have been removed using the
+                Curation Directory tab.
+            </p>
         </div>
     </div>
     <div ng-if="!$ctrl.hasEntities">
-    <ul>
-        <li ng-repeat="item in $ctrl.FileListingService.getSelectedFiles('main')">
-            {{item.name}} {{$ctrl.FileListingService.operations.move.status[item.key]}}
-        </li>
-    </ul>
+        <ul>
+            <li ng-repeat="item in $ctrl.FileListingService.getSelectedFiles('main')">
+                {{ item.name }} {{ $ctrl.FileListingService.operations.move.status[item.key] }}
+            </li>
+        </ul>
 
-    <div ng-if="$ctrl.hasEntities">
-        <div class="alert alert-warning">
-            <p class="lead">Associated Entities Detected</p>
-            <p>This file cannot be renamed until its tags or associated entities have been removed using the Curation Directory tab.</p>
+        <div>
+            <breadcrumb
+                path="$ctrl.FileListingService.listings.modal.params.path"
+                system="$ctrl.FileListingService.listings.modal.params.system"
+                on-browse="$ctrl.onBrowse(file)"
+                skip-root="$ctrl.breadcrumbParams.skipRoot"
+                custom-root="$ctrl.breadcrumbParams.customRoot"
+                pre-root="$ctrl.breadcrumbParams.preRoot"
+            ></breadcrumb>
+            <files-listing
+                on-scroll="$ctrl.scrollToBottom()"
+                listing="$ctrl.getModalListing()"
+                on-browse="$ctrl.onBrowse(file)"
+                operation-label="'Move'"
+                operation="$ctrl.handleMove(file)"
+                >&nbsp;</files-listing
+            >
         </div>
-    </div>
-    
-    <div ng-if="!$ctrl.hasEntities">
-        <breadcrumb
-            path="$ctrl.FileListingService.listings.modal.params.path"
-            system="$ctrl.FileListingService.listings.modal.params.system"
-            on-browse="$ctrl.onBrowse(file)"
-            skip-root="$ctrl.breadcrumbParams.skipRoot"
-            custom-root="$ctrl.breadcrumbParams.customRoot"
-            pre-root="$ctrl.breadcrumbParams.preRoot"
-        ></breadcrumb>
-        <files-listing
-            on-scroll="$ctrl.scrollToBottom()"
-            listing="$ctrl.getModalListing()"
-            on-browse="$ctrl.onBrowse(file)"
-            operation-label="'Move'"
-            operation="$ctrl.handleMove(file)"
-            >&nbsp;</files-listing
-        >
-       
-    </div>
     </div>
 
     <div class="modal-footer">
         <div class="text-right">
-            <button class="btn btn-primary" type="button"
-                    ng-if="!$ctrl.listingProjects"
-                    ng-click="$ctrl.handleFooterMove()"
-                    ng-disabled="$ctrl.hasEntities"
+            <button
+                class="btn btn-primary"
+                type="button"
+                ng-if="!$ctrl.listingProjects"
+                ng-click="$ctrl.handleFooterMove()"
+                ng-disabled="$ctrl.hasEntities"
             >
                 Move Here
             </button>

--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-rename/data-browser-service-rename.template.html
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-rename/data-browser-service-rename.template.html
@@ -5,17 +5,37 @@
     <div ng-if="$ctrl.hasEntities">
         <div class="alert alert-warning">
             <p class="lead">Associated Entities Detected</p>
-            <p>This file cannot be renamed until its tags or associated entities have been removed using the Curation Directory tab.</p>
+            <p>
+                This file or folder cannot be renamed until its tags or associated entities have been removed using the
+                Curation Directory tab.
+            </p>
         </div>
     </div>
     <form>
         <div class="form-group">
             <label for="id-target-name">Enter {{ file.type }} name</label>
-            <input type="text" class="form-control" id="id-target-name" name="target-name" placeholder="New name" ng-model="$ctrl.newName" ng-disabled="$ctrl.hasEntities" autofocus select-on-focus>
+            <input
+                type="text"
+                class="form-control"
+                id="id-target-name"
+                name="target-name"
+                placeholder="New name"
+                ng-model="$ctrl.newName"
+                ng-disabled="$ctrl.hasEntities"
+                autofocus
+                select-on-focus
+            />
         </div>
         <div class="text-right">
             <button class="btn btn-default" type="button" ng-click="$ctrl.cancel()">Cancel</button>
-            <button class="btn btn-primary" type="button" ng-click="$ctrl.rename($event)" ng-disabled="$ctrl.hasEntities">Rename {{ file.type }}</button>
+            <button
+                class="btn btn-primary"
+                type="button"
+                ng-click="$ctrl.rename($event)"
+                ng-disabled="$ctrl.hasEntities"
+            >
+                Rename {{ file.type }}
+            </button>
         </div>
     </form>
 </div>

--- a/designsafe/static/scripts/ng-designsafe/services/file-operation-service.js
+++ b/designsafe/static/scripts/ng-designsafe/services/file-operation-service.js
@@ -84,6 +84,9 @@ export class FileOperationService {
     }
 
     checkForEntities(file) {
+        const entities = this.ProjectService.current.getAllRelatedObjects()
+        const entityFilePaths = entities.map((e) => e._filePaths).flat(1);
+        const hasPathPrefix = entityFilePaths.some(entityPath => entityPath.startsWith(file.path))
         const inProject = ['projects.view', 'projects.curation'].includes(this.$state.current.name);
         const hasEntities = file._entities && file._entities.length;
         const hasTags = file._fileTags && file._fileTags.length;
@@ -92,7 +95,7 @@ export class FileOperationService {
             (tag) => tag.path.replace(/^\/+/, '') === file.path.replace(/^\/+/, '')
         );
 
-        return inProject && (hasEntities || hasTags || hasProjectFileTags);
+        return inProject && (hasPathPrefix || hasEntities || hasTags || hasProjectFileTags);
     }
 
     /***************************************************************************


### PR DESCRIPTION
We want to prevent users from moving or renaming files that are categorized to an entity or contain files that are categorized to an entity. If this happens project will become unresponsive and requires manual effort to fix.

This check will only take place when moving/renaming from the My Projects area. With these changes we will request entities for the project and check that the file path(s) to be move/renamed are not among them. To test this feature, go into any project and try to move/copy files. If there are categories associated to the files you should be notified.