### PR TITLE
hotfix/20201009-postit-href: Always list files before creating postits

### DIFF
--- a/designsafe/apps/api/datafiles/operations/agave_operations.py
+++ b/designsafe/apps/api/datafiles/operations/agave_operations.py
@@ -160,8 +160,7 @@ def download(client, system, path, href, force=True, max_uses=3, lifetime=600, *
     """
     # pylint: disable=protected-access
 
-    if not href:
-        href = client.files.list(systemId=system, filePath=path)[0]['_links']['self']['href']
+    href = client.files.list(systemId=system, filePath=path)[0]['_links']['self']['href']
 
     args = {
         'url': urllib.parse.unquote(href),
@@ -528,9 +527,7 @@ def preview(client, system, path, href, max_uses=3, lifetime=600, *args, **kwarg
 
     file_name = path.strip('/').split('/')[-1]
     file_ext = os.path.splitext(file_name)[1].lower()
-
-    if not href:
-        href = client.files.list(systemId=system, filePath=path)[0]['_links']['self']['href']
+    href = client.files.list(systemId=system, filePath=path)[0]['_links']['self']['href']
 
     args = {
         'url': urllib.parse.unquote(href),


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Summary of Changes: ##
Perform a listing before each call to the postits API in order to ensure that the permissions are correct.
