### PR TITLE
DES-1721 - Add informative message inside trash directories.

### DIFF
--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
@@ -152,7 +152,7 @@ class FilesListingCtrl {
 
     isInTrash() {
         if (this.listing.params.path && this.listing.params.system) {
-            let filePath = this.listing.params.path.split('/');                            
+            let filePath = this.listing.params.path.split('/');
             if (this.listing.params.system == 'designsafe.storage.default' &&
                 filePath[1] == '.Trash')
                 return true;

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
@@ -156,9 +156,8 @@ class FilesListingCtrl {
             if (this.listing.params.system == 'designsafe.storage.default' &&
                 filePath[1] == '.Trash')
                 return true;
-            else
-                if (filePath[0] == '.Trash')
-                    return true;
+            else if (filePath[0] == '.Trash')
+                return true;
         }
         return false;
     }

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
@@ -149,6 +149,13 @@ class FilesListingCtrl {
                 return 'fa-file-o';
         }
     };
+    
+    isInTrash() {
+        if (this.listing.params.path.split('/')[1] == '.Trash')
+            return true;
+        else
+            return false;
+    }
 }
 
 export const FilesListingComponent = {

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
@@ -66,8 +66,8 @@ class FilesListingCtrl {
     constructor($state, FileListingService) {
         'ngInject';
         this.$state = $state;
-        this.FileListingService = FileListingService    
-        
+        this.FileListingService = FileListingService
+
         this.handleScroll = this.handleScroll.bind(this)
     }
 
@@ -149,12 +149,13 @@ class FilesListingCtrl {
                 return 'fa-file-o';
         }
     };
-    
+
     isInTrash() {
-        if (this.listing.params.path.split('/')[1] == '.Trash')
-            return true;
-        else
-            return false;
+        if (this.listing.params.path.split) {
+            if (this.listing.params.path.split('/')[1] == '.Trash')
+                return true;
+        }
+        return false;
     }
 }
 

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
@@ -151,10 +151,14 @@ class FilesListingCtrl {
     };
 
     isInTrash() {
-        if (this.listing.params.path) {
-            let filePath = this.listing.params.path.split('/')
-            if (filePath[1] == '.Trash' || filePath[0] == '.Trash')
+        if (this.listing.params.path && this.listing.params.system) {
+            let filePath = this.listing.params.path.split('/');                            
+            if (this.listing.params.system == 'designsafe.storage.default' &&
+                filePath[1] == '.Trash')
                 return true;
+            else
+                if (filePath[0] == '.Trash')
+                    return true;
         }
         return false;
     }

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
@@ -152,7 +152,8 @@ class FilesListingCtrl {
 
     isInTrash() {
         if (this.listing.params.path) {
-            if (this.listing.params.path.split('/')[1] == '.Trash')
+            let filePath = this.listing.params.path.split('/')
+            if (filePath[1] == '.Trash' || filePath[0] == '.Trash')
                 return true;
         }
         return false;

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
@@ -151,7 +151,7 @@ class FilesListingCtrl {
     };
 
     isInTrash() {
-        if (this.listing.params.path.split) {
+        if (this.listing.params.path) {
             if (this.listing.params.path.split('/')[1] == '.Trash')
                 return true;
         }

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/files-listing.spec.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/files-listing.spec.js
@@ -217,6 +217,7 @@ describe('filesListing', () => {
         $rootScope.listing = {
             ...initialListing,
             params: {
+                system: 'designsafe.storage.default',
                 path: 'test/.Trash/',
             },
         };
@@ -226,10 +227,11 @@ describe('filesListing', () => {
         $rootScope.$digest();
         expect(component.text()).toContain('Trashed items will be kept a maximum of 90 days.');
 
-        $rootScope.listing.params.path = 'test/.Trash/testing';
+        $rootScope.listing.params.path = 'testUser/.Trash/testing';
         $rootScope.$digest();
         expect(component.text()).toContain('Trashed items will be kept a maximum of 90 days.');
 
+        $rootScope.listing.params.system = 'project-12345';
         $rootScope.listing.params.path = '.Trash/';
         $rootScope.$digest();
         expect(component.text()).toContain('Trashed items will be kept a maximum of 90 days.');

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/files-listing.spec.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/files-listing.spec.js
@@ -86,7 +86,7 @@ describe('filesListing', () => {
         $rootScope.listing = {
             ...initialListing,
             listing: [
-                {   
+                {
                     name: "testfile",
                     system: 'designsafe.storage.default',
                     path: '/path/to/file',
@@ -109,7 +109,7 @@ describe('filesListing', () => {
         $rootScope.listing = {
             ...initialListing,
             listing: [
-                {   
+                {
                     name: "testfile",
                     system: 'designsafe.storage.default',
                     path: '/path/to/file',
@@ -130,7 +130,7 @@ describe('filesListing', () => {
         expect(component.find('.test-op-btn').text()).toContain('Test Operation');
         const opButton = component.find('.test-op-btn');
         opButton.triggerHandler('click');
-        expect(mockOperation).toHaveBeenCalledWith({   
+        expect(mockOperation).toHaveBeenCalledWith({
             name: "testfile",
             system: 'designsafe.storage.default',
             path: '/path/to/file',
@@ -148,7 +148,7 @@ describe('filesListing', () => {
         $rootScope.listing = {
             ...initialListing,
             listing: [
-                {   
+                {
                     name: "testfile",
                     system: 'designsafe.storage.default',
                     path: '/path/to/file',
@@ -167,7 +167,7 @@ describe('filesListing', () => {
 
         const fileHref = component.find('.test-file-name');
         fileHref.triggerHandler('click');
-        expect(mockBrowse).toHaveBeenCalledWith({   
+        expect(mockBrowse).toHaveBeenCalledWith({
             name: "testfile",
             system: 'designsafe.storage.default',
             path: '/path/to/file',
@@ -180,7 +180,7 @@ describe('filesListing', () => {
     });
 
     it('calls browseScroll on scroll to bottom', (done) => {
-        const fileMeta = {   
+        const fileMeta = {
             name: "testfile",
             system: 'designsafe.storage.default',
             path: '/path/to/file',
@@ -229,8 +229,15 @@ describe('filesListing', () => {
         $rootScope.listing.params.path = 'test/.Trash/testing';
         $rootScope.$digest();
         expect(component.text()).toContain('Trashed items will be kept a maximum of 90 days.');
+
+        $rootScope.listing.params.path = '.Trash/';
+        $rootScope.$digest();
+        expect(component.text()).toContain('Trashed items will be kept a maximum of 90 days.');
+
+        $rootScope.listing.params.path = '.Trash/testing';
+        $rootScope.$digest();
+        expect(component.text()).toContain('Trashed items will be kept a maximum of 90 days.');
     });
- 
+
 
 });
-

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/files-listing.spec.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/files-listing.spec.js
@@ -213,6 +213,24 @@ describe('filesListing', () => {
         }, 0)
     })
 
+    it('Render inside trash', () => {
+        $rootScope.listing = {
+            ...initialListing,
+            params: {
+                path: 'test/.Trash/',
+            },
+        };
+
+        let el = angular.element('<files-listing listing="listing"></files-listing>');
+        component = $compile(el)($rootScope);
+        $rootScope.$digest();
+        expect(component.text()).toContain('Trashed items will be kept a maximum of 90 days.');
+
+        $rootScope.listing.params.path = 'test/.Trash/testing';
+        $rootScope.$digest();
+        expect(component.text()).toContain('Trashed items will be kept a maximum of 90 days.');
+    });
+ 
 
 });
 

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/files-listing.template.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/files-listing.template.html
@@ -97,6 +97,11 @@
                 </tr>
             </tbody>
             <caption style="padding:0px;">
+                <div data-ng-if="$ctrl.isInTrash()">
+                    <div class="alert alert-warning text-center">
+                        Trashed items will be kept a maximum of 90 days.
+                    </div>
+                </div>
                 <div data-ng-if="$ctrl.listing.loading"
                      style="padding:10px; font-size:large; width:100%;"
                      class="bg-info"


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1721](https://jira.tacc.utexas.edu/browse/DES-1721)

## Summary of Changes: ##
* Added the message, "Trashed items will be kept a maximum of 90 days", between the breadcrumb and file-listing of My Data. 
* Added a basic test to see if the message appears in specified paths.

## Testing Steps: ##
1. Run `npm run test` and see if tests pass.
2. Go to "My Data" from "Data Depot"
3. If there is no ".Trash" create a folder and move it to trash.
4. Go to the ".Trash" directory or any of its subdirectories.
5. Confirm that the message appears.
6. Go to "My Projects" from "Data Depot"
7. Create a Project if there is none.
8. If there is no ".Trash" create a folder and move it to trash.
4. Go to the ".Trash" directory or any of its subdirectories.
5. Confirm that the message appears.

## UI Photos:
![Screenshot from 2020-10-21 10-29-31](https://user-images.githubusercontent.com/9425579/96750873-05fa4800-13bc-11eb-8785-d89b5cf56e72.png)
![Screenshot from 2020-10-21 10-29-51](https://user-images.githubusercontent.com/9425579/96750905-101c4680-13bc-11eb-81aa-629beb9318ae.png)
![Screenshot from 2020-10-21 10-30-12](https://user-images.githubusercontent.com/9425579/96750908-11e60a00-13bc-11eb-88ab-9acf8335b82f.png)
![Screenshot from 2020-10-21 10-30-26](https://user-images.githubusercontent.com/9425579/96750916-13afcd80-13bc-11eb-9f2b-4e1f96500aeb.png)


## Notes: ##
I wasn't sure if it was ok to put this directly inside `<caption>` and not through the `message` api. But this this seemed like it had to be a separate message.