### PR TITLE
task/DES-1926: Instantiate ES clients a-la-carte in the Publication Pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # DesignSafe-CI Portal Release Notes
 
-## v5.15
+## v5.1.5
 Fixes:
 - Update Redis Python client.
 

--- a/designsafe/apps/api/tasks.py
+++ b/designsafe/apps/api/tasks.py
@@ -15,6 +15,8 @@ from requests.exceptions import HTTPError
 from designsafe.apps.api.notifications.models import Notification, Broadcast
 from designsafe.apps.api.agave import get_service_account_client
 from designsafe.apps.projects.models.elasticsearch import IndexedProject
+from designsafe.apps.data.models.elasticsearch import IndexedPublication
+from designsafe.libs.elasticsearch.utils import new_es_client
 from designsafe.apps.data.tasks import agave_indexer
 from elasticsearch_dsl.query import Q
 from elasticsearch.helpers import bulk
@@ -540,7 +542,8 @@ def copy_publication_files_to_corral(self, project_id):
 
     from designsafe.libs.elasticsearch.docs.publications import BaseESPublication
     import shutil
-    publication = BaseESPublication(project_id=project_id)
+    es_client = new_es_client()
+    publication = IndexedPublication.from_id(project_id=project_id, using=es_client)
     filepaths = publication.related_file_paths()
     if not len(filepaths):
         res = get_service_account_client().files.list(
@@ -710,8 +713,9 @@ def save_to_fedora(self, project_id):
     import magic
     from designsafe.libs.elasticsearch.docs.publications import BaseESPublication 
     try:
-        pub = BaseESPublication(project_id=project_id)
-        pub.update(status='published')
+        es_client = new_es_client()
+        pub = BaseESPublication(project_id=project_id, using=es_client)
+        pub.update(status='published', using=es_client)
         _root = os.path.join('/corral-repl/tacc/NHERI/published', project_id)
         fedora_base = 'http://fedoraweb01.tacc.utexas.edu:8080/fcrepo/rest/publications_01'
         res = requests.get(fedora_base)

--- a/designsafe/apps/data/models/elasticsearch.py
+++ b/designsafe/apps/data/models/elasticsearch.py
@@ -330,7 +330,7 @@ class IndexedPublication(Document):
     })
 
     @classmethod
-    def from_id(cls, project_id):
+    def from_id(cls, project_id, using='default'):
         if project_id is None:
             raise DocumentNotFound()
         id_filter = Q('term', **{'projectId._exact': project_id})
@@ -343,10 +343,10 @@ class IndexedPublication(Document):
             id_filter = Q('term', **{'_id': res[0].meta.id}) 
             # Delete all files indexed with the same system/path, except the first result
             delete_query = id_filter & ~id_filter
-            cls.search().filter(delete_query).delete()
-            return cls.get(res[0].meta.id)
+            cls.search(using=using).filter(delete_query).delete()
+            return cls.get(res[0].meta.id, using=using)
         elif res.hits.total.value == 1:
-            return cls.get(res[0].meta.id)
+            return cls.get(res[0].meta.id, using=using)
         else:
             raise DocumentNotFound("No document found for "
                                    "{}".format(project_id))

--- a/designsafe/apps/projects/managers/publication.py
+++ b/designsafe/apps/projects/managers/publication.py
@@ -221,6 +221,7 @@ def publish_resource(project_id, entity_uuids=None, publish_dois=False):
 
     pub = BaseESPublication(project_id=project_id, using=es_client)
     pub.update(status='published', using=es_client)
+    IndexedPublication._index.refresh(using=es_client)
 
     for res in responses:
         logger.info(
@@ -377,7 +378,8 @@ def fix_file_tags(project_id):
             elif 'value' in pub_dict[entname] and 'fileTags' in pub_dict[entname]['value']:
                 fix_tags_no_path(pub_dict[entname])
 
-    pub.update(**pub_dict)
+    pub.update(using=es_client, **pub_dict)
+    IndexedPublication._index.refresh(using=es_client)
 
 
 def archive(project_id):
@@ -561,5 +563,6 @@ def freeze_project_and_entity_metadata(project_id, entity_uuids=None):
     else:
         publication['project'] = prj_json
 
-    pub_doc.update(**publication, using=es_client)
+    pub_doc.update(using=es_client, **publication)
+    IndexedPublication._index.refresh(using=es_client)
     return pub_doc

--- a/designsafe/apps/projects/managers/publication.py
+++ b/designsafe/apps/projects/managers/publication.py
@@ -15,9 +15,11 @@ from pytas.http import TASClient
 from designsafe import settings
 from designsafe.apps.api.agave import service_account
 from designsafe.apps.data.models.agave.files import BaseFileResource
+from designsafe.apps.data.models.elasticsearch import IndexedPublication
 from designsafe.apps.projects.managers import datacite as DataciteManager
 from designsafe.apps.projects.managers.base import ProjectsManager
 from designsafe.libs.elasticsearch.docs.publications import BaseESPublication
+from designsafe.libs.elasticsearch.utils import new_es_client
 
 
 logger = logging.getLogger(__name__)
@@ -195,6 +197,7 @@ def publish_resource(project_id, entity_uuids=None, publish_dois=False):
     :param str project_id: Project Id to publish.
     :param list entity_uuids: list of str Entity uuids to publish.
     """
+    es_client = new_es_client()
     mgr = ProjectsManager(service_account())
     prj = mgr.get_project_by_id(project_id)
     responses = []
@@ -216,8 +219,8 @@ def publish_resource(project_id, entity_uuids=None, publish_dois=False):
             responses.append(res)
 
 
-    pub = BaseESPublication(project_id=project_id)
-    pub.update(status='published')
+    pub = BaseESPublication(project_id=project_id, using=es_client)
+    pub.update(status='published', using=es_client)
 
     for res in responses:
         logger.info(
@@ -308,7 +311,8 @@ def _delete_unused_fields(dict_obj):
 
 
 def fix_file_tags(project_id):
-    pub = BaseESPublication(project_id=project_id)
+    es_client = new_es_client()
+    pub = BaseESPublication(project_id=project_id, using=es_client)
     pub_dict = pub.to_dict()
 
     entities_to_check = list(set(pub_dict.keys()).intersection(list(FIELD_MAP.values())))
@@ -383,7 +387,8 @@ def archive(project_id):
     for a project, and it will also include a formatted json document of the published metadata.
     Note: This metadata file is will only be used until the Fedora system is set up again.
     """
-    pub = BaseESPublication(project_id=project_id)
+    es_client = new_es_client()
+    pub = BaseESPublication(project_id=project_id, using=es_client)
     archive_name = '{}_archive.zip'.format(pub.projectId)
     metadata_name = '{}_metadata.json'.format(pub.projectId)
     pub_dir = settings.DESIGNSAFE_PUBLISHED_PATH
@@ -495,9 +500,10 @@ def freeze_project_and_entity_metadata(project_id, entity_uuids=None):
     :param str project_id: Project id.
     :param list of entity_uuid strings: Entity uuids.
     """
+    es_client = new_es_client()
     mgr = ProjectsManager(service_account())
     prj = mgr.get_project_by_id(project_id)
-    pub_doc = BaseESPublication(project_id=project_id)
+    pub_doc = IndexedPublication.from_id(project_id=project_id, using=es_client)
     publication = pub_doc.to_dict()
 
     if entity_uuids:
@@ -555,5 +561,5 @@ def freeze_project_and_entity_metadata(project_id, entity_uuids=None):
     else:
         publication['project'] = prj_json
 
-    pub_doc.update(**publication)
+    pub_doc.update(**publication, using=es_client)
     return pub_doc

--- a/designsafe/libs/elasticsearch/docs/publications.py
+++ b/designsafe/libs/elasticsearch/docs/publications.py
@@ -31,7 +31,7 @@ class BaseESPublication(BaseESResource):
 
     """
 
-    def __init__(self, wrapped_doc=None, project_id=None, **kwargs):
+    def __init__(self, wrapped_doc=None, project_id=None, using='default', **kwargs):
         """Elastic Search File representation.
 
         This class directly wraps an Agave indexed file.
@@ -40,12 +40,12 @@ class BaseESPublication(BaseESResource):
         super(BaseESPublication, self).__init__(wrapped_doc, **kwargs)
 
         if not wrapped_doc:
-            self._populate(project_id, **kwargs)
+            self._populate(project_id, using=using, **kwargs)
 
-    def _populate(self, project_id, **kwargs):
+    def _populate(self, project_id, using='default', **kwargs):
 
         try:
-            wrapped_doc = self._index_cls.from_id(project_id)
+            wrapped_doc = self._index_cls.from_id(project_id, using=using)
             self._wrap(wrapped_doc, **kwargs)
         except DocumentNotFound:
             self._wrapped = self._index_cls(
@@ -57,14 +57,14 @@ class BaseESPublication(BaseESResource):
     def _index_cls(self):
         return IndexedPublication
 
-    def save(self, using=None, index=None, validate=True,
+    def save(self, using='default', index=None, validate=True,
              **kwargs):  # pylint: disable=unused-argument
         """Save document."""
-        self._wrapped.save()
+        self._wrapped.save(using=using)
 
-    def delete(self):
+    def delete(self, using='default'):
         """Delete."""
-        self._wrapped.delete()
+        self._wrapped.delete(using=using)
 
     @staticmethod
     def hit_to_file(hit):

--- a/designsafe/libs/elasticsearch/utils.py
+++ b/designsafe/libs/elasticsearch/utils.py
@@ -1,5 +1,6 @@
 from future.utils import python_2_unicode_compatible
 import urllib.request, urllib.parse, urllib.error
+from elasticsearch import Elasticsearch
 import logging
 import os 
 
@@ -196,3 +197,15 @@ def full_dedup(limit=1000):
         res = file_search.execute()
 
 
+def new_es_client():
+    """
+    Instantiate a new Elasticsearch client to use when overriding the default.
+    """
+    use_ssl = (not settings.DESIGNSAFE_ENVIRONMENT == 'dev')
+    return Elasticsearch(
+        hosts=settings.ES_CONNECTIONS[settings.DESIGNSAFE_ENVIRONMENT]['hosts'],
+        http_auth=settings.ES_AUTH,
+        max_retries=3,
+        retry_on_timeout=True,
+        use_ssl=use_ssl
+    )


### PR DESCRIPTION
…ying on the default

## Overview: ##
![image](https://user-images.githubusercontent.com/12601812/113765154-84844100-96e1-11eb-9fed-5ad145fa8075.png)
Elasticsearch sniffing errors are much too frequent on the worker machine to rely on the `default` client in the publication pipeline. Until we can investigate and resolve this issue, the best course of action is to instantiate new Elasticsearch clients at each step of the publication pipeline, which eliminates the need to maintain long-lived TCP connections.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1926](https://jira.tacc.utexas.edu/browse/DES-1926)

## Summary of Changes: ##
- Add a `new_es_client()` method to the Elasticsearch utils library to instantiate new clients.
- Update methods in `IndexedPublication` and `BaseESPublication` to support passing in a custom client (defaulting to `default`).
- Update publication pipeline methods to use new ES clients instead of `default`.

## Testing Steps: ##
1. In local dev, try publishing a project and make sure that nothing breaks.

