### PR TITLE
task/DES-1785: Use correct queue for recursive indexing

### DIFF
--- a/designsafe/libs/elasticsearch/utils.py
+++ b/designsafe/libs/elasticsearch/utils.py
@@ -44,15 +44,19 @@ def walk_levels(client, system, path, bottom_up=False, ignore_hidden=False, path
     from designsafe.apps.data.models.agave.files import BaseFileResource
     listing = []
     offset = 0
+    limit = 100
     page = client.files.list(systemId=system,
                              filePath=urllib.parse.quote(path),
                              offset=offset)
-    while page:
-        listing += page
-        offset += 100
+    while True:
         page = client.files.list(systemId=system,
                                  filePath=urllib.parse.quote(path),
                                  offset=offset)
+        listing += page
+        offset += limit
+
+        if len(page) != limit:
+            break
 
     folders = []
     files = []


### PR DESCRIPTION
## Overview: ##
- Use correct queue for the recursive indexing (previously recursive calls were being put in the "default" queue)
- Tweak `walk_levels` method to reduce Agave calls by ~50%.
