### PR TITLE
Task/DES-1935 - Fix text position issues for data depot add button and workspace file links

### DIFF
--- a/designsafe/static/scripts/workspace/components/workspace-data-browser-file-listing/workspace-data-browser-file-listing.template.html
+++ b/designsafe/static/scripts/workspace/components/workspace-data-browser-file-listing/workspace-data-browser-file-listing.template.html
@@ -20,7 +20,7 @@
                                     ng-click="$ctrl.chooseFile(file)">Select</button>
                         <a
                             ng-click="$ctrl.browse($event, file)"
-                            class="btn btn-xs btn-link"
+                            class="btn-xs btn-link"
                             ds-data-draggable
                             data-ds-data="agave://{{file.system}}/{{file.path}}"
                         >

--- a/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css
+++ b/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css
@@ -3275,7 +3275,7 @@ select[multiple].input-lg {
   display: inline-block;
   margin-bottom: 0;
   font-weight: normal;
-  text-align: left;
+  text-align: center;
   vertical-align: middle;
   -ms-touch-action: manipulation;
       touch-action: manipulation;


### PR DESCRIPTION
## Overview: ##
This should fix the issue with the left align "Add" button in the Data Depot while also keeping the left alignment of the file links in the workspace listing.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1935](https://jira.tacc.utexas.edu/browse/DES-1935)

## Testing Steps: ##
1. Check the Data Depot that the blue Add button on the left has center aligned Text
2. File links in the Workspace should still be left aligned

