### PR TITLE
task/DES-1587: Fix projects indexer

### DIFF
--- a/designsafe/apps/api/tasks_unit_test.py
+++ b/designsafe/apps/api/tasks_unit_test.py
@@ -1,0 +1,76 @@
+from django.test import TestCase, RequestFactory
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from mock import patch, MagicMock
+
+TEST_PROJECT = {'uuid': '6262924605326814745-242ac11c-0001-012',
+                'schemaId': None, 'internalUsername': None,
+                'associationIds': [],
+                'lastUpdated': '2020-04-17T09:44:42.939-05:00',
+                'name': 'designsafe.project',
+                'value': {'teamMembers': ['autumn88', 'agharag', 'jlwoodr3'],
+                          'coPis': ['jdietri1', 'akenned4'],
+                          'guestMembers': [],
+                          'projectType':
+                          'simulation',
+                          'projectId': 'PRJ-2750',
+                          'description': 'desc',
+                          'pi': 'akenned4',
+                          'awardNumber': '12345',
+                          'associatedProjects': [], 'ef': 'None', 'keywords': '', 'dois': []},
+                'created': '2018-01-18T11:04:35.636-06:00', 'owner': 'ds_admin',
+                '_links': {'associationIds': []}}
+
+
+class TestProjectIndexer(TestCase):
+
+    @patch('designsafe.apps.api.tasks.get_service_account_client')
+    def test_project_listing(self, mock_client):
+        mock_client().meta.listMetadata.return_value = [TEST_PROJECT]
+        from designsafe.apps.api.tasks import list_all_projects
+        prj_result = next(list_all_projects())
+
+        mock_client().meta.listMetadata.assert_called_with(q='{"name": "designsafe.project"}', offset=0, limit=100)
+        self.assertEqual(prj_result, [TEST_PROJECT])
+
+    @patch('designsafe.apps.api.tasks.bulk')
+    @patch('designsafe.apps.projects.models.elasticsearch.IndexedProject')
+    def test_project_indexer(self, mock_index, mock_bulk):
+        mock_connection = MagicMock()
+        mock_index.Index.name = 'designsafe-test-projects'
+        mock_index._get_connection.return_value = mock_connection
+        from designsafe.apps.api.tasks import index_projects_listing
+
+        index_projects_listing([TEST_PROJECT])
+
+        expected_doc = {**TEST_PROJECT}
+        expected_doc['value']['awardNumber'] = [{'number': '12345'}]
+        del expected_doc['_links']
+
+        mock_bulk.assert_called_with(mock_connection, [
+            {
+                '_index': 'designsafe-test-projects',
+                '_id': '6262924605326814745-242ac11c-0001-012',
+                'doc': expected_doc,
+                '_op_type': 'update',
+                'doc_as_upsert': True
+            }
+        ])
+
+    @patch('designsafe.apps.api.tasks.get_service_account_client')
+    @patch('designsafe.apps.api.tasks.index_projects_listing')
+    def test_index_or_update_project(self, mock_indexer, mock_client):
+        mock_client().meta.listMetadata.return_value = [TEST_PROJECT]
+        from designsafe.apps.api.tasks import index_or_update_project
+        index_or_update_project('test-uuid')
+        mock_client().meta.listMetadata.assert_called_with(q='{"uuid": "test-uuid"}', offset=0, limit=1)
+        mock_indexer.assert_called_with([TEST_PROJECT])
+
+    @patch('designsafe.apps.api.tasks.list_all_projects')
+    @patch('designsafe.apps.api.tasks.index_projects_listing')
+    def test_reindex_projects(self, mock_indexer, mock_listing):
+        mock_listing.return_value.__iter__.return_value= [[TEST_PROJECT]]
+        from designsafe.apps.api.tasks import reindex_projects
+        reindex_projects()
+        mock_listing.assert_called_with()
+        mock_indexer.assert_called_with([TEST_PROJECT])

--- a/designsafe/celery.py
+++ b/designsafe/celery.py
@@ -11,7 +11,6 @@ logger = logging.getLogger(__name__)
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'designsafe.settings')
 
 
-
 from django.conf import settings  # noqa
 
 app = Celery('designsafe')
@@ -22,15 +21,15 @@ app.config_from_object('django.conf:settings', namespace="CELERY")
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
 app.conf.update(
-    CELERYBEAT_SCHEDULE = {
+    CELERYBEAT_SCHEDULE={
         'update_user_storages': {
             'task': 'designsafe.apps.search.tasks.update_search_index',
             'schedule': crontab(minute=0, hour=0),
         },
-       # 'reindex_projects': {
-       #     'task': 'designsafe.apps.api.tasks.reindex_projects',
-       #     'schedule': crontab(hour="*/24", minute=0)
-       # }
+        'reindex_projects': {
+            'task': 'designsafe.apps.api.tasks.reindex_projects',
+            'schedule': crontab(hour=0, minute=0)
+        }
     }
 )
 
@@ -39,6 +38,7 @@ if settings.COMMUNITY_INDEX_SCHEDULE:
         'task': 'designsafe.apps.search.tasks.index_community_data',
         'schedule': crontab(**settings.COMMUNITY_INDEX_SCHEDULE)
     }
+
 
 @app.task(bind=True)
 def debug_task(self):


### PR DESCRIPTION
- Rewrite the projects indexer to make ~99% fewer Tapis and Elasticsearch calls.
- Fix bug where empty date objects would cause indexing to fail.