### PR TITLE
Task/DES-1936 HazMapper Preview/Link

### DIFF
--- a/designsafe/apps/api/datafiles/operations/agave_operations.py
+++ b/designsafe/apps/api/datafiles/operations/agave_operations.py
@@ -560,7 +560,7 @@ def preview(client, system, path, href, max_uses=3, lifetime=600, *args, **kwarg
     elif file_ext in settings.SUPPORTED_HAZMAPPER_PREVIEW_EXTS:
         file_type = 'hazmapper'
         uuid = os.path.splitext(file_name)[0]
-        url = 'http://localhost:4200/project/{uuid}'.format(uuid=uuid)
+        url = 'https://hazmapper.tacc.utexas.edu/hazmapper/project/{uuid}'.format(uuid=uuid)
     else:
         file_type = 'other'
 

--- a/designsafe/apps/api/datafiles/operations/agave_operations.py
+++ b/designsafe/apps/api/datafiles/operations/agave_operations.py
@@ -560,7 +560,7 @@ def preview(client, system, path, href, max_uses=3, lifetime=600, *args, **kwarg
     elif file_ext in settings.SUPPORTED_HAZMAPPER_PREVIEW_EXTS:
         file_type = 'hazmapper'
         uuid = os.path.splitext(file_name)[0]
-        url = 'https://hazmapper.tacc.utexas.edu/hazmapper/project/{uuid}'.format(uuid=uuid)
+        url = 'https://hazmapper.tacc.utexas.edu/staging/project/{uuid}'.format(uuid=uuid)
     else:
         file_type = 'other'
 

--- a/designsafe/apps/api/datafiles/operations/agave_operations.py
+++ b/designsafe/apps/api/datafiles/operations/agave_operations.py
@@ -557,10 +557,6 @@ def preview(client, system, path, href, max_uses=3, lifetime=600, *args, **kwarg
         file_type = 'ipynb'
         tmp = url.replace('https://', '')
         url = 'https://nbviewer.jupyter.org/urls/{tmp}'.format(tmp=tmp)
-    elif file_ext in settings.SUPPORTED_HAZMAPPER_PREVIEW_EXTS:
-        file_type = 'hazmapper'
-        uuid = os.path.splitext(file_name)[0]
-        url = 'https://hazmapper.tacc.utexas.edu/staging/project/{uuid}'.format(uuid=uuid)
     else:
         file_type = 'other'
 

--- a/designsafe/apps/api/datafiles/operations/agave_operations.py
+++ b/designsafe/apps/api/datafiles/operations/agave_operations.py
@@ -56,7 +56,7 @@ def listing(client, system, path, offset=0, limit=100, *args, **kwargs):
 
 def detail(client, system, path, *args, **kwargs):
     """
-    Retrieve the uuid for a file by parsing the query string in _links.metadata.href 
+    Retrieve the uuid for a file by parsing the query string in _links.metadata.href
     """
     listing = client.files.list(systemId=system, filePath=urllib.parse.quote(path), offset=0, limit=1)
 
@@ -557,6 +557,10 @@ def preview(client, system, path, href, max_uses=3, lifetime=600, *args, **kwarg
         file_type = 'ipynb'
         tmp = url.replace('https://', '')
         url = 'https://nbviewer.jupyter.org/urls/{tmp}'.format(tmp=tmp)
+    elif file_ext in settings.SUPPORTED_HAZMAPPER_PREVIEW_EXTS:
+        file_type = 'hazmapper'
+        uuid = os.path.splitext(file_name)[0]
+        url = 'http://localhost:4200/project/{uuid}'.format(uuid=uuid)
     else:
         file_type = 'other'
 

--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -591,15 +591,11 @@ SUPPORTED_TEXT_PREVIEW_EXTS = [
     '.java', '.js', '.less', '.m', '.make', '.md', '.ml', '.mm', '.msg', '.php',
     '.pl', '.properties', '.py', '.rb', '.sass', '.scala', '.script', '.sh', '.sml',
     '.sql', '.txt', '.vi', '.vim', '.xml', '.xsd', '.xsl', '.yaml', '.yml', '.tcl',
-    '.json', '.out', '.err', '.geojson', '.do', '.sas'
+    '.json', '.out', '.err', '.geojson', '.do', '.sas', '.hazmapper'
 ]
 
 SUPPORTED_OBJECT_PREVIEW_EXTS = [
     '.pdf',
-]
-
-SUPPORTED_HAZMAPPER_PREVIEW_EXTS = [
-    '.hazmapper',
 ]
 
 SUPPORTED_VIDEO_EXTS = [

--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -598,6 +598,10 @@ SUPPORTED_OBJECT_PREVIEW_EXTS = [
     '.pdf',
 ]
 
+SUPPORTED_HAZMAPPER_PREVIEW_EXTS = [
+    '.hazmapper',
+]
+
 SUPPORTED_VIDEO_EXTS = [
     '.webm', '.ogv', '.ogg', '.mp4'
 ]

--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.html
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.html
@@ -2,7 +2,7 @@
     <h3 class="modal-title">File Preview: {{ $ctrl.resolve.file.name }}</h3>
 </div>
 <div class="modal-body">
-    <div>
+    <div ng-if="!$ctrl.isHazmapper()">
         <div ng-if="notInJupyterTree()">
             <div class="alert alert-warning">
                 <p class="lead">Unsupported file path</p>
@@ -13,7 +13,7 @@
             <file-metadata file="$ctrl.resolve.file"></file-metadata>
         </div>
     </div>
-    <div class="table-preview actions text-center">
+    <div ng-if="!$ctrl.isHazmapper()" class="table-preview actions text-center">
 
         <button class="btn btn-sm btn-default" ng-if="$ctrl.tests.rename" ng-click="$ctrl.rename()">
             <i class="fa fa-pencil"></i> Rename
@@ -33,10 +33,6 @@
 
         <button class="btn btn-sm btn-default" ng-show="$ctrl.isJupyter()" ng-click="$ctrl.openInJupyter()">
             <i class="fa fa-file-image-o"></i></i> Open In Jupyter
-        </button>
-
-        <button class="btn btn-sm btn-default" ng-if="$ctrl.isHazmapper()" ng-click="$ctrl.openInHazMapper()">
-            <i class="fa fa-file-image-o"></i> Open in HazMapper
         </button>
     </div>
 
@@ -64,6 +60,9 @@
         </div>
 
         <div ng-if="$ctrl.loading">
+            <div ng-if="$ctrl.isHazmapper()" style="font-size:32px">
+              Opening in HazMapper
+            </div>
             <i class="fa fa-spinner fa-spin" style="font-size:150px;line-height:400px" ng-if="$ctrl.loading" id="loading_ind"></i>
         </div>
 

--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.html
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.html
@@ -35,7 +35,7 @@
             <i class="fa fa-file-image-o"></i></i> Open In Jupyter
         </button>
 
-        <button class="btn btn-sm btn-default" ng-if="$ctrl.fileType === 'hazmapper'" ng-click="$ctrl.openInHazMapper()">
+        <button class="btn btn-sm btn-default" ng-if="$ctrl.isHazmapper()" ng-click="$ctrl.openInHazMapper()">
             <i class="fa fa-file-image-o"></i> Open in HazMapper
         </button>
     </div>
@@ -76,13 +76,14 @@
             <p>{{ $ctrl.mapError.message }}</p>
         </div>
 
-        <div class="embed-responsive embed-responsive-4by3" ng-if="$ctrl.fileType === 'hazmapper'" ng-show="!$ctrl.loading">
+        <div class="embed-responsive embed-responsive-4by3" ng-if="$ctrl.hazmapperHref !== ''" ng-show="!$ctrl.loading">
             <iframe class="embed-responsive-item" ng-src="{{ $ctrl.href }}" id="framepreview" iframe-onload="$ctrl.onLoad()"></iframe>
         </div>
 
-        <div ng-if="$ctrl.fileType === 'text'" ng-show="!$ctrl.loading" >
+        <div ng-if="$ctrl.fileType === 'text' && $ctrl.hazmapperHref === ''" ng-show="!$ctrl.loading" >
             <pre style="height:500px">{{$ctrl.textContent}}</pre>
         </div>
+
         <div class="embed-responsive embed-responsive-4by3" ng-if="$ctrl.fileType==='video'" ng-show="!$ctrl.loading" >
             <video id="videoPlayer" class="embed-responsive-item" ng-src="{{$ctrl.videoHref}}" id="framepreview" controls autoplay>
         </div>

--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.html
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.html
@@ -2,19 +2,16 @@
     <h3 class="modal-title">File Preview: {{ $ctrl.resolve.file.name }}</h3>
 </div>
 <div class="modal-body">
-    <div ng-if="!$ctrl.isHazmapper()">
-        <div ng-if="notInJupyterTree()">
-            <div class="alert alert-warning">
-                <p class="lead">Unsupported file path</p>
-                <p>If you want to open this file from DesignSafe you have to copy it to MyData or to a project.</p>
-            </div>
-        </div>
-        <div class="caption">
-            <file-metadata file="$ctrl.resolve.file"></file-metadata>
+    <div ng-if="notInJupyterTree() && !$ctrl.isHazmapper">
+        <div class="alert alert-warning">
+            <p class="lead">Unsupported file path</p>
+            <p>If you want to open this file from DesignSafe you have to copy it to MyData or to a project.</p>
         </div>
     </div>
+    <div class="caption">
+        <file-metadata file="$ctrl.resolve.file"></file-metadata>
+    </div>
     <div ng-if="!$ctrl.isHazmapper()" class="table-preview actions text-center">
-
         <button class="btn btn-sm btn-default" ng-if="$ctrl.tests.rename" ng-click="$ctrl.rename()">
             <i class="fa fa-pencil"></i> Rename
         </button>
@@ -75,11 +72,7 @@
             <p>{{ $ctrl.mapError.message }}</p>
         </div>
 
-        <div class="embed-responsive embed-responsive-4by3" ng-if="$ctrl.hazmapperHref !== ''" ng-show="!$ctrl.loading">
-            <iframe class="embed-responsive-item" ng-src="{{ $ctrl.href }}" id="framepreview" iframe-onload="$ctrl.onLoad()"></iframe>
-        </div>
-
-        <div ng-if="$ctrl.fileType === 'text' && $ctrl.hazmapperHref === ''" ng-show="!$ctrl.loading" >
+        <div ng-if="$ctrl.fileType === 'text' && !$ctrl.isHazmapper()" ng-show="!$ctrl.loading" >
             <pre style="height:500px">{{$ctrl.textContent}}</pre>
         </div>
 

--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.html
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.html
@@ -31,10 +31,14 @@
             <i class="fa fa-cloud-download"></i> Download
         </button>
 
-            <button class="btn btn-sm btn-default" ng-show="$ctrl.isJupyter()" ng-click="$ctrl.openInJupyter()">
-                <i class="fa fa-file-image-o"></i></i> Open In Jupyter
-            </button>
-    </div> 
+        <button class="btn btn-sm btn-default" ng-show="$ctrl.isJupyter()" ng-click="$ctrl.openInJupyter()">
+            <i class="fa fa-file-image-o"></i></i> Open In Jupyter
+        </button>
+
+        <button class="btn btn-sm btn-default" ng-if="$ctrl.fileType === 'hazmapper'" ng-click="$ctrl.openInHazMapper()">
+            <i class="fa fa-file-image-o"></i> Open in HazMapper
+        </button>
+    </div>
 
     <div class="text-center nbv-preview">
 
@@ -70,6 +74,10 @@
         <div ng-if="$ctrl.mapError.show" class="alert alert-warning">
             <p class="lead">Unable to show a preview</p>
             <p>{{ $ctrl.mapError.message }}</p>
+        </div>
+
+        <div class="embed-responsive embed-responsive-4by3" ng-if="$ctrl.fileType === 'hazmapper'" ng-show="!$ctrl.loading">
+            <iframe class="embed-responsive-item" ng-src="{{ $ctrl.href }}" id="framepreview" iframe-onload="$ctrl.onLoad()"></iframe>
         </div>
 
         <div ng-if="$ctrl.fileType === 'text'" ng-show="!$ctrl.loading" >

--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
@@ -47,15 +47,14 @@ class DataBrowserServicePreviewCtrl {
                         e.target.response.text().then((text) => {
                             this.textContent = text;
                             const extension = this.resolve.file.name.split('.').pop();
+
                             if (extension.includes('json')) {
                                 const body = JSON.parse(text);
                                 // Pretty Print JSON
                                 this.textContent = JSON.stringify(body, null, 4);
                                 const isGeoJson = validateGeoJson(body);
                                 if (isGeoJson) this.renderGeoJson(body);
-                            }
-
-                            if (extension.includes('hazmapper')) {
+                            } else if (extension.endsWith('hazmapper')) {
                                 const body = JSON.parse(text);
                                 let uuid = body['uuid'];
                                 this.hazmapperHref = `https://hazmapper.tacc.utexas.edu/staging/project/${uuid}`

--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
@@ -145,10 +145,6 @@ class DataBrowserServicePreviewCtrl {
         return fileExtension === 'hazmapper';
     }
 
-    openInHazMapper() {
-        window.open(this.hazmapperHref);
-    }
-
     renderGeoJson(data) {
         const mapWrapper = document.getElementById('preview_map_wrapper');
         mapWrapper.style.display = 'block';

--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
@@ -57,8 +57,9 @@ class DataBrowserServicePreviewCtrl {
                             } else if (extension.endsWith('hazmapper')) {
                                 const body = JSON.parse(text);
                                 let uuid = body['uuid'];
-                                this.hazmapperHref = `https://hazmapper.tacc.utexas.edu/staging/project/${uuid}`
-                                this.href = this.$sce.trustAs('resourceUrl', this.hazmapperHref);
+                                this.hazmapperHref = `http://localhost:4200/project/${uuid}`
+                                window.open(this.hazmapperHref);
+                                this.close();
                             }
 
                             this.loading = false;

--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
@@ -57,7 +57,7 @@ class DataBrowserServicePreviewCtrl {
                             } else if (extension.endsWith('hazmapper')) {
                                 const body = JSON.parse(text);
                                 let uuid = body['uuid'];
-                                this.hazmapperHref = `http://localhost:4200/project/${uuid}`
+                                this.hazmapperHref = `https://hazmapper.tacc.utexas.edu/hazmapper/project/${uuid}`
                                 window.open(this.hazmapperHref);
                                 this.close();
                             }

--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
@@ -141,10 +141,6 @@ class DataBrowserServicePreviewCtrl {
     }
 
     isHazmapper() {
-        if (this.resolve.api !== 'agave') {
-            return false;
-        }
-
         const fileExtension = this.resolve.file.name.split('.').pop();
         return fileExtension === 'hazmapper';
     }

--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
@@ -72,7 +72,7 @@ class DataBrowserServicePreviewCtrl {
                 }
                 if (this.fileType === 'hazmapper') {
                     const uuid = this.resolve.file.name.split('.')[0];
-                    this.hazmapperHref = 'https://hazmapper.tacc.utexas.edu/hazmapper/project/' + uuid;
+                    this.hazmapperHref = 'https://hazmapper.tacc.utexas.edu/staging/project/{uuid}'.format(uuid=uuid)
                     this.loading = false;
                 }
             },

--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
@@ -21,6 +21,7 @@ class DataBrowserServicePreviewCtrl {
         //TODO DES-1689: working metadata table and operation buttons
         this.textContent = '';
         this.videoHref = '';
+        this.hazmapperHref = '';
         this.loading = true;
         this.error = false;
 
@@ -69,6 +70,11 @@ class DataBrowserServicePreviewCtrl {
                     };
                     oReq.send();
                 }
+                if (this.fileType === 'hazmapper') {
+                    const uuid = this.resolve.file.name.split('.')[0];
+                    this.hazmapperHref = 'http://localhost:4200/project/' + uuid;
+                    this.loading = false;
+                }
             },
             // eslint-disable-next-line
             (err) => {
@@ -114,7 +120,7 @@ class DataBrowserServicePreviewCtrl {
     isJupyter() {
         if (this.resolve.api !== 'agave') {
             return false;
-        } 
+        }
         const fileExtension = this.resolve.file.name.split('.').pop();
         return fileExtension === 'ipynb';
 
@@ -131,10 +137,14 @@ class DataBrowserServicePreviewCtrl {
         window.open(jupyterPath);
     }
 
+    openInHazMapper() {
+        window.open(this.hazmapperHref);
+    }
+
     renderGeoJson(data) {
         const mapWrapper = document.getElementById('preview_map_wrapper');
         mapWrapper.style.display = 'block';
-        
+
         this.mapElement = document.createElement('div');
         this.mapElement.setAttribute('id', 'preview_map');
         this.mapElement.style.height = '500px';

--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
@@ -54,6 +54,14 @@ class DataBrowserServicePreviewCtrl {
                                 const isGeoJson = validateGeoJson(body);
                                 if (isGeoJson) this.renderGeoJson(body);
                             }
+
+                            if (extension.includes('hazmapper')) {
+                                const body = JSON.parse(text);
+                                let uuid = body['uuid'];
+                                this.hazmapperHref = `https://hazmapper.tacc.utexas.edu/staging/project/${uuid}`
+                                this.href = this.$sce.trustAs('resourceUrl', this.hazmapperHref);
+                            }
+
                             this.loading = false;
                             this.$scope.$apply();
                         });
@@ -69,11 +77,6 @@ class DataBrowserServicePreviewCtrl {
                         this.$scope.$apply();
                     };
                     oReq.send();
-                }
-                if (this.fileType === 'hazmapper') {
-                    const uuid = this.resolve.file.name.split('.')[0];
-                    this.hazmapperHref = 'https://hazmapper.tacc.utexas.edu/staging/project/{uuid}'.format(uuid=uuid)
-                    this.loading = false;
                 }
             },
             // eslint-disable-next-line
@@ -135,6 +138,15 @@ class DataBrowserServicePreviewCtrl {
         };
         const jupyterPath = this.FileOperationService.openInJupyter(params);
         window.open(jupyterPath);
+    }
+
+    isHazmapper() {
+        if (this.resolve.api !== 'agave') {
+            return false;
+        }
+
+        const fileExtension = this.resolve.file.name.split('.').pop();
+        return fileExtension === 'hazmapper';
     }
 
     openInHazMapper() {

--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
@@ -72,7 +72,7 @@ class DataBrowserServicePreviewCtrl {
                 }
                 if (this.fileType === 'hazmapper') {
                     const uuid = this.resolve.file.name.split('.')[0];
-                    this.hazmapperHref = 'http://localhost:4200/project/' + uuid;
+                    this.hazmapperHref = 'https://hazmapper.tacc.utexas.edu/hazmapper/project/' + uuid;
                     this.loading = false;
                 }
             },

--- a/designsafe/static/scripts/ng-designsafe/services/file-operation-service.js
+++ b/designsafe/static/scripts/ng-designsafe/services/file-operation-service.js
@@ -50,25 +50,41 @@ export class FileOperationService {
     getTests(files) {
         const externalDataStates = ['boxData', 'dropboxData', 'googledriveData'];
         const agaveDataStates = ['myData', 'projects.view', 'projects.curation'];
+        let isHazmapper = files.length > 0
+            ? files.some(e => e.name.endsWith('hazmapper'))
+            : false;
         const tests = {
-            copy: this.Django.context.authenticated && files.length > 0,
+            copy: this.Django.context.authenticated && !isHazmapper && files.length > 0,
             move:
                 this.Django.context.authenticated &&
                 files.length > 0 &&
+                !isHazmapper &&
                 agaveDataStates.includes(this.$state.current.name),
             rename:
                 this.Django.context.authenticated &&
                 files.length === 1 &&
+                !isHazmapper &&
                 [...agaveDataStates].includes(this.$state.current.name),
-            upload: this.Django.context.authenticated && agaveDataStates.includes(this.$state.current.name),
-            preview: files.length === 1 && files[0].format !== 'folder',
-            previewImages: files.length > 0 && !externalDataStates.includes(this.$state.current.name),
+            upload:
+                this.Django.context.authenticated &&
+                !isHazmapper &&
+                agaveDataStates.includes(this.$state.current.name),
+            preview:
+                files.length === 1 &&
+                !isHazmapper &&
+                files[0].format !== 'folder',
+            previewImages:
+                files.length > 0 &&
+                !isHazmapper &&
+                !externalDataStates.includes(this.$state.current.name),
             download:
                 files.length > 0 &&
+                !isHazmapper &&
                 !files.some((f) => f.format === 'folder') &&
                 !externalDataStates.includes(this.$state.current.name),
             trash:
                 this.Django.context.authenticated &&
+                !isHazmapper &&
                 files.length > 0 &&
                 agaveDataStates.includes(this.$state.current.name),
         };


### PR DESCRIPTION
## Overview: ##
Adds preview and link (to HazMapper) for `<map_uuid>.hazmapper` files.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1936](https://jira.tacc.utexas.edu/browse/DES-1936)

## Summary of Changes: ##
Added to `agave_operations.py` for processing `.hazmapper` files.
Added iframe preview for `.hazmapper` files and a button to open in HazMapper. 

## Testing Steps: ##
1. Run HazMapper/Geoapi locally (have to change default port 8000)
2. Create a file with a project's uuid + .hazmapper
3. For now, you have to change the hazmapperHref in `data-browser-service-preview.component.js` and `agave_operations.py` to `'http://localhost:4200/project/' + uuid;` rather than the production server.
4. Confirm link and iframe loads.

## UI Photos:
![Data Depot | DesignSafe-CI — Mozilla Firefox_012](https://user-images.githubusercontent.com/9425579/115305076-6a0f8600-a12b-11eb-9fe8-f130c64f573b.png)

## Notes: ##
Tested against HazMapper's master branch (the project routes aren't in production yet, they will be there really soon). 
Also, we aren't sure how to handle public/private maps yet. The link points to the private project for now.