### PR TITLE
Add instructions on installing CA certificates on Fedora/RHEL/CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ Every file needed is in `conf/nginx/certs`.
 3. `$ sudo cp ca.pem /usr/local/share/ca-certificates/extra/designsafeCA.pem`
 4. `$ sudo update-ca-certificates`
 
+<<<<<<< HEAD
+=======
+##### Fedora & CentOS & RHEL
+1. `$ sudo dnf install ca-certificates` or </br>`$ sudo yum install ca-certificates`
+2. `$ sudo update-ca-trust enable`
+3. `$ cd $PROJECT/conf/nginx/certificates`
+4. `$ sudo cp ca.pem /usr/share/pki/ca-trust-source/anchors/designsafeCA.pem` or </br>`$ sudo cp ca.pem /etc/pki/ca-trust/source/anchors/designsafeCA.pem`
+5. `$ sudo update-ca-trust`
+
+>>>>>>> 1fe3dc9f... Add instructions on installing CA certificates on Fedora/RHEL/CentOS
 #### Firefox UI
 
 1. Go to preferences

--- a/README.md
+++ b/README.md
@@ -113,13 +113,12 @@ Every file needed is in `conf/nginx/certs`.
 
 #### Linux
 
+##### Ubuntu & Debian
 1. `$ cd $PROJECT/conf/nginx/certificates`
 2. `$ sudo mkdir /usr/local/share/ca-certificates/extra`
 3. `$ sudo cp ca.pem /usr/local/share/ca-certificates/extra/designsafeCA.pem`
 4. `$ sudo update-ca-certificates`
 
-<<<<<<< HEAD
-=======
 ##### Fedora & CentOS & RHEL
 1. `$ sudo dnf install ca-certificates` or </br>`$ sudo yum install ca-certificates`
 2. `$ sudo update-ca-trust enable`
@@ -127,7 +126,6 @@ Every file needed is in `conf/nginx/certs`.
 4. `$ sudo cp ca.pem /usr/share/pki/ca-trust-source/anchors/designsafeCA.pem` or </br>`$ sudo cp ca.pem /etc/pki/ca-trust/source/anchors/designsafeCA.pem`
 5. `$ sudo update-ca-trust`
 
->>>>>>> 1fe3dc9f... Add instructions on installing CA certificates on Fedora/RHEL/CentOS
 #### Firefox UI
 
 1. Go to preferences


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

N/A

## Summary of Changes: ##
Added instructions for adding ca-certificates on Fedora/RHEL/CentOS linux distributions. 

## Testing Steps: ##
1. Install a Red Hat-based linux distribution.
2. Follow the instructions on `README.md`.
3. `openssl verify $PROJECT/conf/nginx/certificates/ca.pem`

## UI Photos:
N/A

## Notes: ##
Followed [Fedora's official documentation](https://docs.fedoraproject.org/en-US/quick-docs/using-shared-system-certificates/#proc_adding-new-certificates) and a [Red Hat tutorial](https://www.redhat.com/sysadmin/ca-certificates-cli) for reference.