### PR TITLE
Task/DES-1976 - Fix missing file tags for versioned publications

### DIFF
--- a/designsafe/apps/projects/managers/publication.py
+++ b/designsafe/apps/projects/managers/publication.py
@@ -495,16 +495,11 @@ def fix_file_tags(project_id, revision=None):
                     fix_tags_no_path(entity)
         else:
             if 'value' in pub_dict[entname] and 'fileTags' in pub_dict[entname]['value'] and check_complete_tags(pub_dict[entname]['value']['fileTags']):
-                logger.info('FIRST IF')
                 fix_tags_path(pub_dict[entname])
             elif 'value' in pub_dict[entname] and 'fileTags' in pub_dict[entname]['value']:
                 fix_tags_no_path(pub_dict[entname])
 
-    logger.info('PubDICT ======> %s', pub_dict)
-    logger.info('EntityCHECK ======> %s', entities_to_check)
-
     pub.update(using=es_client, **pub_dict)
-    logger.info('PUB ======> %s', pub)
     IndexedPublication._index.refresh(using=es_client)
 
 

--- a/designsafe/apps/projects/managers/publication.py
+++ b/designsafe/apps/projects/managers/publication.py
@@ -447,10 +447,11 @@ def fix_file_tags(project_id, revision=None):
     def fix_tags_path(entity):
         for tag in entity['value']['fileTags']:
             try:
+                pub_base = "{}v{}".format(project_id, revision) if revision else project_id
                 pub_file = BaseFileResource.listing(
                     service_account(),
                     system="designsafe.storage.published",
-                    path="{}{}".format(project_id, tag['path'])
+                    path="{}{}".format(pub_base, tag['path'])
                 )
                 tag['fileUuid'] = pub_file.uuid
             except Exception as err:
@@ -462,7 +463,8 @@ def fix_file_tags(project_id, revision=None):
             proj_other = BaseFileResource.listing(service_account(), system="project-{}".format(entity['uuid']), path="")
             for child in proj_other.children:
                 try:
-                    pub_file = BaseFileResource.listing(service_account(), system="designsafe.storage.published", path="{}{}".format(project_id, child.path))
+                    pub_base = "{}v{}".format(project_id, revision) if revision else project_id
+                    pub_file = BaseFileResource.listing(service_account(), system="designsafe.storage.published", path="{}{}".format(pub_base, child.path))
                     proj_file = BaseFileResource.listing(service_account(), system="project-{}".format(entity['uuid']), path=child.path)
                     for tag in entity['value']['fileTags']:
                         if tag['fileUuid'] == proj_file.uuid:
@@ -493,11 +495,16 @@ def fix_file_tags(project_id, revision=None):
                     fix_tags_no_path(entity)
         else:
             if 'value' in pub_dict[entname] and 'fileTags' in pub_dict[entname]['value'] and check_complete_tags(pub_dict[entname]['value']['fileTags']):
+                logger.info('FIRST IF')
                 fix_tags_path(pub_dict[entname])
             elif 'value' in pub_dict[entname] and 'fileTags' in pub_dict[entname]['value']:
                 fix_tags_no_path(pub_dict[entname])
 
+    logger.info('PubDICT ======> %s', pub_dict)
+    logger.info('EntityCHECK ======> %s', entities_to_check)
+
     pub.update(using=es_client, **pub_dict)
+    logger.info('PUB ======> %s', pub)
     IndexedPublication._index.refresh(using=es_client)
 
 

--- a/designsafe/static/scripts/projects/components/file-categories/file-categories.component.js
+++ b/designsafe/static/scripts/projects/components/file-categories/file-categories.component.js
@@ -287,7 +287,7 @@ class FileCategoriesCtrl {
 
         if (this.scheme === 'public') {
             return tags.filter((tag) => {
-                return tag.path == this.file.path.replace(/^\/*PRJ-[0-9]{4}/g, '');
+                return tag.path == this.file.path.replace(/(\/*PRJ-[0-9]+)?(v([0-9]+))?/g, '');
             });
         }
    
@@ -302,7 +302,6 @@ export const FileCategoriesComponent = {
     controller: FileCategoriesCtrl,
     controllerAs: '$ctrl',
     bindings: {
-        //roject: '=',
         file: '=',
         showTags: '=',
         editTags: '=',


### PR DESCRIPTION
## Overview: ##
Subsequent versions of a publication would not correctly update the file uuids for the file tags in a project.
We needed to adjust a regex pattern in the file listing for publications as well as update a base path being used when attempting to correct the file uuid being updated in the publication/versioning process.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1976](https://jira.tacc.utexas.edu/browse/DES-1976)

## Testing Steps: ##
1. You'll have to copy your project files into a versioned directory you want to test on corral. For example: you would copy the files (which have tags in your project to /published/PRJ-1234v2)
2. When those files are copied shell into the django container running locally and run the following task 
`from designsafe.apps.api import tasks` 
`tasks.swap_file_tag_uuids('PRJ-1234', revision=2)`
3. Check your publication to make sure the file tags appear (in this case v2 of your publication)
