### PR TITLE
task/DES-1236 - Corrections for passing metadata to DataCite

### DIFF
--- a/designsafe/apps/projects/models/agave/base.py
+++ b/designsafe/apps/projects/models/agave/base.py
@@ -416,16 +416,28 @@ class Project(MetadataModel):
             self.award_number,
             key=lambda x: (x.get('order', 0), x.get('name', ''))
         )
-        attributes['identifiers'] += [
-            {
-                'identifierType': 'NSF Award Number',
-                'identifier': '{name} - {number}'.format(
-                    name=award['name'],
-                    number=award['number']
-                ),
-            } for award in awards
-            if award.get('name') and award.get('number')
-        ]
+        attributes['fundingReferences'] = []
+        for award in awards:
+            attributes['fundingReferences'].append({
+                'fundername': award['name'],
+                'awardnumber': award['number']
+                })
+
+        attributes['relatedIdentifiers'] = []
+        for related_entity in self.related_entities():
+            rel_ent_dict = related_entity.to_body_dict()
+            if 'dois' in rel_ent_dict['value'] and len(rel_ent_dict['value']['dois']):
+                attributes['relatedIdentifiers'].append({
+                    'relatedIdentifier': rel_ent_dict['value']['dois'],
+                    'relatedIdentifierType': 'DOI',
+                    'relationType': 'IsPartOf'
+                })
+            elif 'uuid' in rel_ent_dict['value'] and len(rel_ent_dict['value']['uuid']):
+                attributes['relatedIdentifiers'].append({
+                    'relatedIdentifier': 'https://agave.designsafe-ci.org/meta/v2/data/' + related_entity['value']['uuid'],
+                    'relatedIdentifierType': 'URL',
+                    'relationType': 'IsPartOf'
+                })
         return attributes
 
 


### PR DESCRIPTION
## Overview: ##
Some of the metadata is being submitted to Datacite with incorrect mapping.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1236](https://jira.tacc.utexas.edu/browse/DES-1236)

## Summary of Changes: ##
This should make the metadata passed to Datacite correctly cite multiple DOIs and multiple award numbers in publications.  I followed all_data_models_mapping_fedora_2021 in DES-1666.

## Testing Steps: ##
1. Pick a publication that has multiple DOIs and Awards.  I used PRJ-2864
2. Open the DS Django shell locally
3. Run 
```
from designsafe.apps.projects.managers.base import ProjectsManager
from designsafe.apps.api.agave import service_account
manager = ProjectsManager(service_account())
project = manager.get_project_by_id("PRJ-XXX")
project.to_datacite_json()
```

## UI Photos:

## Notes: ##
