### PR TITLE
task/DES-1905: bump Celery version and use unique hostnames for workers.

### DIFF
--- a/bin/run-celery-debug.sh
+++ b/bin/run-celery-debug.sh
@@ -4,4 +4,5 @@
 # Run Celery task queue for development
 #
 celery -A designsafe beat -l info --pidfile= --schedule=/tmp/celerybeat-schedule &
-celery -A designsafe worker -l debug
+celery -A designsafe worker -l info --autoscale=15,5 -Q indexing,files -n designsafe_worker01 &
+celery -A designsafe worker -l info --autoscale=10,3 -Q default,api -n designsafe_worker02

--- a/bin/run-celery.sh
+++ b/bin/run-celery.sh
@@ -2,5 +2,5 @@
 
 # Run Celery as the DesignSafe Community Account
 celery -A designsafe beat -l info --pidfile= --schedule=/tmp/celerybeat-schedule &
-celery -A designsafe worker -l info --autoscale=15,5 -Q indexing,files &
-celery -A designsafe worker -l info --autoscale=10,3 -Q default,api
+celery -A designsafe worker -l info --autoscale=15,5 -Q indexing,files -n designsafe_worker01 &
+celery -A designsafe worker -l info --autoscale=10,3 -Q default,api -n designsafe_worker02

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 agavepy==0.9.3
 alabaster==0.7.10
-amqp==2.2.1
+amqp==5.0.5
 appnope==0.1.0
 asn1crypto==0.24.0
 astroid==1.6.5
@@ -11,10 +11,10 @@ backports.functools-lru-cache==1.5
 backports.shutil-get-terminal-size==1.0.0
 backports.ssl-match-hostname==3.4.0.2
 beautifulsoup4==4.5.3
-billiard==3.5.0.3
+billiard==3.6.3.0
 boxsdk==2.9.0
 cachetools==2.0.1
-celery==4.1.0
+celery==5.0.5
 certifi==2017.7.27.1
 cffi==1.10.0
 chardet==3.0.4
@@ -89,7 +89,7 @@ jdcal==1.3
 Jinja2==2.7.3
 jsonfield==2.0.2
 jsonpickle==0.9.6
-kombu==4.1.0
+kombu==5.0.2
 lazy-object-proxy==1.3.1
 MarkupSafe==1.1.1
 mccabe==0.6.1
@@ -164,7 +164,7 @@ uritemplate==3.0.0
 urllib3==1.22
 uWSGI==2.0.18
 uwsgitop==0.11
-vine==1.1.4
+vine==5.0.0
 virtualenv==13.0.1
 wcwidth==0.1.7
 websocket-client==0.53.0


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1905](https://jira.tacc.utexas.edu/browse/DES-1905)

## Summary of Changes: ##

## Testing Steps: ##
1. Rebuild container with `docker-compose -f conf/docker/docker-compose.yml build`
2. Bring up the portal and run `celery -A designsafe inspect active_queues` inside the `des_django` container. There should be 4 queues and 2 nodes online.

## UI Photos:

## Notes: ##
