### PR TITLE
task/DES-1836 Addendum: Accommodate previous category names

### DIFF
--- a/designsafe/static/scripts/applications/controllers/application-edit.js
+++ b/designsafe/static/scripts/applications/controllers/application-edit.js
@@ -1868,7 +1868,7 @@ export function applicationEditCtrl(window, angular, $, _) {
                                                                             if (appCategories.includes(appCategory)) {
                                                                                 app.appCategory = appCategory;
                                                                             } else if (appCategory == 'Data Collections') {
-                                                                                app.appCategory = 'Partner Data Apps';
+                                                                                app.appCategory = 'Hazard Apps';
                                                                             }
                                                                             if (app.appCategory) {
                                                                                 app.tags.splice(app.tags.indexOf(app.tags.filter(s => s.includes('appCategory'))[0]));
@@ -1986,7 +1986,7 @@ export function applicationEditCtrl(window, angular, $, _) {
                             if (appCategories.includes(appCategory)) {
                                 app.appCategory = appCategory;
                             } else if (appCategory == 'Data Collections') {
-                                app.appCategory = 'Partner Data Apps';
+                                app.appCategory = 'Hazard Apps';
                             }
                             if (app.appCategory) {
                                 app.tags.splice(app.tags.indexOf(app.tags.filter(s => s.includes('appCategory'))[0]));

--- a/designsafe/static/scripts/applications/controllers/application-edit.js
+++ b/designsafe/static/scripts/applications/controllers/application-edit.js
@@ -1867,8 +1867,10 @@ export function applicationEditCtrl(window, angular, $, _) {
 
                                                                             if (appCategories.includes(appCategory)) {
                                                                                 app.appCategory = appCategory;
-                                                                            } else if (appCategory == 'Data Collections') {
+                                                                            } else if (appCategory === 'Data Collections' || appCategory === 'Partner Data Apps') {
                                                                                 app.appCategory = 'Hazard Apps';
+                                                                            } else if (appCategory == 'Data Processing') {
+                                                                                app.appCategory = 'Analysis';
                                                                             }
                                                                             if (app.appCategory) {
                                                                                 app.tags.splice(app.tags.indexOf(app.tags.filter(s => s.includes('appCategory'))[0]));

--- a/designsafe/static/scripts/applications/controllers/application-edit.js
+++ b/designsafe/static/scripts/applications/controllers/application-edit.js
@@ -1869,7 +1869,7 @@ export function applicationEditCtrl(window, angular, $, _) {
                                                                                 app.appCategory = appCategory;
                                                                             } else if (appCategory === 'Data Collections' || appCategory === 'Partner Data Apps') {
                                                                                 app.appCategory = 'Hazard Apps';
-                                                                            } else if (appCategory == 'Data Processing') {
+                                                                            } else if (appCategory === 'Data Processing') {
                                                                                 app.appCategory = 'Analysis';
                                                                             }
                                                                             if (app.appCategory) {

--- a/designsafe/static/scripts/ng-designsafe/ng-designsafe.js
+++ b/designsafe/static/scripts/ng-designsafe/ng-designsafe.js
@@ -76,7 +76,7 @@ export const ngDesignsafe = angular.module('designsafe',
             );
         }
     ])
-    .constant('appCategories', ['Simulation', 'Visualization', 'Data Processing', 'Partner Data Apps', 'Utilities'])
+    .constant('appCategories', ['Simulation', 'Visualization', 'Analysis', 'Hazard Apps', 'Utilities'])
     // Current list of icons for apps
     .constant('appIcons', ['Compress', 'Extract', 'MATLAB', 'Paraview', 'Hazmapper', 'Jupyter', 'ADCIRC', 'QGIS', 'LS-DYNA', 'LS-Pre/Post', 'VisIt', 'OpenFOAM', 'OpenSees', 'NGL']);
 

--- a/designsafe/static/scripts/workspace/services/simple-list-service.js
+++ b/designsafe/static/scripts/workspace/services/simple-list-service.js
@@ -105,9 +105,9 @@ export function simpleListService($http, $q, djangoUrl, appCategories, appIcons)
                             if (appCategory in appsByCategory) {
                                 appsByCategory[appCategory].push(appMeta);
                             } else if (appCategory === 'Data Collections' || appCategory === 'Partner Data Apps') {
-                                app.appCategory = 'Hazard Apps';
+                                appsByCategory['Hazard Apps'].push(appMeta);
                             } else if (appCategory === 'Data Processing') {
-                                app.appCategory = 'Analysis';
+                                appsByCategory['Analysis'].push(appMeta);
                             } else {
                                 // If App has no category, place in Simulation tab
                                 appsByCategory['Simulation'].push(appMeta);

--- a/designsafe/static/scripts/workspace/services/simple-list-service.js
+++ b/designsafe/static/scripts/workspace/services/simple-list-service.js
@@ -106,7 +106,7 @@ export function simpleListService($http, $q, djangoUrl, appCategories, appIcons)
                                 appsByCategory[appCategory].push(appMeta);
                             } else if (appCategory === 'Data Collections' || appCategory === 'Partner Data Apps') {
                                 app.appCategory = 'Hazard Apps';
-                            } else if (appCategory == 'Data Processing') {
+                            } else if (appCategory === 'Data Processing') {
                                 app.appCategory = 'Analysis';
                             } else {
                                 // If App has no category, place in Simulation tab

--- a/designsafe/static/scripts/workspace/services/simple-list-service.js
+++ b/designsafe/static/scripts/workspace/services/simple-list-service.js
@@ -105,7 +105,7 @@ export function simpleListService($http, $q, djangoUrl, appCategories, appIcons)
                             if (appCategory in appsByCategory) {
                                 appsByCategory[appCategory].push(appMeta);
                             } else if (appCategory == 'Data Collections') {
-                                appsByCategory['Partner Data Apps'].push(appMeta);
+                                appsByCategory['Hazard Apps'].push(appMeta);
                             } else {
                                 // If App has no category, place in Simulation tab
                                 appsByCategory['Simulation'].push(appMeta);

--- a/designsafe/static/scripts/workspace/services/simple-list-service.js
+++ b/designsafe/static/scripts/workspace/services/simple-list-service.js
@@ -104,8 +104,10 @@ export function simpleListService($http, $q, djangoUrl, appCategories, appIcons)
                             // Place appMeta in category
                             if (appCategory in appsByCategory) {
                                 appsByCategory[appCategory].push(appMeta);
-                            } else if (appCategory == 'Data Collections') {
-                                appsByCategory['Hazard Apps'].push(appMeta);
+                            } else if (appCategory === 'Data Collections' || appCategory === 'Partner Data Apps') {
+                                app.appCategory = 'Hazard Apps';
+                            } else if (appCategory == 'Data Processing') {
+                                app.appCategory = 'Analysis';
                             } else {
                                 // If App has no category, place in Simulation tab
                                 appsByCategory['Simulation'].push(appMeta);


### PR DESCRIPTION
## Overview: ##

Addendum to https://github.com/DesignSafe-CI/portal/pull/848.

Accommodate deprecated app category names by interpreting an existing app with an old category to be categorized to the new category.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-1836](https://jira.tacc.utexas.edu/browse/DES-1836)

## Testing Steps: ##
1. When testing in dev, all existing apps should auto populate to their new respective category.
