### PR TITLE
Task/DES-1752 - Fix publication status update issue with other publications

### DIFF
--- a/designsafe/apps/api/tasks.py
+++ b/designsafe/apps/api/tasks.py
@@ -866,7 +866,7 @@ def swap_file_tag_uuids(self, project_id):
         raise self.retry(exc=exc)
 
 @shared_task(bind=True)
-def set_publish_status(self, project_id, entity_uuids, publish_dois=False):
+def set_publish_status(self, project_id, entity_uuids=None, publish_dois=False):
     from designsafe.apps.projects.managers import publication as PublicationManager
     # Only publish DOIs created from prod
     if getattr(settings, 'DESIGNSAFE_ENVIRONMENT', 'dev') == 'default':

--- a/designsafe/apps/api/tasks.py
+++ b/designsafe/apps/api/tasks.py
@@ -781,7 +781,7 @@ def copy_publication_files_to_corral(self, project_id):
 
 
 @shared_task(bind=True, max_retries=1, default_retry_delay=60)
-def freeze_publication_meta(self, project_id, entity_uuids):
+def freeze_publication_meta(self, project_id, entity_uuids=None):
     """Freeze publication meta.
 
     :param str project_id: Project Id.

--- a/designsafe/apps/projects/managers/publication.py
+++ b/designsafe/apps/projects/managers/publication.py
@@ -184,9 +184,9 @@ def publish_resource(project_id, entity_uuids=None, publish_dois=False):
     to `"published"` that way it shows up in the published listing.
 
     If publish_dois is False Datacite will keep the newly created DOIs in
-    "DRAFT" status, but they will not be set to "PUBLISHED". A DOI on
-    DataCite can only be deleted if it is in "DRAFT" status. Once a DOI
-    is set to "PUBLISHED" or "RESERVED" it can't be deleted.
+    "DRAFT" status, and not "PUBLISHED". A DOI on DataCite can only be
+    deleted if it is in "DRAFT" status. Once a DOI is set to "PUBLISHED"
+    or "RESERVED" it can't be deleted.
 
     :param str project_id: Project Id to publish.
     :param list entity_uuids: list of str Entity uuids to publish.

--- a/designsafe/apps/projects/managers/publication.py
+++ b/designsafe/apps/projects/managers/publication.py
@@ -196,15 +196,16 @@ def publish_resource(project_id, entity_uuids=None, publish_dois=False):
     responses = []
 
     if publish_dois:
-        for ent_uuid in entity_uuids:
-            entity = None
-            if ent_uuid:
-                entity = mgr.get_entity_by_uuid(ent_uuid)
-            
-            if entity:
-                for doi in entity.dois:
-                    res = DataciteManager.publish_doi(doi)
-                    responses.append(res)
+        if entity_uuids:
+            for ent_uuid in entity_uuids:
+                entity = None
+                if ent_uuid:
+                    entity = mgr.get_entity_by_uuid(ent_uuid)
+                
+                if entity:
+                    for doi in entity.dois:
+                        res = DataciteManager.publish_doi(doi)
+                        responses.append(res)
         
         for doi in prj.dois:
             res = DataciteManager.publish_doi(doi)


### PR DESCRIPTION
Other publications do not have entities, and when they are being published part of the publication task chain will fail silently and prevent the publication status from being set correctly.