### PR TITLE
bug/DES-1928: Fix typo in NEES citation modal and add .sas to previewable filetypes.

### DIFF
--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -591,7 +591,7 @@ SUPPORTED_TEXT_PREVIEW_EXTS = [
     '.java', '.js', '.less', '.m', '.make', '.md', '.ml', '.mm', '.msg', '.php',
     '.pl', '.properties', '.py', '.rb', '.sass', '.scala', '.script', '.sh', '.sml',
     '.sql', '.txt', '.vi', '.vim', '.xml', '.xsd', '.xsl', '.yaml', '.yml', '.tcl',
-    '.json', '.out', '.err', '.geojson', '.do'
+    '.json', '.out', '.err', '.geojson', '.do', '.sas'
 ]
 
 SUPPORTED_OBJECT_PREVIEW_EXTS = [

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/publication-advanced-search/publication-advanced-search.component.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/publication-advanced-search/publication-advanced-search.component.js
@@ -43,7 +43,7 @@ class PublicationAdvancedSearchCtrl {
             'Report',
             'REU',
             'Social Sciences',
-            'Softwarem',
+            'Software',
             'Survey',
             'Video',
             'White Paper',

--- a/designsafe/static/scripts/data-depot/components/modals/nees-doi-list.template.html
+++ b/designsafe/static/scripts/data-depot/components/modals/nees-doi-list.template.html
@@ -8,7 +8,7 @@
                 {{ doi.citationString }}
             </div>
             <div>
-                <a href="{{doi.doiURL}}" target="_blank">{{doi.doiUrl}}</a>
+                <a href="{{doi.doiUrl}}" target="_blank">{{doi.doiUrl}}</a>
             </div>
         </li>
     </ul>

--- a/designsafe/static/scripts/projects/components/edit-project/edit-project.component.js
+++ b/designsafe/static/scripts/projects/components/edit-project/edit-project.component.js
@@ -62,7 +62,7 @@ class EditProjectCtrl {
             'Report',
             'REU',
             'Social Sciences',
-            'Softwarem',
+            'Software',
             'Survey',
             'Video',
             'White Paper',


### PR DESCRIPTION
This PR fixes 2 issues that have outstanding tickets associated with them.

Testing instructions:
1. Go to https://designsafe.dev/data/browser/public/nees.public/NEES-2009-0707.groups and click "view all DOIs".
2. Make sure that the DOI links in the modal work correctly..
