### PR TITLE
Task/DES-2015 - Fix issues with failing type other publications

### DIFF
--- a/designsafe/apps/projects/managers/datacite.py
+++ b/designsafe/apps/projects/managers/datacite.py
@@ -102,7 +102,7 @@ def create_or_update_doi(attributes=None, doi=None):
         http_verb = requests.post
         url = DOIS_URL
 
-    # Remove non kernel-4 schema fields. We cannot update these field.
+    # Remove non kernel-4 schema fields. We cannot update these fields.
     # These fields are part of the metadata handled by DataCite.
     # For more info:
     # https://schema.datacite.org/meta/kernel-4.3/example/datacite-example-full-v4.xml

--- a/designsafe/apps/projects/models/agave/base.py
+++ b/designsafe/apps/projects/models/agave/base.py
@@ -341,14 +341,6 @@ class Project(MetadataModel):
         attributes['subjects'] = [
             {'subject': keyword} for keyword in self.keywords.split(',')
         ]
-        attributes['dates'] = [{
-            'dateType': 'Accepted',
-            'date': '{}-{}-{}'.format(
-                utc_now.year,
-                utc_now.month,
-                utc_now.day
-            )
-        }]
         attributes['language'] = 'English'
         attributes['identifiers'] = [
             {
@@ -365,8 +357,8 @@ class Project(MetadataModel):
         attributes['fundingReferences'] = []
         for award in awards:
             attributes['fundingReferences'].append({
-                'fundername': award['name'],
-                'awardnumber': award['number']
+                'funderName': award['name'],
+                'awardNumber': award['number']
                 })
 
         attributes['relatedIdentifiers'] = []


### PR DESCRIPTION
## Overview: ##
For a while now, type Other publications have been failing to complete the publication process. Their DOI status failed to update to "published" on DataCite due to a failing API post, and this led to some other issues as a result.

This change fixes a couple typos in the JSON attributes passed to DataCite

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2015](https://jira.tacc.utexas.edu/browse/DES-2015)

## Summary of Changes: ##
Fixed a couple typos related to the award information and removed an unused date field.

