### PR TITLE
Replace "start date" filters with simple show/hide history toggle.

### DIFF
--- a/designsafe/apps/nco/managers/projects.py
+++ b/designsafe/apps/nco/managers/projects.py
@@ -68,7 +68,13 @@ class NcoProjectsManager(object):
                 return {"dateStart": {"$gt": start, "$lt": end}}
             return in_range
 
+        def no_history():
+            """Hide already completed events."""
+            yesterday = date - timedelta(days=1)
+            return {"dateEnd": {"$gt": yesterday}}
+
         range_switch = {
+            "No History": no_history,
             "Happening This Week": this_week,
             "Happening This Month": this_month,
             "Event Started Last 7 Days": last_n_days(7),

--- a/designsafe/static/scripts/nco/components/nco-scheduler-filters/nco-scheduler-filters.component.js
+++ b/designsafe/static/scripts/nco/components/nco-scheduler-filters/nco-scheduler-filters.component.js
@@ -18,7 +18,7 @@ class NcoSchedulerFiltersCtrl {
             'Start Date - oldest first',
             'Award Number',
             'Facility',
-	    'PI Name'
+            'PI Name'
         ];
         this._ui.timeFilters = [
             'Event Started Last 7 Days',
@@ -32,7 +32,8 @@ class NcoSchedulerFiltersCtrl {
             'Happening This Week',
             'Happening This Month',
         ];
-        this.sortby = 'Start Date - newest first';
+        this.sortby = 'Start Date - oldest first';
+        this.historyEnabled = false;
     }
 
     applyFilterAndSort(){
@@ -45,10 +46,18 @@ class NcoSchedulerFiltersCtrl {
                 });
             }
         }
+        if (! this.historyEnabled) {
+            this.filters.push({ name: "time", value: "No History" });
+        }
         if (this.sortby){
             this.sort.push(this.sortby);
         }
         this.filterAndSort({ filters: this.filters, sort:this.sort });
+    }
+
+    toggleHistory() {
+        this.historyEnabled = !this.historyEnabled;
+        this.applyFilterAndSort();
     }
 }
 

--- a/designsafe/static/scripts/nco/components/nco-scheduler-filters/nco-scheduler-filters.template.html
+++ b/designsafe/static/scripts/nco/components/nco-scheduler-filters/nco-scheduler-filters.template.html
@@ -12,14 +12,15 @@
         </select>
     </div>
     <div class="filter form-group">
-        <select name="time"
-                id="filter-time"
-                data-ng-model="$ctrl.filterSel.time"
-                data-ng-options="name for name in $ctrl._ui.timeFilters"
-                data-ng-change="$ctrl.applyFilterAndSort()"
-                class="form-control">
-            <option value="">-- Filter by Start Date --</option>
-        </select>
+        <span class="fa-stack fa-lg" style="margin: -8px;" ng-if="$ctrl.historyEnabled" data-ng-click="$ctrl.toggleHistory()">
+            <i class="fa fa-square fa-stack-1x" style="color: white;"></i>
+            <i class="fa fa-check-square fa-stack-1x" style="color: #1CB500;"></i>
+        </span>
+        <span class="fa-stack fa-lg" style="margin: -8px;" ng-if="!$ctrl.historyEnabled" data-ng-click="$ctrl.toggleHistory()">
+            <i class="fa fa-square fa-stack-1x" style="color: white;"></i>
+            <i class="fa fa-square-o fa-stack-1x" style="color: lightgray;"></i>
+        </span>
+        <label date-ng-click="$ctrl.toggleHistory()">Show Past Events</label>
     </div>
     <span style="width: 75px; display: inline-block;">&nbsp;</span>
     <h3 class="sort-title">Sort by:</h3>

--- a/designsafe/static/scripts/nco/components/nco-scheduler/nco-scheduler.component.js
+++ b/designsafe/static/scripts/nco/components/nco-scheduler/nco-scheduler.component.js
@@ -10,7 +10,11 @@ class NcoSchedulerCtrl {
         this._ui = { loading: true };
         this.filters = [];
         this.sorts = [];
-        this.loadProjects()
+
+        this.filters.push( { name: "time", value: "No History" } );
+        this.sorts.push( "Start Date - oldest first" );
+
+        this.loadProjects({ filters: this.filters, sorts: this.sorts })
             .then((resp) => {
                 return resp;
             }, (err) => {


### PR DESCRIPTION
## Overview: ##

Users were confused by the default view and could not easily figure out
how to see what is happening right now in the facilities.  They were being
presented by default with the full history of all projects in all facilities,
sorted from newest to oldest, causing projects scheduled a year or more into
the future to be the first thing displayed when they load the page.

This change replaces the menu of "start date"-based filters entirely with 
a simple checkbox to show or hide projects that are already completed.  
It also reverses the default ordering from "newest first" to "oldest first".

Applying the new "hide history" filter and reversing the sort order by default 
on page load will mean users are now presented immediately with a view
of projects that is more in-line with expectations:

 * Projects in facilities currently are the first things they see, and
 * Upcoming projects appear the further down the page they go.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-XXX](https://jira.tacc.utexas.edu/browse/DES-XXX)

## Summary of Changes: ##

* Remove "start date" filter menu from filter bar component.
* Add checkbox to show or hide events with end date in the past.
* Add a default filter to the initial loadProjects() call when the page loads that activates this "hide history" filter.
* Reverse the default sort order from descending by "start date" to ascending.

## Testing Steps: ##
1. Load the app page (/nco)
2. Confirm the events are sorted by oldest "start date" first instead of newest upon initial page load.
3. Confirm the default view on initial page load is not showing events with an "end date" before today.
4. Confirm the show/hide history checkbox is working.


## UI Photos: ##

![nco-app-history-on](https://user-images.githubusercontent.com/5141273/146029533-34049be9-22c3-4df0-bb63-ac66e55cada5.png)

![nco-app-history-off](https://user-images.githubusercontent.com/5141273/146029577-44aca168-f71b-4d00-b268-8cbb8570ec26.png)

## Notes: ##

Events that have an empty "start date" field are being sorted at the top of the list.  This is not a code problem.  This is a data problem fixed in the database.  These entries just need to be updated with a start date to fall into their appropriate place in the list.

The code for how to setup a checkbox like this was borrowed from how the Data Depot file listings are doing it.