### PR TITLE
Bug/DES-1783 - Fix issue with saving initial publication object

### DIFF
--- a/designsafe/apps/api/projects/views.py
+++ b/designsafe/apps/api/projects/views.py
@@ -58,16 +58,11 @@ class PublicationView(BaseApiView):
     def post(self, request, **kwargs):
         if request.is_ajax():
             data = json.loads(request.body)
-
         else:
             data = request.POST
 
-        # logger.debug('publication: %s', json.dumps(data, indent=2))
         status = data.get('status', 'saved')
-        pub = save_publication(
-            data['publication'],
-            status
-        )
+        pub = save_publication(data['publication'], status)
         
         if data.get('status', 'save').startswith('publish'):
             (
@@ -90,7 +85,7 @@ class PublicationView(BaseApiView):
                         countdown=60
                     )
                 ) |
-                tasks.swap_file_tag_uuids.si(pub.project_id) |
+                tasks.swap_file_tag_uuids.si(pub.projectId) |
                 tasks.set_publish_status.si(
                     pub.projectId,
                     data.get('mainEntityUuids')

--- a/designsafe/apps/api/publications/operations.py
+++ b/designsafe/apps/api/publications/operations.py
@@ -3,6 +3,7 @@ from designsafe.apps.api.publications import search_utils
 from designsafe.libs.elasticsearch.exceptions import DocumentNotFound
 from django.contrib.auth import get_user_model
 from elasticsearch_dsl import Q
+import datetime
 import json
 import urllib
 import logging
@@ -193,11 +194,7 @@ def neesdescription(project_id, *args):
     return {'description': desc}
 
 
-def save_publication(
-            self,
-            publication,
-            status='publishing'
-    ):  # pylint: disable=no-self-use
+def save_publication(publication, status='publishing'):
         """Save publication."""
         publication['projectId'] = publication['project']['value']['projectId']
         publication['created'] = datetime.datetime.now().isoformat()


### PR DESCRIPTION
## Overview: ##
Publication objects are failing to save initially because of a couple typos
- `datetime` module is not imported
- `self` parameter of `save_publication` operation is not used and throwing off input parameters

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1783](https://jira.tacc.utexas.edu/browse/DES-1783)

## Summary of Changes: ##

## Testing Steps: ##
1. You can test this on one of the test publications "walk other demo" if needed. Shell into Django container locally

```
from designsafe.apps.api.publications.operations import save_publication
pub = {
  "license":{"datasets": "","software": "", "works": "Creative Commons Attribution Share Alike"},
  "project":{"uuid": "{{prj-uuid}}", "value": {"projectId": "{{PRJ-XXXX}}"}}
}
pub = save_publication(pub, 'saving')
```
Should not have an error and should save the publication.


## UI Photos:

## Notes: ##
