### PR TITLE
Task/DES-1847 - Fix issue with download modal for v1 projects

### DIFF
--- a/designsafe/static/scripts/data-depot/components/published/published.component.js
+++ b/designsafe/static/scripts/data-depot/components/published/published.component.js
@@ -448,8 +448,7 @@ export class PublishedDataCtrl {
         this.$uibModal.open({
             component: 'publicationDownloadModal',
             resolve: {
-                publication: () => {return this.browser.publication;},
-                mediaUrl: () => {return this.browser.listing.mediaUrl();},
+                publication: () => {return this.browser.publication;}
             },
             size: 'lg'
         });


### PR DESCRIPTION
## Overview: ##
Mediaurl param was causing issues with the publication download modal.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1847](https://jira.tacc.utexas.edu/browse/DES-1847)

## Summary of Changes: ##

## Testing Steps: ##
1. open up an older publication from around early 2018-2017 and check that the "download dataset" button opens the modal in the top right

## UI Photos:
![Screen Shot 2021-01-12 at 10 19 28 AM](https://user-images.githubusercontent.com/29575979/104341715-b8274480-54bf-11eb-9741-2eda8d8f02a4.png)

