### PR TITLE
task/DES-1942: Add Other and Check Sheet options to advanced search dropdown

### DIFF
--- a/designsafe/apps/api/publications/search_utils.py
+++ b/designsafe/apps/api/publications/search_utils.py
@@ -51,6 +51,29 @@ def nh_event_query(nh_event):
 
 
 def other_type_query(data_type):
+    data_types = [
+            'Check Sheet',
+            'Code',
+            'Database',
+            'Dataset',
+            'Image',
+            'Jupyter Notebook',
+            'Learning Object',
+            'Model',
+            'Paper',
+            'Proceeding',
+            'Poster',
+            'Presentation',
+            'Report',
+            'REU',
+            'Social Sciences',
+            'Software',
+            'Survey',
+            'Video',
+            'White Paper',
+    ]
+    if data_type == 'Other':
+        return ~Q({'terms': {'project.value.dataType.keyword': data_types}}) # | ~Q({'exists', {'field': 'project.value.dataType.keyword'}})
     return Q({'term': {'project.value.dataType.keyword': data_type}})
 
 

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/publication-advanced-search/publication-advanced-search.component.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/publication-advanced-search/publication-advanced-search.component.js
@@ -28,7 +28,7 @@ class PublicationAdvancedSearchCtrl {
         this.rapidEventTypes = [{ name: '', label: 'All Types' }, ...this.rapidEventTypes];
 
         this.otherTypes = [
-            'Custom',
+            'Check Sheet',
             'Code',
             'Database',
             'Dataset',
@@ -47,6 +47,7 @@ class PublicationAdvancedSearchCtrl {
             'Survey',
             'Video',
             'White Paper',
+            'Other',
         ].map((type) => ({ name: type, label: type }));
         this.otherTypes = [{ name: '', label: 'All Types' }, ...this.otherTypes];
 


### PR DESCRIPTION
## Overview: ##
- Change the dropdown filter "Custom" to "Other"
- This Other Data Type (formerly Custom) filter needs to display all Data Types that users wrote in themselves
- Add "Check Sheet" as a predefined piece of metadata to the list of Data Types

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1942](https://jira.tacc.utexas.edu/browse/DES-1942)

## Summary of Changes: ##

## Testing Steps: ##
1. In Advanced Search, check "other" and select "check sheet" and "other" in the dropdown. "check sheet" should return checksheet projects and "other" should return a bunch of projects with "other"/"none" or custom types.

## UI Photos:

## Notes: ##
