### PR TITLE
Task/DES-2117: Log abstract publication listings in metrics

### DIFF
--- a/designsafe/apps/api/projects/views.py
+++ b/designsafe/apps/api/projects/views.py
@@ -66,6 +66,22 @@ class PublicationView(BaseApiView):
 
         if pub is not None and hasattr(pub, 'project'):
             pub_dict = pub.to_dict()
+
+            if pub_dict['project']['value']['projectType'] != 'other':
+                metrics.info('Data Depot',
+                     extra={
+                         'user': request.user.username,
+                         'sessionId': getattr(request.session, 'session_key', ''),
+                         'operation': 'listing',
+                         'agent': request.META.get('HTTP_USER_AGENT'),
+                         'ip': get_client_ip(request),
+                         'info': {
+                             'api': 'agave',
+                             'systemId': 'designsafe.storage.published',
+                             'filePath': project_id,
+                             'query': {} }
+                     })
+
             if latest_pub_dict:
                 pub_dict['latestRevision'] = latest_pub_dict
             return JsonResponse(pub_dict)


### PR DESCRIPTION
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2117](https://jira.tacc.utexas.edu/browse/DES-2117)

## Summary of Changes: ##
Add metrics logging so that viewing a publication's abstract listing (by navigating to that publication) is logged as a listing of that publication's root directory.

## Testing Steps: ##
1. Navigate to a non-Other type publication and inspect the logs in Docker.

