### PR TITLE
Bug/DES-2149: Make HazMapper link location dynamic.

### DIFF
--- a/designsafe/static/scripts/data-depot/components/projects/_common/hazmapper-maps/hazmapper-maps.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/_common/hazmapper-maps/hazmapper-maps.component.js
@@ -16,7 +16,7 @@ class HazmapperMapsCtrl {
                     map.href = `https://hazmapper.tacc.utexas.edu/staging/project/${map.uuid}`;
                     break;
                 default:
-                    map.href = `http://localhost:4200/project/${map.uuid}`;
+                    map.href = `http://hazmapper.local:4200/project/${map.uuid}`;
             }
         });
 

--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js
@@ -22,7 +22,6 @@ class DataBrowserServicePreviewCtrl {
         //TODO DES-1689: working metadata table and operation buttons
         this.textContent = '';
         this.videoHref = '';
-        this.hazmapperHref = '';
         this.loading = true;
         this.error = false;
 
@@ -58,13 +57,18 @@ class DataBrowserServicePreviewCtrl {
                                 if (isGeoJson) this.renderGeoJson(body);
                             } else if (extension.endsWith('hazmapper')) {
                                 const body = JSON.parse(text);
-                                let uuid = body['uuid'];
-                                if (window.location.origin.includes('designsafeci-dev.tacc.utexas.edu')) {
-                                  this.hazmapperHref = `https://hazmapper.tacc.utexas.edu/staging/project/${uuid}`
-                                } else {
-                                  this.hazmapperHref = `https://hazmapper.tacc.utexas.edu/hazmapper/project/${uuid}`
+                                let hazmapperHref = '';
+                                switch (body.deployment) {
+                                    case 'production':
+                                        hazmapperHref = `https://hazmapper.tacc.utexas.edu/hazmapper/project/${body.uuid}`;
+                                        break;
+                                    case 'staging':
+                                        hazmapperHref = `https://hazmapper.tacc.utexas.edu/staging/project/${body.uuid}`;
+                                        break;
+                                    default:
+                                        hazmapperHref = `http://hazmapper.local:4200/project/${body.uuid}`;
                                 }
-                                window.open(this.hazmapperHref);
+                                window.open(hazmapperHref);
                                 this.close();
                             }
 


### PR DESCRIPTION
## Overview: ##
Make HazMapper map links when opening files more defined and dynamic by utilizing the new `deployment` field in the saved file.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2149](https://jira.tacc.utexas.edu/browse/DES-2149)

## Summary of Changes: ##
Changed handling of the hazmapper file in [data-browser-service-preview.component.js](https://github.com/DesignSafe-CI/portal/blob/cf26bc0a822dbe4696c41d27a8396d16670f5bb6/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-preview/data-browser-service-preview.component.js#L61).

## Testing Steps: ##
1. Try creating a file in https://hazmapper.tacc.utexas.edu/staging/ go to `Manage` (in the left-hand panel) and click `Save`.
2. Click on the file that you saved and ensure that it goes to the staging (because you saved it in staging)
3. Repeat the step above locally:
  - https://github.com/TACC-Cloud/hazmapper
    - `ng serve --host hazmapper.local`
  - https://github.com/TACC-Cloud/geoapi
    - `docker-compose up`
    - `docker exec -it geoapi python3 initdb.py`
  - Go to http://hazmapper.local:4200
4.  Make sure to delete the project locally because the file may linger (it is a uneditable file)

## UI Photos:
N/A

## Notes: ##
Production does not have this yet. So there isn't a way to test it there.
