### PR TITLE
Task/DES-2067 - Archived Data Cap

### DIFF
--- a/designsafe/static/scripts/projects/components/publication-download/publication-download.component.js
+++ b/designsafe/static/scripts/projects/components/publication-download/publication-download.component.js
@@ -2,11 +2,12 @@ import PublicationDownloadModalTemplate from './publication-download.template.ht
 
 class PublicationDownloadModalCtrl {
 
-    constructor(FileListingService, FileOperationService, $http) {
+    constructor(FileListingService, FileOperationService, $http, $q) {
         'ngInject';
         this.FileListingService = FileListingService;
         this.FileOperationService = FileOperationService;
         this.$http = $http;
+        this.$q = $q;
     }
 
     $onInit() {
@@ -16,32 +17,51 @@ class PublicationDownloadModalCtrl {
         this.publication = this.resolve.publication;
         this.prjId = this.publication.project.value.projectId;
         
-        const archive_path = (this.publication.revision
+        const archiveSystem = 'designsafe.storage.published'
+        const archivePath = (this.publication.revision
             ? `/archives/${this.prjId}v${this.publication.revision}_archive.zip`
             : `/archives/${this.prjId}_archive.zip`
         )
-        const archive_system = 'designsafe.storage.published'
-
-        this.FileListingService.getDetail({
-            api: 'agave',
-            scheme: 'public',
-            system: archive_system,
-            path: archive_path,
-        })
-            .then((resp) => {
-                this.arcData = resp.data;
-            })
-            .finally(() => {
-                if (!this.arcData) {
-                    this.error = true;
-                }
-                this.loaded = true;
+        const archiveMetaPath = (this.publication.revision
+            ? `/archives/${this.prjId}v${this.publication.revision}_metadata.json`
+            : `/archives/${this.prjId}_metadata.json`
+        )
+        const archiveRequest = this.FileListingService.getDetail({
+                api: 'agave',
+                scheme: 'public',
+                system: archiveSystem,
+                path: archivePath,
+            }).then((resp) => {
+                return resp.data;
+            }).catch((e) => {
+                return null;
             });
+        const archiveMetaRequest = this.FileListingService.getDetail({
+                api: 'agave',
+                scheme: 'public',
+                system: archiveSystem,
+                path: archiveMetaPath,
+            }).then((resp) => {
+                return resp.data;
+            }).catch((e) => {
+                return null;
+            });
+        this.$q.all([
+            archiveRequest,
+            archiveMetaRequest
+        ]).then(([archive, metadata]) => {
+            this.archive = archive;
+            this.metadata = metadata;
+            if (!this.archive && !this.metadata) {
+                this.error = true;
+            }
+            this.loaded = true;
+        });
     }
 
     download() {
         this.retrievingPostit = true;
-        const files = [this.arcData]
+        const files = [this.archive]
         this.FileOperationService.download({ api: 'agave', scheme: 'public', files }).then(
             (_) => (this.retrievingPostit = false)
         );

--- a/designsafe/static/scripts/projects/components/publication-download/publication-download.component.js
+++ b/designsafe/static/scripts/projects/components/publication-download/publication-download.component.js
@@ -59,9 +59,9 @@ class PublicationDownloadModalCtrl {
         });
     }
 
-    download() {
+    download(fileObj) {
         this.retrievingPostit = true;
-        const files = [this.archive]
+        const files = [fileObj]
         this.FileOperationService.download({ api: 'agave', scheme: 'public', files }).then(
             (_) => (this.retrievingPostit = false)
         );

--- a/designsafe/static/scripts/projects/components/publication-download/publication-download.template.html
+++ b/designsafe/static/scripts/projects/components/publication-download/publication-download.template.html
@@ -12,10 +12,21 @@
     </h3>
 </div>
 <div class="modal-body" ng-if="$ctrl.loaded">
-    <div ng-if="!$ctrl.error" style="margin-top: 5px;">
+    <div ng-if="!$ctrl.error && $ctrl.archive" style="margin-top: 5px;">
         <p>
-            This download is a ZIP file of the complete project dataset. The size of the ZIP file is <strong>{{$ctrl.arcData.length|bytes}}</strong>.
+            This download is a ZIP file of the complete project dataset. The size of the ZIP file is <strong>{{$ctrl.archive.length|bytes}}</strong>.
             <!-- A JSON file is included that contains all of the metadata. -->
+        </p>
+    </div>
+    <div class="alert alert-warning" ng-if="!$ctrl.error && !$ctrl.archive" style="margin-top: 5px;">
+        <p>
+            This dataset is too large to download through the DesignSafe portal. Please reference our
+            <a href="/rw/user-guides/globus-data-transfer-guide/"  target="_blank">Globus Data Transfer Guide</a>
+            or
+            <a href="/help/new-ticket/?category=DATA_CURATION_PUBLICATION&subject=Large+Publication+archive+request:+{{$ctrl.prjId}}">
+                submit a ticket
+            </a>
+            if you would like to download the data from this publication.
         </p>
     </div>
     <div class="alert alert-danger" ng-if="$ctrl.error">
@@ -112,7 +123,7 @@
         <a href="/rw/user-guides/curating-publishing-projects/policies/publication/" target="_blank">Data Usage Agreement</a>
     </p>
     <br>
-    <div class="text-right" ng-if="!$ctrl.error">
+    <div class="text-right" ng-if="!$ctrl.error || !$ctrl.archive">
         <button class="btn btn-add" ng-click="$ctrl.download()" ng-disabled="!$ctrl.loaded || $ctrl.retrievingPostit">
             <div class="btn-container" ng-if="!$ctrl.retrievingPostit">
                 <span class="curation-download"></span>

--- a/designsafe/static/scripts/projects/components/publication-download/publication-download.template.html
+++ b/designsafe/static/scripts/projects/components/publication-download/publication-download.template.html
@@ -123,12 +123,24 @@
         <a href="/rw/user-guides/curating-publishing-projects/policies/publication/" target="_blank">Data Usage Agreement</a>
     </p>
     <br>
-    <div class="text-right" ng-if="!$ctrl.error || !$ctrl.archive">
-        <button class="btn btn-add" ng-click="$ctrl.download()" ng-disabled="!$ctrl.loaded || $ctrl.retrievingPostit">
+    <div class="text-right" ng-if="!$ctrl.error">
+        <button class="btn btn-add" ng-if="$ctrl.archive" ng-click="$ctrl.download($ctrl.archive)" ng-disabled="!$ctrl.loaded || $ctrl.retrievingPostit">
             <div class="btn-container" ng-if="!$ctrl.retrievingPostit">
                 <span class="curation-download"></span>
                 &ensp;
                 <strong>Download</strong>
+            </div>
+            <div class="btn-container" ng-if="$ctrl.retrievingPostit">
+                <span ng-if="$ctrl.retrievingPostit" style="font-size:18px">
+                    <i class="fa fa-spinner fa-spin"></i> Loading...
+                </span>
+            </div>
+        </button>
+        <button class="btn btn-add" ng-if="!$ctrl.archive" ng-click="$ctrl.download($ctrl.metadata)" ng-disabled="!$ctrl.loaded || $ctrl.retrievingPostit">
+            <div class="btn-container" ng-if="!$ctrl.retrievingPostit">
+                <span class="curation-download"></span>
+                &ensp;
+                <strong>Download Metadata</strong>
             </div>
             <div class="btn-container" ng-if="$ctrl.retrievingPostit">
                 <span ng-if="$ctrl.retrievingPostit" style="font-size:18px">

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ idna==2.5
 imagesize==0.7.1
 importlib-metadata==2.0.0
 ipaddress==1.0.18
-ipdb==0.9.4
+# ipdb==0.9.4
 ipython==5.4.1
 ipython-genutils==0.2.0
 isort==4.3.4


### PR DESCRIPTION
## Overview: ##
This PR will put a 5GB limit on the archive method for Publications. If a publication has a dataset that is over 5GB, `archive` will only create a json metadata document. The publication download modal has been updated to display the download for the json metadata, and/or the zip file archive if available. There is also a message for publications that are too large.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2067](https://jira.tacc.utexas.edu/browse/DES-2067)

## Summary of Changes: ##
- 5GB archive cap on publication `archive` method
- Updated publication download modal to display unique options for normal publications, oversized publications, and errors retrieving any archived data

## Testing Steps: ##
**For the archive method** 
1. (running locally) exec into the django container and create the path `/corral-repl/tacc/NHERI/published/`
2. create the path `/corral-repl/tacc/NHERI/published/archive/`
3. build test publication directories for a small and large (5GB+) dataset `/corral-repl/tacc/NHERI/published/PRJ-1234/` & `/corral-repl/tacc/NHERI/published/PRJ-5678/`
4. docker cp some files into these directories for testing
5. exec back into the django container and run the `archive` method on your test directories. 
```
from designsafe.apps.projects.managers.publication import archive
archive('PRJ-1234')
archive('PRJ-5678')
```
6. you should see logs to match the expected output, and the results of the operation will be in `/corral-repl/tacc/NHERI/published/archive/`
7. delete the directories and files that you needed to create in the steps above to get things back to how they were. (NOTE: you may have to `chmod -R 0755` everything above the `/corral-repl/tacc/NHERI/` path to do this)

**For the download modal updates**
1. You will see publications with oversized datasets still (I've not removed these yet). This is an example of a project with a "large dataset" `https://designsafe.dev/data/browser/public/designsafe.storage.published/PRJ-2313`
2. Look at any other local publication to check what the standard display will look like
3. For an example of the error message, you can look up a test publication that does not have an archive or fudge the `projectId` variable in the component to look for something that doesn't exist like `PRJ-ABCD`

## Notes: ##
If have questions about anything poke me on slack. 
