### PR TITLE
Task/DES-1969 - Disable some features while a project is publishing

### DIFF
--- a/designsafe/apps/api/projects/views.py
+++ b/designsafe/apps/api/projects/views.py
@@ -136,24 +136,6 @@ class PublicationView(BaseApiView):
         }, status=200)
 
 class AmendPublicationView(BaseApiView):
-    # not using GET for anything...
-    # @profile_fn
-    # def get(self, request, project_id, revision):
-    #     """
-    #     Get a version of a publication by it's project ID and revision number
-    #     """
-    #     pub = BaseESPublication(project_id=project_id, revision=revision)
-    #     latest_revision = IndexedPublication.max_revision(project_id=project_id)
-    #     if pub is not None and hasattr(pub, 'project'):
-    #         return JsonResponse({
-    #             'publication': pub.to_dict(),
-    #             'latestVersion': latest_revision,
-    #             })
-    #     else:
-    #         return JsonResponse({'status': 404,
-    #                              'message': 'Not found'},
-    #                             status=404)
-
     @method_decorator(agave_jwt_login)
     @method_decorator(login_required)
     def post(self, request, **kwargs):

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-amend/pipeline-amend.template.html
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-amend/pipeline-amend.template.html
@@ -1,5 +1,7 @@
 <div class="pipeline-nav">
-    <a ng-click="$ctrl.goStart()">
+    <a ng-class="{'btn disabled': $ctrl.ui.loading || $ctrl.ui.submitted}"
+       ng-click="$ctrl.goStart()"
+    >
         <i class="fa fa-arrow-left"></i> Back
     </a>
     <button class="btn btn-small btn-add"

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-start/pipeline-start.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-start/pipeline-start.component.js
@@ -17,6 +17,7 @@ class PipelineStartCtrl {
             loading: true,
             showAmendVersion: false,
             isPublished: false,
+            isProcessing: false,
             directSelect: '',
             directPreview: ''
         };
@@ -31,6 +32,9 @@ class PipelineStartCtrl {
                 );
                 if (this.publication.status) {
                     this.ui.isPublished = true;
+                    if (this.publication.status != 'published') {
+                        this.ui.isProcessing = true;
+                    }
                 }
                 this.ui.loading = false;
             }, (error) => {

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-start/pipeline-start.template.html
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-start/pipeline-start.template.html
@@ -13,6 +13,21 @@
             </h3>
         </div>
     </div>
+    <!-- Notifications -->
+    <div class="pipeline-notification">
+        <div class="alert alert-warning" ng-if="$ctrl.ui.isProcessing">
+            <span>
+                <i class="fa fa-exclamation-triangle"></i>
+            </span>
+            <span>
+                Your publication request is processing. Please allow 24 hours for this process to complete.
+                If your publication does not appear in the "Published" section of the Data Depot or if you
+                are still seeing this message after 24 hours, please
+                <a href="/help/new-ticket/?category=DATA_CURATION_PUBLICATION&subject=Publication+submission+has+not+resolved:+{{$ctrl.project.value.projectId}}"
+                target="_blank">submit a ticket</a>.
+            </span>
+        </div>
+    </div>
     <div ng-if="!$ctrl.ui.loading">
         <div class="pipeline-section">
             <h3>Publishing</h3>
@@ -43,7 +58,7 @@
                 </ul>
                 <button class="btn btn-small btn-add"
                         ng-click="$ctrl.goAmend()"
-                        ng-disabled="!$ctrl.ui.isPublished"
+                        ng-disabled="!$ctrl.ui.isPublished || $ctrl.ui.isProcessing"
                 >
                     Amend
                 </button>
@@ -59,7 +74,7 @@
                 </ul>
                 <button class="btn btn-small btn-add"
                         ng-click="$ctrl.goVersion()"
-                        ng-disabled="!$ctrl.ui.isPublished"
+                        ng-disabled="!$ctrl.ui.isPublished || $ctrl.ui.isProcessing"
                 >
                     Version
                 </button>

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-version/pipeline-version-changes.template.html
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-version/pipeline-version-changes.template.html
@@ -1,5 +1,7 @@
 <div class="pipeline-nav">
-    <a ng-click="$ctrl.goVersionProject()">
+    <a ng-class="{'btn disabled': $ctrl.ui.loading || $ctrl.ui.submitted}"
+       ng-click="$ctrl.goVersionProject()"
+    >
         <i class="fa fa-arrow-left"></i> Back
     </a>
     <button class="btn btn-small btn-add"

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.html
@@ -88,7 +88,6 @@
                     <strong>{{ $ctrl.browser.publication.project.value.dois[0] }}</strong>
                 </td>
             </tr>
-            <!-- Commenting out until after group feature review -->
             <tr class="prj-row" ng-if="$ctrl.readOnly && $ctrl.browser.publication.latestRevision">
                 <td>
                     <span>Version</span>

--- a/designsafe/static/scripts/data-depot/components/published/published-view.component.js
+++ b/designsafe/static/scripts/data-depot/components/published/published-view.component.js
@@ -227,9 +227,13 @@ class PublishedViewCtrl {
     }
 
     prepVersions(publication) {
+        // returns a list of publication versions
         if (publication.latestRevision) {
             let vers = ['Original'];
-            let max = publication.latestRevision.revision;
+            let max = (publication.latestRevision.status === 'published'
+                ? publication.latestRevision.revision
+                : publication.latestRevision.revision - 1
+            )
             if (typeof max == 'number') {
                 for (let i = 2; i <= max; i++) {
                     vers.push(i);

--- a/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css
+++ b/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css
@@ -2794,6 +2794,10 @@ input[type="search"] {
   flex-direction: column;
   align-items: center;
 }
+.pipeline-notification.div {
+  display: flex;
+  align-items: center;
+}
 .pipeline-header {
   text-align: center;
   margin-bottom: 40px;


### PR DESCRIPTION
## Overview: ##
There are several areas in the portal that need to disabled while projects are in the process of being published. This can be picked up by checking the status of the publication object.

Disable submit buttons and force users out of the publication/amend/version pipelines after submitting
Prevent users from entering the pipeline if status is "publishing"
Prevent users from selecting the latest version of a publication if that version's status is "publishing"


## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1969](https://jira.tacc.utexas.edu/browse/DES-1969)

