### PR TITLE
Task/DES-2148 - Fix bugs for custom entity inputs

### DIFF
--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
@@ -228,10 +228,10 @@
                 <div class="well">
                     <div class="entity-meta-field">
                         <div class="entity-meta-label">Simulation Type</div>
-                        <span ng-if="!$ctrl.isValid(hybsim.value.experimentalFacilityOther)" class="entity-meta-data-cap">
+                        <span ng-if="!$ctrl.isValid(hybsim.value.simulationTypeOther)" class="entity-meta-data-cap">
                             {{ hybsim.value.simulationType.replace('_', ' ') }}
                         </span>
-                        <span ng-if="$ctrl.isValid(hybsim.value.experimentalFacilityOther)" class="entity-meta-data-cap">
+                        <span ng-if="$ctrl.isValid(hybsim.value.simulationTypeOther)" class="entity-meta-data-cap">
                             {{ hybsim.value.simulationTypeOther }}
                         </span>
                     </div>

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
@@ -235,10 +235,10 @@
                 <div class="well">
                     <div class="entity-meta-field">
                         <div class="entity-meta-label">Simulation Type</div>
-                        <span ng-if="!$ctrl.isValid(simulation.value.experimentalFacilityOther)" class="entity-meta-data-cap">
+                        <span ng-if="!$ctrl.isValid(simulation.value.simulationTypeOther)" class="entity-meta-data-cap">
                             {{ simulation.value.simulationType.replace('_', ' ') }}
                         </span>
-                        <span ng-if="$ctrl.isValid(simulation.value.experimentalFacilityOther)" class="entity-meta-data-cap">
+                        <span ng-if="$ctrl.isValid(simulation.value.simulationTypeOther)" class="entity-meta-data-cap">
                             {{ simulation.value.simulationTypeOther }}
                         </span>
                     </div>

--- a/designsafe/static/scripts/projects/components/manage-experiments/manage-experiments.component.html
+++ b/designsafe/static/scripts/projects/components/manage-experiments/manage-experiments.component.html
@@ -80,16 +80,15 @@
           <span class="label label-danger">Required</span>
         </label>
         <div>
-          <select ng-options="ef.name as ef.label for ef in $ctrl.ui.efs[$ctrl.data.project.value.projectType]"
-                  style="background:white; width:100%"
-                  ng-model="$ctrl.form.addExperiments[0].experimentalFacility"
+          <select class="form-control"
                   id="add-exp-facility"
-                  ng-required="true"
-                  class="form-control">
+                  ng-options="ef.name as ef.label for ef in $ctrl.ui.efs[$ctrl.data.project.value.projectType]"
+                  ng-model="$ctrl.form.addExperiments[0].experimentalFacility"
+                  ng-required="true">
               <option value="">-- Select an Experimental Facility --</option>
           </select>
-          <input  type="text"
-                  style="background:white; width:100%"
+          <input  class="form-control"
+                  type="text"
                   id="add-exp-facility-other"
                   placeholder="Custom Experimental Facility"
                   ng-model="$ctrl.form.addExperiments[0].experimentalFacilityOther"
@@ -104,16 +103,15 @@
             <span class="label label-danger">Required</span>
           </label>
         <div>
-          <select ng-options="type.name as type.label for type in $ctrl.ui.experimentTypes[$ctrl.form.addExperiments[0].experimentalFacility]"
-                  style="background:white; width:100%"
-                  ng-model="$ctrl.form.addExperiments[0].experimentType"
+          <select class="form-control"
                   id="add-exp-type"
-                  ng-required="true"
-                  class="form-control">
+                  ng-options="type.name as type.label for type in $ctrl.ui.experimentTypes[$ctrl.form.addExperiments[0].experimentalFacility]"
+                  ng-model="$ctrl.form.addExperiments[0].experimentType"
+                  ng-required="true">
               <option value="">-- Select an Experiment Type --</option>
           </select>
-          <input  type="text"
-                  style="background:white; width:100%"
+          <input  class="form-control"
+                  type="text"
                   id="add-exp-facility-other"
                   placeholder="Custom Experiment Type"
                   ng-model="$ctrl.form.addExperiments[0].experimentTypeOther"
@@ -128,16 +126,15 @@
             <span class="label label-danger">Required</span>
           </label>
         <div>
-          <select ng-options="et.name as et.label for et in $ctrl.ui.equipmentTypes[$ctrl.form.addExperiments[0].experimentalFacility]"
-                  style="background:white; width:100%"
-                  ng-model="$ctrl.form.addExperiments[0].equipmentType"
+          <select class="form-control"
                   id="id-equipment-type"
-                  ng-required="true"
-                  class="form-control">
+                  ng-options="et.name as et.label for et in $ctrl.ui.equipmentTypes[$ctrl.form.addExperiments[0].experimentalFacility]"
+                  ng-model="$ctrl.form.addExperiments[0].equipmentType"
+                  ng-required="true">
               <option value="">-- Select an Equipment Type --</option>
           </select>
-          <input  type="text"
-                  style="background:white; width:100%"
+          <input  class="form-control"
+                  type="text"
                   id="add-exp-facility-other"
                   placeholder="Custom Equipment Type"
                   ng-model="$ctrl.form.addExperiments[0].equipmentTypeOther"
@@ -254,11 +251,7 @@
             <span class="label label-danger">Required</span>
           </label>
           <div>
-            <select style="width:100%"
-                    class="grayed-out"
-                    id="edit-exp-facility"
-                    disabled
-                    class="form-control">
+            <select class="form-control grayed-out" id="edit-exp-facility" disabled>
               <option value="$ctrl.editExpForm.facility">{{ $ctrl.editExpForm.facility }}</option>
             </select>
           </div>
@@ -270,11 +263,7 @@
               <span class="label label-danger">Required</span>
             </label>
           <div>
-            <select style=" width:100%"
-                    class="grayed-out"
-                    id="edit-exp-type"
-                    disabled
-                    class="form-control">
+            <select class="form-control grayed-out" id="edit-exp-type" disabled>
               <option value="$ctrl.editExpForm.type">{{ $ctrl.editExpForm.type }}</option>
             </select>
           </div>
@@ -286,17 +275,17 @@
               <span class="label label-danger">Required</span>
             </label>
           <div>
-            <select ng-options="equip.name as equip.label for equip in $ctrl.editExpForm.equipmentList"
-                    ng-model="$ctrl.editExpForm.equipment"
-                    style="background:white; width:100%"
+            <select class="form-control"
                     id="id-equipment-type"
+                    ng-options="equip.name as equip.label for equip in $ctrl.editExpForm.equipmentList"
+                    ng-model="$ctrl.editExpForm.equipment"
                     class="form-control"
             >
             </select>
-            <input type="text"
-                   style="background:white; width:100%"
+            <input class="form-control"
+                   type="text"
                    id="id-equipment-type-other"
-                   placeholder="$ctrl.editExpForm.equipmentOther"
+                   placeholder="{{$ctrl.editExpForm.equipmentOther || 'Custom Equipment Type'}}"
                    ng-model="$ctrl.editExpForm.equipmentOther"
                    ng-if="$ctrl.editExpForm.equipment == 'other'"
                    ng-required="true"
@@ -404,7 +393,7 @@
               <div class="entity-meta-field">
                 <div class="entity-meta-label">Experiment Type</div>
                 <span ng-if="!$ctrl.isValid(experiment.value.experimentTypeOther)"
-                        class="entity-meta-data-cap">{{ $ctrl.getET(experiment) }}</span>
+                        class="entity-meta-data-cap">{{ $ctrl.getExpType(experiment) }}</span>
                 <span ng-if="$ctrl.isValid(experiment.value.experimentTypeOther)"
                         class="entity-meta-data-cap">{{ experiment.value.experimentTypeOther }}</span>
               </div>
@@ -417,14 +406,14 @@
               <div class="entity-meta-field">
                 <div class="entity-meta-label">Experimental Facility</div>
                 <span ng-if="!$ctrl.isValid(experiment.value.experimentalFacilityOther)"
-                        class="entity-meta-data-cap">{{ $ctrl.getEF(experiment.value.experimentalFacility) }}</span>
+                        class="entity-meta-data-cap">{{ $ctrl.getExpFacility(experiment.value.experimentalFacility) }}</span>
                 <span ng-if="$ctrl.isValid(experiment.value.experimentalFacilityOther)"
                         class="entity-meta-data-cap">{{ experiment.value.experimentalFacilityOther }}</span>
               </div>
               <div class="entity-meta-field">
                 <div class="entity-meta-label">Equipment Type</div>
                 <span ng-if="!$ctrl.isValid(experiment.value.equipmentTypeOther)"
-                        class="entity-meta-data-cap">{{ $ctrl.getEQ(experiment) }}</span>
+                        class="entity-meta-data-cap">{{ $ctrl.getEquipment(experiment) }}</span>
                 <span ng-if="$ctrl.isValid(experiment.value.equipmentTypeOther)"
                         class="entity-meta-data-cap">{{ experiment.value.equipmentTypeOther }}</span>  
               </div>

--- a/designsafe/static/scripts/projects/components/manage-experiments/manage-experiments.component.js
+++ b/designsafe/static/scripts/projects/components/manage-experiments/manage-experiments.component.js
@@ -104,7 +104,7 @@ class ManageExperimentsCtrl {
         this.close();
     }
 
-    getEF(str) {
+    getExpFacility(str) {
         let efs = this.ui.efs[this.data.project.value.projectType];
         let ef = _.find(efs, function(ef) {
             return ef.name === str;
@@ -112,7 +112,7 @@ class ManageExperimentsCtrl {
         return ef.label;
     }
 
-    getET(exp) {
+    getExpType(exp) {
         let ets = this.ui.experimentTypes[exp.value.experimentalFacility];
         let et = _.find(ets, (x) => {
             return x.name === exp.value.experimentType;
@@ -120,7 +120,7 @@ class ManageExperimentsCtrl {
         return et.label;
     }
 
-    getEQ(exp) {
+    getEquipment(exp) {
         let eqts = this.ui.equipmentTypes[exp.value.experimentalFacility];
         let eqt = _.find(eqts, (x) => {
             return x.name === exp.value.equipmentType;
@@ -212,8 +212,10 @@ class ManageExperimentsCtrl {
             start: exp.value.procedureStart,
             end: exp.value.procedureEnd,
             title: exp.value.title,
-            facility: exp.getEF(this.data.project.value.projectType, exp.value.experimentalFacility).label,
-            type: this.getET(experiment),
+            facility: (exp.value.experimentalFacility === 'other' ?
+                exp.value.experimentalFacilityOther : this.getExpFacility(exp.value.experimentalFacility)),
+            type: (exp.value.experimentType === 'other' ?
+                exp.value.experimentTypeOther : this.getExpType(exp)),
             equipment: exp.value.equipmentType,
             equipmentOther: exp.value.equipmentTypeOther,
             equipmentList: this.equipmentTypes[exp.value.experimentalFacility],
@@ -280,7 +282,9 @@ class ManageExperimentsCtrl {
         exp.value.authors = this.editExpForm.authors;
         exp.value.guests = this.editExpForm.guests;
         exp.value.equipmentType = this.editExpForm.equipment;
-        exp.value.equipmentTypeOther = this.editExpForm.equipmentOther;
+        exp.value.equipmentTypeOther = (this.editExpForm.equipment === 'other' ?
+            this.editExpForm.equipmentOther : ''
+        )
         this.ui.savingEditExp = true;
         this.ProjectEntitiesService.update({
             data: {
@@ -333,39 +337,26 @@ class ManageExperimentsCtrl {
     saveExperiment($event) {
         $event.preventDefault();
         this.data.busy = true;
-        // This modal needs to be refactored.
+        // This modal needs some tidying up.
         // we will never be adding more than one experiment at a time.
-        // there is also no need for entity management within this modal.
         this.form.addExperiments[0].authors = this.data.users;
-        if (this.form.addExperiments[0].procedureStart && !this.form.addExperiments[0].procedureEnd) {
-            this.form.addExperiments[0].procedureEnd = this.form.addExperiments[0].procedureStart;
-        }
-        let addActions = this.form.addExperiments.filter((exp) => (exp.title && exp.experimentalFacility && exp.experimentType)).map((exp) => {
-            exp.description = exp.description || '';
-            return this.ProjectEntitiesService.create({
-                data: {
-                    uuid: this.data.project.uuid,
-                    name: 'designsafe.project.experiment',
-                    entity: exp,
-                },
-            }).then((res) => {
-                this.data.project.addEntity(res);
-                this.data.experiments = this.data.project.experiment_set;
-                this.data.users.forEach((user) => {
-                    user.authorship = false;
-                });
+        var experiment = this.form.addExperiments[0];
+        this.ProjectEntitiesService.create({
+            data: {
+                uuid: this.data.project.uuid,
+                name: 'designsafe.project.experiment',
+                entity: experiment
+            }
+        }).then((res) => {
+            this.data.project.addEntity(res);
+            this.data.experiments = this.data.project.experiment_set;
+        }).then(() => {
+            this.data.busy = false;
+            this.form.addExperiments = [{}];
+            this.data.users.forEach((user) => {
+                user.authorship = false;
             });
         });
-
-        this.$q.all(addActions).then(
-            (results) => { /* eslint-disable-line */
-                this.data.busy = false;
-                this.form.addExperiments = [{}];
-            },
-            (error) => {
-                this.data.error = error;
-            }
-        );
     }
 }
 

--- a/designsafe/static/scripts/projects/components/manage-experiments/manage-experiments.component.js
+++ b/designsafe/static/scripts/projects/components/manage-experiments/manage-experiments.component.js
@@ -340,7 +340,7 @@ class ManageExperimentsCtrl {
         // This modal needs some tidying up.
         // we will never be adding more than one experiment at a time.
         this.form.addExperiments[0].authors = this.data.users;
-        var experiment = this.form.addExperiments[0];
+        let experiment = this.form.addExperiments[0];
         this.ProjectEntitiesService.create({
             data: {
                 uuid: this.data.project.uuid,

--- a/designsafe/static/scripts/projects/components/manage-field-recon/collections/manage-field-recon-collections.component.js
+++ b/designsafe/static/scripts/projects/components/manage-field-recon/collections/manage-field-recon-collections.component.js
@@ -29,7 +29,7 @@ class ManageFieldReconCollectionsCtrl {
             if (typeof m == 'string') {
                 // if user is guest append their data
                 if(m.slice(0,5) === 'guest') {
-                    var guestData = this.project.value.guestMembers.find(
+                    let guestData = this.project.value.guestMembers.find(
                         (x) => x.user === m
                     );
                     members[i] = {
@@ -276,42 +276,28 @@ class ManageFieldReconCollectionsCtrl {
                     auth.order = i;
                 }
             });
-            usersToClean = _.uniq(usersToClean, 'name');
-        } else {
-            usersToClean = _.uniq(usersToClean, 'name');
         }
+        usersToClean = _.uniq(usersToClean, 'name');
+
         /*
-        Restore previous authorship status if any
+        It is possible that a user added to a collection may no longer be on a project
+        Remove any users on the collection that are not on the project
         */
-        if (auths.length) {
-            auths.forEach((a) => {
-                usersToClean.forEach((u, i) => {
-                    if (a.name === u.name) {
-                        usersToClean[i] = a;
-                    }
-                });
-            });
-        }
+        usersToClean = usersToClean.filter((m) => this.data.users.find((u) => u.name === m.name));
+
         /*
-        It is possible that a user added to an experiment may no longer be on a project
-        Remove any users on the experiment that are not on the project
+        Restore previous authorship status and order if any
         */
-        let rmList = [];
-        usersToClean.forEach((m) => {
-            let person = this.data.users.find((u) => u.name === m.name);
-            if (!person) {
-                rmList.push(m);
-            }
-        });
-        rmList.forEach((m) => {
-            let index = usersToClean.indexOf(m);
-            if (index > -1) {
-                usersToClean.splice(index, 1);
-            }
-        });
+        usersToClean = usersToClean.map((u) => auths.find((a) => u.name == a.name) || u);
+
+        /*
+        Reorder to accomodate blank spots in order and give order to users with no order
+        */
+        usersToClean = usersToClean.sort((a, b) => a.order - b.order);
         usersToClean.forEach((u, i) => {
             u.order = i;
         });
+
         return usersToClean;
     }
 

--- a/designsafe/static/scripts/projects/components/manage-field-recon/missions/manage-field-recon-missions.component.js
+++ b/designsafe/static/scripts/projects/components/manage-field-recon/missions/manage-field-recon-missions.component.js
@@ -115,42 +115,28 @@ class ManageFieldReconMissionsCtrl {
                     auth.order = i;
                 }
             });
-            usersToClean = _.uniq(usersToClean, 'name');
-        } else {
-            usersToClean = _.uniq(usersToClean, 'name');
         }
+        usersToClean = _.uniq(usersToClean, 'name');
+
         /*
-        Restore previous authorship status if any
+        It is possible that a user added to a mission may no longer be on a project
+        Remove any users on the mission that are not on the project
         */
-        if (auths.length) {
-            auths.forEach((a) => {
-                usersToClean.forEach((u, i) => {
-                    if (a.name === u.name) {
-                        usersToClean[i] = a;
-                    }
-                });
-            });
-        }
+        usersToClean = usersToClean.filter((m) => this.data.users.find((u) => u.name === m.name));
+
         /*
-        It is possible that a user added to an experiment may no longer be on a project
-        Remove any users on the experiment that are not on the project
+        Restore previous authorship status and order if any
         */
-        let rmList = [];
-        usersToClean.forEach((m) => {
-            let person = this.data.users.find((u) => u.name === m.name);
-            if (!person) {
-                rmList.push(m);
-            }
-        });
-        rmList.forEach((m) => {
-            let index = usersToClean.indexOf(m);
-            if (index > -1) {
-                usersToClean.splice(index, 1);
-            }
-        });
+        usersToClean = usersToClean.map((u) => auths.find((a) => u.name == a.name) || u);
+
+        /*
+        Reorder to accomodate blank spots in order and give order to users with no order
+        */
+        usersToClean = usersToClean.sort((a, b) => a.order - b.order);
         usersToClean.forEach((u, i) => {
             u.order = i;
         });
+
         return usersToClean;
     }
 
@@ -169,49 +155,6 @@ class ManageFieldReconMissionsCtrl {
             }
         }
         return true;
-    }
-
-    orderAuthors(up) {
-        let a;
-        let b;
-        if (up) {
-            if (this.form.selectedAuthor.order <= 0) {
-                return;
-            }
-            // move up
-            a = this.form.authors.find(
-                (x) => {
-                    x.order === this.form.selectedAuthor.order - 1;
-                }
-            );
-            b = this.form.authors.find(
-                (x) => {
-                    x.order === this.form.selectedAuthor.order;
-                }
-            );
-            a.order = a.order + b.order;
-            b.order = a.order - b.order;
-            a.order = a.order - b.order;
-        } else {
-            if (this.form.selectedAuthor.order >=
-                this.form.authors.length - 1) {
-                return;
-            }
-            // move down
-            a = this.form.authors.find(
-                (x) => {
-                    x.order === this.form.selectedAuthor.order + 1;
-                }
-            );
-            b = this.form.authors.find(
-                (x) => {
-                    x.order === this.form.selectedAuthor.order;
-                }
-            );
-            a.order = a.order + b.order;
-            b.order = a.order - b.order;
-            a.order = a.order - b.order;
-        }
     }
 
     saveMission($event) {

--- a/designsafe/static/scripts/projects/components/manage-hybrid-simulations/manage-hybrid-simulations.component.html
+++ b/designsafe/static/scripts/projects/components/manage-hybrid-simulations/manage-hybrid-simulations.component.html
@@ -29,15 +29,16 @@
           <span class="label label-danger">Required</span>
         </label>
         <div>
-          <select ng-options="type.name as type.label for type in $ctrl.ui.simulationTypes"
-                  style="background:white; width:100%"
-                  ng-model="$ctrl.form.addSimulation[0].simulationType"
+          <select class="form-control"
                   id="add-sim-type"
+                  ng-options="type.name as type.label for type in $ctrl.ui.simulationTypes"
+                  ng-model="$ctrl.form.addSimulation[0].simulationType"
                   ng-required="true">
+                  <option value="">-- Select Simulation Type --</option>
           </select>
-          <input  type="text"
-                  style="background:white; width:100%"
+          <input  class="form-control"
                   id="add-sim-type-other"
+                  type="text"
                   placeholder="Custom Hybrid Simulation Type"
                   ng-model="$ctrl.form.addSimulation[0].simulationTypeOther"
                   ng-if="$ctrl.form.addSimulation[0].simulationType == 'Other'"
@@ -104,11 +105,25 @@
             <span class="label label-danger">Required</span>
           </label>
           <div>
-            <select style="background:white; width:100%"
+            <!-- <select style="background:white; width:100%"
                     id="edit-sim-type"
                     readonly>
               <option value="$ctrl.editSimForm.simulationType">{{ $ctrl.editSimForm.simulationType }}</option>
+            </select> -->
+            <select class="form-control"
+                    id="id-simulation-type"
+                    ng-options="type.name as type.label for type in $ctrl.ui.simulationTypes"
+                    ng-model="$ctrl.editSimForm.simulationType"
+            >
             </select>
+            <input class="form-control"
+                   type="text"
+                   id="id-equipment-type-other"
+                   placeholder="{{$ctrl.editSimForm.simulationTypeOther || 'Custom Hybrid Simulation Type'}}"
+                   ng-model="$ctrl.editSimForm.simulationTypeOther"
+                   ng-if="$ctrl.editSimForm.simulationType == 'Other'"
+                   ng-required="true"
+            >
           </div>
         </div>
         <!-- Edit Hybrid Simulation Description -->

--- a/designsafe/static/scripts/projects/components/manage-hybrid-simulations/manage-hybrid-simulations.component.js
+++ b/designsafe/static/scripts/projects/components/manage-hybrid-simulations/manage-hybrid-simulations.component.js
@@ -25,7 +25,7 @@ class ManageHybridSimCtrl {
             if (typeof m == 'string') {
                 // if user is guest append their data
                 if(m.slice(0,5) === 'guest') {
-                    var guestData = this.project.value.guestMembers.find(x => x.user === m);
+                    let guestData = this.project.value.guestMembers.find(x => x.user === m);
                     members[i] = {
                         name: m,
                         order: i,
@@ -103,7 +103,7 @@ class ManageHybridSimCtrl {
         $event.preventDefault();
         this.data.busy = true;
         this.form.addSimulation[0].authors = this.data.users;
-        var simulation = this.form.addSimulation[0];
+        let simulation = this.form.addSimulation[0];
         this.ProjectEntitiesService.create({
             data: {
                 uuid: this.data.project.uuid,
@@ -125,9 +125,9 @@ class ManageHybridSimCtrl {
 
     configureAuthors(exp) {
         // combine project and experiment users then check if any authors need to be built into objects
-        var usersToClean = [...new Set([...this.data.users, ...exp.value.authors.slice()])];
-        var modAuths = false;
-        var auths = [];
+        let usersToClean = [...new Set([...this.data.users, ...exp.value.authors.slice()])];
+        let modAuths = false;
+        let auths = [];
 
         usersToClean.forEach((a) => {
             if (typeof a == 'string') {
@@ -143,7 +143,7 @@ class ManageHybridSimCtrl {
                 if (typeof auth == 'string') {
                     // if user is guest append their data
                     if(auth.slice(0,5) === 'guest') {
-                        var guestData = this.project.value.guestMembers.find(x => x.user === auth);
+                        let guestData = this.project.value.guestMembers.find(x => x.user === auth);
                         usersToClean[i] = {
                             name: auth,
                             order: i,
@@ -161,49 +161,35 @@ class ManageHybridSimCtrl {
                     auth.order = i;
                 }
             });
-            usersToClean = _.uniq(usersToClean, 'name');
-        } else {
-            usersToClean = _.uniq(usersToClean, 'name');
         }
+        usersToClean = _.uniq(usersToClean, 'name');
+
         /*
-        Restore previous authorship status if any
+        It is possible that a user added to an simulation may no longer be on a project
+        Remove any users on the simulation that are not on the project
         */
-        if (auths.length) {
-            auths.forEach((a) => {
-                usersToClean.forEach((u, i) => {
-                    if (a.name === u.name) {
-                        usersToClean[i] = a;
-                    }
-                });
-            });
-        }
+        usersToClean = usersToClean.filter((m) => this.data.users.find((u) => u.name === m.name));
+
         /*
-        It is possible that a user added to an experiment may no longer be on a project
-        Remove any users on the experiment that are not on the project
+        Restore previous authorship status and order if any
         */
-        var rmList = [];
-        usersToClean.forEach((m) => {
-          var person = this.data.users.find(u => u.name === m.name);
-          if (!person) {
-            rmList.push(m);
-          }
-        });
-        rmList.forEach((m) => {
-          var index = usersToClean.indexOf(m);
-          if (index > -1) {
-            usersToClean.splice(index, 1);
-          }
-        });
+        usersToClean = usersToClean.map((u) => auths.find((a) => u.name == a.name) || u);
+
+        /*
+        Reorder to accomodate blank spots in order and give order to users with no order
+        */
+        usersToClean = usersToClean.sort((a, b) => a.order - b.order);
         usersToClean.forEach((u, i) => {
             u.order = i;
         });
+
         return usersToClean;
     }
 
     editSim(simulation) {
         document.getElementById('modal-header').scrollIntoView({ behavior: 'smooth' });
-        var sim = jQuery.extend(true, {}, simulation);
-        var auths = this.configureAuthors(sim);
+        let sim = jQuery.extend(true, {}, simulation);
+        let auths = this.configureAuthors(sim);
         this.editSimForm = {
             sim: sim,
             authors: auths,
@@ -232,8 +218,11 @@ class ManageHybridSimCtrl {
     }
 
     orderAuthors(up) {
-        var a;
-        var b;
+        if (!this.editSimForm.selectedAuthor) {
+            return;
+        }
+        let a,
+            b;
         if (up) {
             if (this.editSimForm.selectedAuthor.order <= 0) {
                 return;
@@ -258,7 +247,7 @@ class ManageHybridSimCtrl {
     }
 
     saveEditSimulation() {
-        var sim = this.editSimForm.sim;
+        let sim = this.editSimForm.sim;
         sim.value.title = this.editSimForm.title;
         sim.value.description = this.editSimForm.description;
         sim.value.authors = this.editSimForm.authors;
@@ -274,7 +263,7 @@ class ManageHybridSimCtrl {
                 entity: sim
             }
         }).then((e) => {
-            var ent = this.data.project.getRelatedByUuid(e.uuid);
+            let ent = this.data.project.getRelatedByUuid(e.uuid);
             ent.update(e);
             this.ui.savingEditSim = false;
             this.data.simulations = this.data.project.hybridsimulation_set;

--- a/designsafe/static/scripts/projects/components/manage-hybrid-simulations/manage-hybrid-simulations.component.js
+++ b/designsafe/static/scripts/projects/components/manage-hybrid-simulations/manage-hybrid-simulations.component.js
@@ -104,13 +104,6 @@ class ManageHybridSimCtrl {
         this.data.busy = true;
         this.form.addSimulation[0].authors = this.data.users;
         var simulation = this.form.addSimulation[0];
-        if (_.isEmpty(simulation.title) || typeof simulation.title === 'undefined' ||
-            _.isEmpty(simulation.simulationType) || typeof simulation.simulationType === 'undefined') {
-            this.data.error = 'Title and Type are required.';
-            this.data.busy = false;
-            return;
-        }
-        simulation.description = simulation.description || '';
         this.ProjectEntitiesService.create({
             data: {
                 uuid: this.data.project.uuid,
@@ -270,6 +263,10 @@ class ManageHybridSimCtrl {
         sim.value.description = this.editSimForm.description;
         sim.value.authors = this.editSimForm.authors;
         sim.value.guests = this.editSimForm.guests;
+        sim.value.simulationType = this.editSimForm.simulationType;
+        sim.value.simulationTypeOther = (this.editSimForm.simulationType === 'Other' ?
+            this.editSimForm.simulationTypeOther : ''
+        )
         this.ui.savingEditSim = true;
         this.ProjectEntitiesService.update({
             data: {

--- a/designsafe/static/scripts/projects/components/manage-simulations/manage-simulations.component.html
+++ b/designsafe/static/scripts/projects/components/manage-simulations/manage-simulations.component.html
@@ -29,15 +29,16 @@
           <span class="label label-danger">Required</span>
         </label>
         <div>
-          <select ng-options="type.name as type.label for type in $ctrl.ui.simulationTypes"
-                  style="background:white; width:100%"
-                  ng-model="$ctrl.form.addSimulation[0].simulationType"
+          <select class="form-control"
                   id="add-sim-type"
+                  ng-options="type.name as type.label for type in $ctrl.ui.simulationTypes"
+                  ng-model="$ctrl.form.addSimulation[0].simulationType"
                   ng-required="true">
+                  <option value="">-- Select Simulation Type --</option>
           </select>
-          <input  type="text"
-                  style="background:white; width:100%"
+          <input  class="form-control"
                   id="add-sim-type-other"
+                  type="text"
                   placeholder="Custom Simulation Type"
                   ng-model="$ctrl.form.addSimulation[0].simulationTypeOther"
                   ng-if="$ctrl.form.addSimulation[0].simulationType == 'Other'"
@@ -104,11 +105,20 @@
             <span class="label label-danger">Required</span>
           </label>
           <div>
-            <select style="background:white; width:100%"
-                    id="edit-sim-type"
-                    readonly>
-              <option value="$ctrl.editSimForm.simulationType">{{ $ctrl.editSimForm.simulationType }}</option>
+            <select class="form-control"
+                    id="id-simulation-type"
+                    ng-options="type.name as type.label for type in $ctrl.ui.simulationTypes"
+                    ng-model="$ctrl.editSimForm.simulationType"
+            >
             </select>
+            <input class="form-control"
+                   type="text"
+                   id="id-equipment-type-other"
+                   placeholder="{{$ctrl.editSimForm.simulationTypeOther || 'Custom Simulation Type'}}"
+                   ng-model="$ctrl.editSimForm.simulationTypeOther"
+                   ng-if="$ctrl.editSimForm.simulationType == 'Other'"
+                   ng-required="true"
+            >
           </div>
         </div>
         <!-- Edit Simulation Description -->

--- a/designsafe/static/scripts/projects/components/manage-simulations/manage-simulations.component.js
+++ b/designsafe/static/scripts/projects/components/manage-simulations/manage-simulations.component.js
@@ -93,13 +93,6 @@ class ManageSimulationCtrl {
         this.data.busy = true;
         this.form.addSimulation[0].authors = this.data.users;
         var simulation = this.form.addSimulation[0];
-        if (_.isEmpty(simulation.title) || typeof simulation.title === 'undefined' ||
-            _.isEmpty(simulation.simulationType) || typeof simulation.simulationType === 'undefined') {
-            this.data.error = 'Title and Type are required.';
-            this.data.busy = false;
-            return;
-        }
-        simulation.description = simulation.description || '';
         this.ProjectEntitiesService.create({
             data: {
                 uuid: this.data.project.uuid,
@@ -260,6 +253,10 @@ class ManageSimulationCtrl {
         sim.value.description = this.editSimForm.description;
         sim.value.authors = this.editSimForm.authors;
         sim.value.guests = this.editSimForm.guests;
+        sim.value.simulationType = this.editSimForm.simulationType;
+        sim.value.simulationTypeOther = (this.editSimForm.simulationType === 'Other' ?
+            this.editSimForm.simulationTypeOther : ''
+        )
         this.ui.savingEditSim = true;
         this.ProjectEntitiesService.update({
             data: {


### PR DESCRIPTION
## Overview: ##
This should resolve several bugs related to custom inputs on project entities...

1. User supplied inputs for project entities (experiments, simulations and hybrid simulations) should render instead of "Other" in the publication preview.
2. When switching from a custom input to a preset, the custom value should be cleared to prevent issues and it should display a preset.
3. Removed redundant object pruning before posting changes to the backend
4. Revert request queue for creating multiple experiments at once (this never happens and no one will ever need to do this)
5. Refactor some ambiguous code

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2148](https://jira.tacc.utexas.edu/browse/DES-2148)

## Testing Steps: ##
1. Work in an Experimental, Simulation, or Hybrid Simulation project
2. Create an Experiment, Simulation, Hybrid Simulation with custom fields. You should be able to save and edit these fields without issues (some experimental inputs cannot be changed after being created).
3. Check the publication preview area to ensure the custom values appear in the entity's metadata. They should display the custom input and not "Other"

