### PR TITLE
Task/DES-2076 - Fix Bug with Archive Download Link

### DIFF
--- a/designsafe/static/scripts/projects/components/publication-download/publication-download.component.js
+++ b/designsafe/static/scripts/projects/components/publication-download/publication-download.component.js
@@ -17,7 +17,7 @@ class PublicationDownloadModalCtrl {
         this.prjId = this.publication.project.value.projectId;
         
         const archive_path = (this.publication.revision
-            ? `/archives/${this.prjId}r${this.publication.revision}_archive.zip`
+            ? `/archives/${this.prjId}v${this.publication.revision}_archive.zip`
             : `/archives/${this.prjId}_archive.zip`
         )
         const archive_system = 'designsafe.storage.published'


### PR DESCRIPTION
## Overview: ##
Utterly massive PR to fix Publication Archive downloads for versioned publications

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2076](https://jira.tacc.utexas.edu/browse/DES-2076)

## Summary of Changes: ##
swapped the old `r2(3,4,5...)` iterator to `v2(3,4,5...)` for the download link.

## Testing Steps: ##
1.  Try to download a published archive of a versioned publication

