### PR TITLE
task/DES-1836: Rename app categories

### DIFF
--- a/designsafe/static/scripts/applications/controllers/application-edit.js
+++ b/designsafe/static/scripts/applications/controllers/application-edit.js
@@ -1868,7 +1868,7 @@ export function applicationEditCtrl(window, angular, $, _) {
                                                                             if (appCategories.includes(appCategory)) {
                                                                                 app.appCategory = appCategory;
                                                                             } else if (appCategory == 'Data Collections') {
-                                                                                app.appCategory = 'Partner Data Apps';
+                                                                                app.appCategory = 'Hazard Apps';
                                                                             }
                                                                             if (app.appCategory) {
                                                                                 app.tags.splice(app.tags.indexOf(app.tags.filter(s => s.includes('appCategory'))[0]));
@@ -1986,7 +1986,7 @@ export function applicationEditCtrl(window, angular, $, _) {
                             if (appCategories.includes(appCategory)) {
                                 app.appCategory = appCategory;
                             } else if (appCategory == 'Data Collections') {
-                                app.appCategory = 'Partner Data Apps';
+                                app.appCategory = 'Hazard Apps';
                             }
                             if (app.appCategory) {
                                 app.tags.splice(app.tags.indexOf(app.tags.filter(s => s.includes('appCategory'))[0]));

--- a/designsafe/static/scripts/ng-designsafe/ng-designsafe.js
+++ b/designsafe/static/scripts/ng-designsafe/ng-designsafe.js
@@ -76,7 +76,7 @@ export const ngDesignsafe = angular.module('designsafe',
             );
         }
     ])
-    .constant('appCategories', ['Simulation', 'Visualization', 'Data Processing', 'Partner Data Apps', 'Utilities'])
+    .constant('appCategories', ['Simulation', 'Visualization', 'Analysis', 'Hazard Apps', 'Utilities'])
     // Current list of icons for apps
     .constant('appIcons', ['Compress', 'Extract', 'MATLAB', 'Paraview', 'Hazmapper', 'Jupyter', 'ADCIRC', 'QGIS', 'LS-DYNA', 'LS-Pre/Post', 'VisIt', 'OpenFOAM', 'OpenSees', 'NGL']);
 

--- a/designsafe/static/scripts/workspace/services/simple-list-service.js
+++ b/designsafe/static/scripts/workspace/services/simple-list-service.js
@@ -105,7 +105,7 @@ export function simpleListService($http, $q, djangoUrl, appCategories, appIcons)
                             if (appCategory in appsByCategory) {
                                 appsByCategory[appCategory].push(appMeta);
                             } else if (appCategory == 'Data Collections') {
-                                appsByCategory['Partner Data Apps'].push(appMeta);
+                                appsByCategory['Hazard Apps'].push(appMeta);
                             } else {
                                 // If App has no category, place in Simulation tab
                                 appsByCategory['Simulation'].push(appMeta);


### PR DESCRIPTION
## Overview: ##
This is a quick fix to rename some app categories per the DES-1836 task. A future PR will come that further decouples app categories from the deployed code, and allows for dynamic app category population.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-1836](https://jira.tacc.utexas.edu/browse/DES-1836)

## Testing Steps: ##
1. Once deployed to dev, we can publish test apps to these new categories, which will appear in the apps tray.
