### PR TITLE
task/DES-1834 - Add license URLs to Google Dataset meta tags

### DIFF
--- a/designsafe/apps/projects/models/agave/base.py
+++ b/designsafe/apps/projects/models/agave/base.py
@@ -337,19 +337,13 @@ class Project(MetadataModel):
         dataset_json['creator'] = generate_creators(authors)
         dataset_json['author'] = generate_creators(authors)
         try:
-            pub = IndexedPublication.from_id(self.project_id)
-            dataset_json['license'] = {
-                "@type": "CreativeWork",
-                "license": pub.licenses.works
-                }
+            pub = IndexedPublication.from_id(self.project_id) 
+            dataset_json['license'] = generate_licenses(pub)
         except (DocumentNotFound, AttributeError):
             pass
         try:
             pub = IndexedPublicationLegacy.from_id(self.project_id)
-            dataset_json['license'] = {
-                "@type": "CreativeWork",
-                "license":pub.licenses.works
-            }
+            dataset_json['license'] = generate_licenses(pub)
         except DocumentNotFound:
             pass
 
@@ -472,7 +466,16 @@ def generate_creators(authors):
             creators_details.append(details)
         return creators_details
 
-
+def generate_licenses(pub):
+    license_details = []
+    if pub.licenses.works == "Creative Commons Attribution Share Alike":
+        url = "https://creativecommons.org/licenses/by/4.0/"
+    license_details = {
+        "@type": "CreativeWork",
+        "license": pub.licenses.works,
+        "url": url
+    }
+    return license_details
 
 def _process_authors(authors):
     """Process authors.

--- a/designsafe/apps/projects/models/agave/base.py
+++ b/designsafe/apps/projects/models/agave/base.py
@@ -468,11 +468,26 @@ def generate_creators(authors):
 
 def generate_licenses(pub):
     license_details = []
-    if pub.licenses.works == "Creative Commons Attribution Share Alike":
+    url = []
+    license_type = []
+    if pub.licenses.datasets == "Open Data Commons Attribution":
+        url = "https://opendatacommons.org/licenses/by/1-0/"
+        license_type = pub.licenses.datasets
+    elif pub.licenses.datasets == "Open Data Commons Public Domain Dedication":
+        url = "https://opendatacommons.org/licenses/pddl/1-0/"
+        license_type = pub.licenses.datasets
+    elif pub.licenses.works == "Creative Commons Attribution Share Alike":
         url = "https://creativecommons.org/licenses/by/4.0/"
+        license_type = pub.licenses.works
+    elif pub.licenses.works == "Creative Commons Public Domain Dedication":
+        url = "https://creativecommons.org/publicdomain/zero/1.0/"
+        license_type = pub.licenses.works
+    elif pub.licenses.software == "GNU General Public License":
+        url = "http://www.gnu.org/licenses/gpl.html"
+        license_type = pub.licenses.software
     license_details = {
         "@type": "CreativeWork",
-        "license": pub.licenses.works,
+        "license": license_type,
         "url": url
     }
     return license_details


### PR DESCRIPTION
## Overview: ##
Google needs either "name" or "url" to be specified for the license in Dataset search tags. I'm adding urls and making sure that all license types are being picked up.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1834](https://jira.tacc.utexas.edu/browse/DES-1834)

## Summary of Changes: ##
- Created a modular `generate_licenses` function
- Added urls for each type of license

## Testing Steps: ##
View the page source for each of these publications
1. Open Data Commons Attribution -  PRJ-2971
2. Open Data Commons Public Domain Dedication - PRJ-2534
3. Creative Commons Attribution Share Alike - PRJ-2982
4. Creative Commons Public Domain Dedication - PRJ-2519
5. GNU General Public License - PRJ-2938

## UI Photos:

## Notes: ##
Creative Commons Attribution Share Alike publications seem to not render locally in either this branch or master