### PR TITLE
DES-661 - Fix user-agent warning for supported IOS browsers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![codecov](https://codecov.io/gh/DesignSafe-CI/portal/branch/master/graph/badge.svg)](https://codecov.io/gh/DesignSafe-CI/portal)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8399b864b0d115d86450/maintainability)](https://codeclimate.com/github/DesignSafe-CI/portal/maintainability)
 
-# DesignSafe-CI Portal
+# DesignSafe-CI Portall
 
 ## Prequisites for running the portal application
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![codecov](https://codecov.io/gh/DesignSafe-CI/portal/branch/master/graph/badge.svg)](https://codecov.io/gh/DesignSafe-CI/portal)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8399b864b0d115d86450/maintainability)](https://codeclimate.com/github/DesignSafe-CI/portal/maintainability)
 
-# DesignSafe-CI Portall
+# DesignSafe-CI Portal
 
 ## Prequisites for running the portal application
 

--- a/designsafe/middleware.py
+++ b/designsafe/middleware.py
@@ -17,27 +17,10 @@ from django.shortcuts import redirect, reverse
 
 logger = logging.getLogger(__name__)
 
-class DesignSafeSupportedBrowserMiddleware:
-    """
-    Middleware to check if the user is running Chrome or Firefox and 
-    flash a warning otherwise.
-    """
-
-    def process_request(self, request):
-        user_agent = request.META['HTTP_USER_AGENT']
-        agent_is_supported = ('Chrome' in user_agent) or ('Firefox' in user_agent)
-
-        if not agent_is_supported:
-            messages.warning(request, '<h4>Unsupported Browser</h4>'
-                                      'Your browser is not supported by DesignSafe. '
-                                      'Please switch to <a href="https://www.google.com/chrome">Chrome</a> '
-                                      'or <a href="https://www.mozilla.org/en-US/firefox/new/">Firefox</a> '
-                                      'if you experience issues.')
-
 class DesignsafeProfileUpdateMiddleware:
 
     """
-    Middleware to check if a user's profile has the update_required flag set to 
+    Middleware to check if a user's profile has the update_required flag set to
     True, and force them to update their profile if so.
     """
 

--- a/designsafe/templates/base.html
+++ b/designsafe/templates/base.html
@@ -119,7 +119,7 @@
 
         var userAgent = navigator.userAgent
 
-        if(!(userAgent.includes("Chrome") || userAgent.includes("Firefox"))) {
+        if(!(userAgent.includes("Chrome") || userAgent.includes("Firefox") || userAgent.includes("FxiOS") || userAgent.includes("CriOS"))) {
             $("#agentMessage").append("\
                 <div class='alert alert-warning'>\
                     <button type='button' class='close' data-dismiss='alert' aria-label='Close'>\


### PR DESCRIPTION
## Overview: ##
Fixes an incorrect error message that pops up on supported browsers on IOS devices.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-661](https://jira.tacc.utexas.edu/browse/DES-661)

## Summary of Changes: ##
Added a separate condition for IOS user-agent names (FxiOS, CriOS) for supported browsers. 

## Testing Steps: ##
1. Open the site on supported browsers (Firefox and Chrome) on IOS.
2. Confirm that you do not see the error message about unsupported browsers.

## UI Photos:
N/A

## Notes: ##
I have tested with two IOS devices and my Android phone with both Firefox and Chrome on each device to confirm correct behavior.