### PR TITLE
bug/DES-2069: Support weblink in Box listings

### DIFF
--- a/designsafe/apps/api/datafiles/operations/box_operations.py
+++ b/designsafe/apps/api/datafiles/operations/box_operations.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 def listing(client, system, path, offset=0, limit=100, *args, **kwargs):
     offset = int(offset)
-    limit = int(limit)  
+    limit = int(limit)
 
     if not path:
         folder = client.root_folder()
@@ -15,6 +15,7 @@ def listing(client, system, path, offset=0, limit=100, *args, **kwargs):
         folder = client.folder(folder_id=path)
 
     items = folder.get_items(limit=limit, offset=offset, fields=['name', 'size', 'type', 'modified_at', 'id'])
+
     mapped_items = map(lambda f: {
         'system': None,
         'type': 'dir' if f.type == 'folder' else 'file',
@@ -22,7 +23,7 @@ def listing(client, system, path, offset=0, limit=100, *args, **kwargs):
         'mimeType': f.type,
         'path': f.id,
         'name': f.name,
-        'length': f.size,
+        'length': f.size if f.type != 'web_link' else '',
         'lastModified': f.modified_at,
 
     }, items)
@@ -86,4 +87,4 @@ def mkdir(client, system, path, dirname):
     return {'name': dirname, 'path': newdir.id}
 
 
-    
+


### PR DESCRIPTION
## Overview: ##
The Weblink (Bookmarks) document type in Box does not have a `size` attribute, so we'll ignore that for these file types.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2069](https://jira.tacc.utexas.edu/browse/DES-2069)

## Testing Steps: ##
1. Go to https://designsafe.dev/data/browser/box/ and ensure the listing doesn't fail
