### PR TITLE
Task/des 1949:  Fix overscroll behavior

### DIFF
--- a/designsafe/static/styles/ng-designsafe.css
+++ b/designsafe/static/styles/ng-designsafe.css
@@ -354,6 +354,7 @@
 .ds-table-display-wrapper {
     height:500px;
     overflow:scroll;
+    overscroll-behavior-block: contain;
 }
 
 .ds-table-display-wrapper table tfoot tr td {


### PR DESCRIPTION
## Overview: ##
"While scrolling through files in the Data Depot, if a user reaches the end of what is loaded before infinite scroll loads more files, the page will scroll down to the footer and move the toolbar out of view. The user then has to move their mouse out of the files and scroll the page back up to view the toolbar and other navigation."

This PR adds a CSS attribute that Wesley uncovered that prevents the page from scrolling when the user reaches the bottom.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1949](https://jira.tacc.utexas.edu/browse/DES-1949)

## Summary of Changes: ##

## Testing Steps: ##
1. Scroll to the bottom of a file/publication listing and confirm that the surrounding page doesn't scroll further upon reaching the end.

## UI Photos:

## Notes: ##
