### PR TITLE
DES-2047 Fix: Edit Project url location fix

### DIFF
--- a/designsafe/static/scripts/data-depot/components/projects/curation-directory/curation-directory.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/curation-directory/curation-directory.component.html
@@ -4,8 +4,8 @@
         <div class="prj-head-container">
             <span class="prj-head-title">
                 {{$ctrl.browser.project.value.projectId}} | <strong>{{ $ctrl.browser.project.value.title }}</strong>
-                <a class="prj-head-edit" ng-click="$ctrl.manageProject($event)"><strong>Edit Project</strong></a>
             </span>
+            <a class="prj-head-edit" ng-click="$ctrl.manageProject($event)"><strong>Edit Project</strong></a>
         </div>
         <table style="table-layout: fixed; width: 100%; margin-top: 10px; margin-bottom: 10px;">
             <colgroup>

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-project/pipeline-project.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-project/pipeline-project.component.html
@@ -73,7 +73,6 @@
         <div class="prj-head-container">
             <span class="prj-head-title">
                 {{$ctrl.project.value.projectId}} | <strong>{{ $ctrl.project.value.title }}</strong>
-                <a class="prj-head-edit" ng-click="$ctrl.manageProject($event)"><strong>Edit Project</strong></a>
             </span>
         </div>
         <table style="table-layout: fixed; width: 100%; margin-top: 10px; margin-bottom: 10px;">

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-project/pipeline-project.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-project/pipeline-project.component.html
@@ -74,6 +74,7 @@
             <span class="prj-head-title">
                 {{$ctrl.project.value.projectId}} | <strong>{{ $ctrl.project.value.title }}</strong>
             </span>
+            <a class="prj-head-edit" ng-click="$ctrl.manageProject($event)"><strong>Edit Project</strong></a>
         </div>
         <table style="table-layout: fixed; width: 100%; margin-top: 10px; margin-bottom: 10px;">
             <colgroup>

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-project/pipeline-project.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-project/pipeline-project.component.js
@@ -113,17 +113,6 @@ class PipelineProjectCtrl {
         }
     }
 
-    manageProject() {
-        return this.$uibModal.open({
-            component: 'manageProject',
-            resolve: {
-                project: () => this.project,
-            },
-            backdrop: 'static',
-            size: 'lg',
-        });
-    }
-
 }
 
 PipelineProjectCtrl.$inject = ['ProjectEntitiesService', 'ProjectService', '$uibModal', '$state'];

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-project/pipeline-project.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-project/pipeline-project.component.js
@@ -113,6 +113,17 @@ class PipelineProjectCtrl {
         }
     }
 
+    manageProject() {
+        return this.$uibModal.open({
+            component: 'manageProject',
+            resolve: {
+                project: () => this.project,
+            },
+            backdrop: 'static',
+            size: 'lg',
+        });
+    }
+
 }
 
 PipelineProjectCtrl.$inject = ['ProjectEntitiesService', 'ProjectService', '$uibModal', '$state'];

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
@@ -4,7 +4,6 @@
         <div class="prj-head-container">
             <span class="prj-head-title">
                 {{$ctrl.browser.project.value.projectId}} | <strong>{{ $ctrl.browser.project.value.title }}</strong>
-                <a class="prj-head-edit" ng-click="$ctrl.manageProject($event)" ng-if="!$ctrl.readOnly"><strong>Edit Project</strong></a>
             </span>
             <div class="prj-head-buttons">
                 <button class="btn-sm btn-secondary prj-head-download" ng-click="$ctrl.download()" ng-if="$ctrl.readOnly">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.js
@@ -117,17 +117,6 @@ class PublicationPreviewFieldReconCtrl {
         this.$state.go('projects.curation', {projectId: this.browser.project.uuid});
     }
 
-    manageProject() {
-        return this.$uibModal.open({
-            component: 'manageProject',
-            resolve: {
-                project: () => this.browser.project,
-            },
-            backdrop: 'static',
-            size: 'lg',
-        });
-    }
-
     ordered(parent, entities) {
         let order = (ent) => {
             if (ent._ui && ent._ui.orders && ent._ui.orders.length) {

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
@@ -4,7 +4,6 @@
         <div class="prj-head-container">
             <span class="prj-head-title">
                 {{$ctrl.browser.project.value.projectId}} | <strong>{{ $ctrl.browser.project.value.title }}</strong>
-                <a class="prj-head-edit" ng-click="$ctrl.manageProject($event)" ng-if="!$ctrl.readOnly"><strong>Edit Project</strong></a>
             </span>
             <div class="prj-head-buttons">
                 <button class="btn-sm btn-secondary prj-head-download" ng-click="$ctrl.download()" ng-if="$ctrl.readOnly">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.js
@@ -16,7 +16,7 @@ class PublicationPreviewHybSimCtrl {
         this.$q = $q;
         this.FileOperationService = FileOperationService;
     }
-    
+
     $onInit() {
         this.readOnly = this.$state.current.name.indexOf('publishedData') === 0;
         this.projectId = this.ProjectService.resolveParams.projectId;
@@ -88,24 +88,13 @@ class PublicationPreviewHybSimCtrl {
         }
         return false;
     }
-    
+
     goWork() {
         this.$state.go('projects.view', {projectId: this.browser.project.uuid});
     }
 
     goCuration() {
         this.$state.go('projects.curation', {projectId: this.browser.project.uuid});
-    }
-
-    manageProject() {
-        return this.$uibModal.open({
-            component: 'manageProject',
-            resolve: {
-                project: () => this.browser.project,
-            },
-            backdrop: 'static',
-            size: 'lg',
-        });
     }
 
     prepareModal() {

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.html
@@ -4,7 +4,6 @@
         <div class="prj-head-container">
             <span class="prj-head-title">
                 {{$ctrl.browser.project.value.projectId}} | <strong>{{ $ctrl.browser.project.value.title }}</strong>
-                <a class="prj-head-edit" ng-click="$ctrl.manageProject($event)" ng-if="!$ctrl.readOnly"><strong>Edit Project</strong></a>
             </span>
             <div class="prj-head-buttons">
                 <button class="btn-sm btn-secondary prj-head-download" ng-click="$ctrl.download()" ng-if="$ctrl.readOnly">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.js
@@ -15,7 +15,7 @@ class PublicationPreviewOtherCtrl {
         this.$state = $state;
         this.$q = $q;
     }
-    
+
     $onInit() {
         this.projectId = this.ProjectService.resolveParams.projectId;
         this.filePath = this.ProjectService.resolveParams.filePath;
@@ -37,24 +37,13 @@ class PublicationPreviewOtherCtrl {
             this.ui.loading = false;
         }
     }
-    
+
     goWork() {
         this.$state.go('projects.view', {projectId: this.browser.project.uuid, data: this.browser}, {reload: true});
     }
 
     goCuration() {
         this.$state.go('projects.curation', {projectId: this.browser.project.uuid, data: this.browser}, {reload: true});
-    }
-
-    manageProject() {
-        return this.$uibModal.open({
-            component: 'manageProject',
-            resolve: {
-                project: () => this.browser.project,
-            },
-            backdrop: 'static',
-            size: 'lg',
-        });
     }
 
     prepareModal() {

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
@@ -4,7 +4,6 @@
         <div class="prj-head-container">
             <span class="prj-head-title">
                 {{$ctrl.browser.project.value.projectId}} | <strong>{{ $ctrl.browser.project.value.title }}</strong>
-                <a class="prj-head-edit" ng-click="$ctrl.manageProject($event)" ng-if="!$ctrl.readOnly"><strong>Edit Project</strong></a>
             </span>
             <div class="prj-head-buttons">
                 <button class="btn-sm btn-secondary prj-head-download" ng-click="$ctrl.download()" ng-if="$ctrl.readOnly">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.js
@@ -16,7 +16,7 @@ class PublicationPreviewSimCtrl {
         this.$stateParams = $stateParams;
         this.$q = $q;
     }
-    
+
     $onInit() {
         this.readOnly = this.$state.current.name.indexOf('publishedData') === 0;
         this.projectId = this.ProjectService.resolveParams.projectId;
@@ -32,13 +32,11 @@ class PublicationPreviewSimCtrl {
             editTags: false,
         };
 
-        
 
         if (this.filePath === '/' && !this.$stateParams.query_string) {
             this.ui.fileNav = false;
         }
 
-        
 
         this.$q.all([
             this.ProjectService.get({ uuid: this.projectId }),
@@ -53,7 +51,6 @@ class PublicationPreviewSimCtrl {
             this.ProjectEntitiesService.listEntities({ uuid: this.projectId, name: 'all' }),
         ])
         .then(([project, listing, ents]) => {
-            
             this.breadcrumbParams = {
                 root: {label: project.value.projectId, path: ''}, 
                 path: this.FileListingService.listings.main.params.path,
@@ -91,24 +88,13 @@ class PublicationPreviewSimCtrl {
         }
         return false;
     }
-    
+
     goWork() {
         this.$state.go('projects.view', {projectId: this.browser.project.uuid, data: this.browser});
     }
 
     goCuration() {
         this.$state.go('projects.curation', {projectId: this.browser.project.uuid});
-    }
-
-    manageProject() {
-        return this.$uibModal.open({
-            component: 'manageProject',
-            resolve: {
-                project: () => this.browser.project,
-            },
-            backdrop: 'static',
-            size: 'lg',
-        });
     }
 
     prepareModal() {

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
@@ -4,7 +4,6 @@
         <div class="prj-head-container">
             <span class="prj-head-title">
                 {{$ctrl.browser.project.value.projectId}} | <strong>{{ $ctrl.browser.project.value.title }}</strong>
-                <a class="prj-head-edit" ng-click="$ctrl.manageProject($event)" ng-if="!$ctrl.readOnly"><strong>Edit Project</strong></a>
             </span>
             <div class="prj-head-buttons">
                 <button class="btn-sm btn-secondary prj-head-download" ng-click="$ctrl.download()" ng-if="$ctrl.readOnly">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.js
@@ -124,17 +124,6 @@ class PublicationPreviewCtrl {
         this.$state.go('projects.curation', {projectId: this.browser.project.uuid});
     }
 
-    manageProject() {
-            return this.$uibModal.open({
-            component: 'manageProject',
-            resolve: {
-                project: () => this.browser.project,
-            },
-            backdrop: 'static',
-            size: 'lg',
-        });
-    }
-
     prepareModal() {
         this.$uibModal.open({
             template: PublicationPopupTemplate,


### PR DESCRIPTION
## Overview: ##
Moved the remaining Edit Project urls on other templates that I missed before.

Also removed the Edit Project urls from the Publication Preview as per a new secondary request from Craig.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2047](https://jira.tacc.utexas.edu/browse/DES-2047)

## Summary of Changes: ##

## Testing Steps: ##
1. Click through each of the tabs in multiple types of projects.
2. Confirm that the Edit Project is now right-aligned on the Working Directory and Curation Directory pages.
3. Confirm that the Edit Project url does not exist on the Publication Preview page.

## UI Photos:

## Notes: ##
