### PR TITLE
bug/DES-2018: Fix infinite scroll in publication filenav.

### DIFF
--- a/designsafe/static/scripts/data-depot/components/published/published-view.component.js
+++ b/designsafe/static/scripts/data-depot/components/published/published-view.component.js
@@ -66,7 +66,7 @@ class PublishedViewCtrl {
                 system: 'designsafe.storage.published',
                 path: this.$stateParams.filePath,
                 query_string: this.$stateParams.query_string,
-            }).then(_ => this.getProjectListings());
+            });
         }
         else {
             this.getProjectListings();


### PR DESCRIPTION
## Overview: ##
Infinite scroll was broken in listings inside of a publication due to an unnecessary abstract listing that was being performed. This PR removes the call to do that listing.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2018](https://jira.tacc.utexas.edu/browse/DES-2018)

## Summary of Changes: ##

## Testing Steps: ##
1. Try infinite scroll in a directory listing inside a publication, e.g. https://designsafe.dev/data/browser/public/designsafe.storage.published/PRJ-2421/Building%20Modelling

