### PR TITLE
task/DES-2113: Add `djangocms-snippet` plugin

### DIFF
--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -62,6 +62,7 @@ INSTALLED_APPS = (
     'djangocms_picture',
     'djangocms_video',
     'djangocms_forms',
+    'djangocms_snippet',
     'snowpenguin.django.recaptcha2',
     'filer',
     'easy_thumbnails',

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,6 +51,7 @@ djangocms-file==2.4.0
 djangocms-forms==0.2.5
 djangocms-googlemap==1.4.0
 djangocms-picture==2.4.0
+djangocms-snippet==2.3.0
 djangocms-style==2.3.0
 djangocms-text-ckeditor==3.5.0
 djangocms-video==2.3.0


### PR DESCRIPTION
## Overview: ##
Hedda/CMD have requested the DjangoCMS Snippets plugin to be enabled.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2113](https://jira.tacc.utexas.edu/browse/DES-2113)

## Testing Steps: ##
1. run `docker exec -it des_django python manage.py migrate`
2. Go to a cms page, edit the page, and add a snippet
3. Confirm it succeeds and there are no errors

## UI Photos:

<img width="540" alt="Screen Shot 2021-11-09 at 4 25 04 PM" src="https://user-images.githubusercontent.com/20326896/141015359-905d98ce-7a57-4181-9a49-478eabfc5ace.png">
