### PR TITLE
task/DES-1542 - Support old collection type for FR projects in relationship tree

### DIFF
--- a/designsafe/static/scripts/projects/components/project-tree/project-tree.component.js
+++ b/designsafe/static/scripts/projects/components/project-tree/project-tree.component.js
@@ -519,7 +519,8 @@ class ProjectTreeCtrl {
         this.project.allCollections = [].concat(
             this.project.socialscience_set || [],
             this.project.geoscience_set || [],
-            this.project.planning_set || []
+            this.project.planning_set || [],
+            this.project.collection_set || [],
         );
         if (this.rootCategoryUuid) {
             missions = _.filter(


### PR DESCRIPTION
## Overview: ##
Before the other collection types were created, there was just a generic "collection" that was categorized under missions for FR projects... Since there were some published projects using this older model, we need to support the display of those collections in the relationship tree. You can use this existing publication to test the view:
https://www.designsafe-ci.org/data/browser/public/designsafe.storage.published//PRJ-2440

**Note:** Mission and Collection ordering was not available when these projects were published, so you should see things categorized correctly, but the order may not match 100% to the published view.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1542](https://jira.tacc.utexas.edu/browse/DES-1542)

## Summary of Changes: ##

## Testing Steps: ##
1. Check the Field Research relationship Tree for older FR publications. Here is one:
https://designsafe.dev/data/browser/public/designsafe.storage.published//PRJ-2440

## UI Photos:
**BEFORE**
![Screen Shot 2021-01-07 at 3 06 08 PM](https://user-images.githubusercontent.com/29575979/103944914-f9070e00-50f9-11eb-8f1d-9ee6f11ce1bc.png)

**AFTER**
![Screen Shot 2021-01-07 at 3 06 17 PM](https://user-images.githubusercontent.com/29575979/103944923-fc01fe80-50f9-11eb-8f52-b150a3114278.png)
