### PR TITLE
Task/DES-2143 - Fix various bugs and formatting issues related to datepicker

### DIFF
--- a/designsafe/static/scripts/projects/components/manage-experiments/manage-experiments.component.html
+++ b/designsafe/static/scripts/projects/components/manage-experiments/manage-experiments.component.html
@@ -23,7 +23,7 @@
         </div>
       </div>
       <!-- Experiment Date -->
-      <div class="expDate form-group">
+      <div class="form-group">
         <label>
           <span class="pull-left" style="margin-right: 5px">Dates of Experiment</span>
           <span class="label label-danger">Required</span>
@@ -31,46 +31,16 @@
         <p>
           If you only want to enter a single date, fill in the first field.
         </p>
-        <div style="display:flex;">
-          <span class="input-group" style="width:25%;">
-            <input  type="text" 
-                    uib-datepicker-popup="MM-dd-yyyy"
-                    ng-model="$ctrl.form.addExperiments[0].procedureStart"
-                    is-open="isStartOpen"
-                    placeholder="mm-dd-yyyy"
-                    autocomplete="chrome-off"
-                    datepicker-options="dateOptions"
-                    date-disabled="disabled(date, mode)"
-                    ng-required="true"
-                    close-text="Close"
-                    class="form-control">
-            <span class="input-group-btn">
-              <button type="button" class="btn btn-default" ng-click="isStartOpen = !isStartOpen">
-                <i class="glyphicon glyphicon-calendar"></i>
-              </button>
-            </span>
-          </span>
-          <span style="padding:6px;">
-            &#8213;
-          </span>
-          <span class="input-group" style="width:25%;">
-            <input  type="text"
-                    uib-datepicker-popup="MM-dd-yyyy"
-                    ng-model="$ctrl.form.addExperiments[0].procedureEnd"
-                    is-open="isEndOpen"
-                    placeholder="mm-dd-yyyy"
-                    autocomplete="chrome-off"
-                    datepicker-options="dateOptions"
-                    date-disabled="disabled(date, mode)"
-                    ng-required="false"
-                    close-text="Close"
-                    class="form-control">
-            <span class="input-group-btn">
-              <button type="button" class="btn btn-default" ng-click="isEndOpen = !isEndOpen">
-                <i class="glyphicon glyphicon-calendar"></i>
-              </button>
-            </span>
-          </span>
+        <div class="form-group" style="display:flex; width:50%;">
+          <input  class="form-control"
+                  type="date" 
+                  ng-model="$ctrl.form.addExperiments[0].procedureStart"
+                  ng-required="true">
+          <span style="padding:6px;">&#8213;</span>
+          <input  class="form-control"
+                  type="date"
+                  ng-model="$ctrl.form.addExperiments[0].procedureEnd"
+                  ng-required="false">
         </div>
       </div>
       <!-- Experimental Facility -->
@@ -197,7 +167,7 @@
           </div>
         </div>
         <!-- Edit Experiment Date -->
-        <div class="expDate form-group">
+        <div class="form-group">
           <label>
             <span class="pull-left" style="margin-right: 5px">Dates of Experiment</span>
             <span class="label label-danger">Required</span>
@@ -205,46 +175,16 @@
           <p>
             Please confirm your experiment dates for each update. If you only want to enter a single date, fill in the first field.
           </p>
-          <div style="display:flex;">
-            <span class="input-group" style="width:25%;">
-              <input  type="text"
-                      uib-datepicker-popup="MM-dd-yyyy"
-                      ng-model="$ctrl.editExpForm.start"
-                      is-open="isStartOpen"
-                      placeholder="{{$ctrl.editExpForm.start | date:'MM-dd-yyyy'}}"
-                      autocomplete="chrome-off"
-                      datepicker-options="dateOptions"
-                      date-disabled="disabled(date, mode)"
-                      ng-required="true"
-                      close-text="Close"
-                      class="form-control">
-              <span class="input-group-btn">
-                <button type="button" class="btn btn-default" ng-click="isStartOpen = !isStartOpen">
-                  <i class="glyphicon glyphicon-calendar"></i>
-                </button>
-              </span>
-            </span>
-            <span style="padding:6px;">
-              &#8213;
-            </span>
-            <span class="input-group" style="width:25%;">
-              <input  type="text"
-                      uib-datepicker-popup="MM-dd-yyyy"
-                      ng-model="$ctrl.editExpForm.end"
-                      is-open="isEndOpen"
-                      placeholder="{{$ctrl.editExpForm.end ? ($ctrl.editExpForm.end | date:'MM-dd-yyyy') : 'mm-dd-yyyy'}}"
-                      autocomplete="chrome-off"
-                      datepicker-options="dateOptions"
-                      date-disabled="disabled(date, mode)"
-                      ng-required="false"
-                      close-text="Close"
-                      class="form-control">
-              <span class="input-group-btn">
-                <button type="button" class="btn btn-default" ng-click="isEndOpen = !isEndOpen">
-                  <i class="glyphicon glyphicon-calendar"></i>
-                </button>
-              </span>
-            </span>
+          <div class="form-group" style="display:flex; width:50%;">
+            <input  class="form-control"
+                    type="date" 
+                    ng-model="$ctrl.editExpForm.start"
+                    ng-required="true">
+            <span style="padding:6px;">&#8213;</span>
+            <input  class="form-control"
+                    type="date"
+                    ng-model="$ctrl.editExpForm.end"
+                    ng-required="false">
           </div>
         </div>
         <!-- Edit Experimental Facility -->

--- a/designsafe/static/scripts/projects/components/manage-experiments/manage-experiments.component.js
+++ b/designsafe/static/scripts/projects/components/manage-experiments/manage-experiments.component.js
@@ -196,9 +196,7 @@ class ManageExperimentsCtrl {
         let auths = this.configureAuthors(exp);
         document.getElementById('modal-header').scrollIntoView({ behavior: 'smooth' });
 
-        if (exp.value.procedureEnd &&
-            exp.value.procedureEnd !== 'None' &&
-            exp.value.procedureEnd !== exp.value.procedureStart) {
+        if (exp.value.procedureEnd && exp.value.procedureEnd !== exp.value.procedureStart) {
                 exp.value.procedureEnd = new Date(exp.value.procedureEnd);
         } else {
             exp.value.procedureEnd = '';

--- a/designsafe/static/scripts/projects/components/manage-field-recon/collections/manage-field-recon-collections.component.html
+++ b/designsafe/static/scripts/projects/components/manage-field-recon/collections/manage-field-recon-collections.component.html
@@ -8,7 +8,7 @@
 </div>
 <div class="modal-body">
     <div class="well">
-        <ng-form name="addForm" data-ng-hide="$ctrl.ui.showEditCollectionForm" autocomplete="off">
+        <form name="addForm" data-ng-hide="$ctrl.ui.showEditCollectionForm" autocomplete="off">
             <div class="collection-type form-group">
                 <div style="padding-bottom: 10px;">
                     <label for="id-type">
@@ -195,50 +195,16 @@
                             </span>
                         </div>
                     </label>
-                    <div style="display: flex;">
-                        <input type="text"
-                            id="id-date-start"
-                            data-uib-datepicker-popup="MM-dd-yyyy"
-                            data-ng-model="$ctrl.form.dateStart"
-                            data-is-open="isStartOpen"
-                            placeholder="mm-dd-yyyy"
-                            autocomplete="chrome-off"
-                            data-date-picker-options="dateOptions"
-                            data-date-disabled="disabled(date, mode)"
-                            data-ng-required="true"
-                            data-close-text="Close"
-                            class="form-control"
-                            style="width: 25%; display:inline-block;" />
-                        <span class="input-group-btn">
-                            <button type="button"
-                                    class="btn btn-default"
-                                    data-ng-click="isStartOpen = !isStartOpen">
-                                <i class="glyphicon glyphicon-calendar"></i>
-                            </button>
-                        </span>
-                        <span style="padding:6px; margin-left:30px;">
-                            &#8213;
-                        </span>
-                        <input type="text"
-                            id="id-date-end"
-                            data-uib-datepicker-popup="MM-dd-yyyy"
-                            data-ng-model="$ctrl.form.dateEnd"
-                            data-is-open="isEndOpen"
-                            placeholder="mm-dd-yyyy"
-                            autocomplete="chrome-off"
-                            data-date-picker-options="dateOptions"
-                            data-date-disabled="disabled(date, mode)"
-                            data-ng-required="false"
-                            data-close-text="Close"
-                            class="form-control"
-                            style="width: 25%; display:inline-block;" />
-                        <span class="input-group-btn">
-                            <button type="button"
-                                    class="btn btn-default"
-                                    data-ng-click="isEndOpen = !isEndOpen">
-                                <i class="glyphicon glyphicon-calendar"></i>
-                            </button>
-                        </span>
+                    <div style="display:flex; width:50%;">
+                        <input  class="form-control"
+                                type="date"
+                                ng-model="$ctrl.form.dateStart"
+                                ng-required="true">
+                        <span style="padding:6px;">&#8213;</span>
+                        <input  class="form-control"
+                                type="date"
+                                ng-model="$ctrl.form.dateEnd"
+                                ng-required="false">
                     </div>
                 </div>
                 <div class="data-collectors form-group">

--- a/designsafe/static/scripts/projects/components/manage-field-recon/collections/manage-field-recon-collections.component.js
+++ b/designsafe/static/scripts/projects/components/manage-field-recon/collections/manage-field-recon-collections.component.js
@@ -324,8 +324,7 @@ class ManageFieldReconCollectionsCtrl {
                 sampleApproach: this.form.sampleApproach.filter(sample => sample != null),
                 sampleSize: this.form.sampleSize || '',
                 dateStart: this.form.dateStart,
-                // dateEnd: this.form.dateEnd,
-                dateEnd: (this.form.dateEnd ? this.form.dateEnd : this.form.dateStart),
+                dateEnd: this.form.dateEnd,
                 dataCollectors: this.form.dataCollectors,
                 location: this.form.location,
                 latitude: this.form.latitude,
@@ -359,8 +358,7 @@ class ManageFieldReconCollectionsCtrl {
                     })
                     .filter(input => input),
                 dateStart: this.form.dateStart,
-                // dateEnd: this.form.dateEnd,
-                dateEnd: (this.form.dateEnd ? this.form.dateEnd : this.form.dateStart),
+                dateEnd: this.form.dateEnd,
                 dataCollectors: this.form.dataCollectors,
                 location: this.form.location,
                 latitude: this.form.latitude,
@@ -383,6 +381,11 @@ class ManageFieldReconCollectionsCtrl {
                 description: this.form.description,
             },
         }
+        if ('dateEnd' in collection[type]) {
+            if (isNaN(Date.parse(collection[type].dateEnd))) {
+                collection[type].dateEnd = new Date(collection[type].dateStart);
+            }
+        }
         return collection[type];
     }
 
@@ -401,7 +404,7 @@ class ManageFieldReconCollectionsCtrl {
             }
         }).then( (res) => {
             this.data.project.addEntity(res);
-            // this.data.collections = this.project.collection_set;
+            // this.data.collections = this.project.collection_set; // unsupported collection
             this.data.socialScienceCollections = this.project.socialscience_set;
             this.data.planningCollections = this.project.planning_set;
             this.data.geoscienceCollections = this.project.geoscience_set;
@@ -417,13 +420,9 @@ class ManageFieldReconCollectionsCtrl {
     editCollection(collection) {
         document.getElementById('modal-header').scrollIntoView({ behavior: 'smooth' });
         this.data.editCollection = Object.assign({}, collection);
-
-        if (this.data.editCollection.value.dateEnd && this.data.editCollection.value.dateEnd !== 'None') {
-            if (this.data.editCollection.value.dateEnd === this.data.editCollection.value.dateStart) {
-                this.data.editCollection.value.dateEnd = '';
-            } else {
+        if (this.data.editCollection.value.dateEnd &&
+            this.data.editCollection.value.dateEnd !== this.data.editCollection.value.dateStart) {
                 this.data.editCollection.value.dateEnd = new Date(this.data.editCollection.value.dateEnd);
-            }
         } else {
             this.data.editCollection.value.dateEnd = '';
         }
@@ -515,7 +514,7 @@ class ManageFieldReconCollectionsCtrl {
         }
         if (['designsafe.project.field_recon.social_science', 'designsafe.project.field_recon.geoscience'].includes(this.form.collectionType)) {
             this.data.editCollection.value.dateStart = this.form.dateStart;
-            this.data.editCollection.value.dateEnd = (this.form.dateEnd ? this.form.dateEnd : this.form.dateStart);
+            this.data.editCollection.value.dateEnd = this.form.dateEnd;
             this.data.editCollection.value.location = this.form.location;
             this.data.editCollection.value.longitude = this.form.longitude;
             this.data.editCollection.value.latitude = this.form.latitude;
@@ -527,6 +526,9 @@ class ManageFieldReconCollectionsCtrl {
                 return type;
             })
             .filter(input => input);
+            if (isNaN(Date.parse(this.data.editCollection.value.dateEnd))) {
+                this.data.editCollection.value.dateEnd = new Date(this.data.editCollection.value.dateStart);
+            }
         }
         if (['designsafe.project.field_recon.report'].includes(this.form.collectionType)) {
             this.data.editCollection.value.authors = this.form.dataCollectors;

--- a/designsafe/static/scripts/projects/components/manage-field-recon/missions/manage-field-recon-missions.component.html
+++ b/designsafe/static/scripts/projects/components/manage-field-recon/missions/manage-field-recon-missions.component.html
@@ -46,7 +46,7 @@
                        data-ng-model="$ctrl.form.event"
                        class="form-control"/>
             </div>
-            <div class="expDate form-group">
+            <div class="form-group">
                 <label for="id-date-start">
                     <div style="display: flex; flex-direction: column">
                         <div>
@@ -59,47 +59,16 @@
                         </span>
                     </div>
                 </label>
-                <div style="display: flex;">
-                    <input type="text"
-                           id="id-date-start"
-                           data-uib-datepicker-popup="MM-dd-yyyy"
-                           data-ng-model="$ctrl.form.dateStart"
-                           data-is-open="isStartOpen"
-                           placeholder="mm-dd-yyyy"
-                           data-date-picker-options="dateOptions"
-                           data-date-disabled="disabled(date, mode)"
-                           data-ng-required="true"
-                           data-close-text="Close"
-                           class="form-control"
-                           style="width: 25%; display:inline-block;" />
-                    <span class="input-group-btn">
-                        <button type="button"
-                                class="btn btn-default"
-                                data-ng-click="isStartOpen = !isStartOpen">
-                            <i class="glyphicon glyphicon-calendar"></i>
-                        </button>
-                    </span>
-                    <span style="padding:6px; margin-left:30px;">
-                        &#8213;
-                    </span>
-                    <input type="text"
-                           id="id-date-end"
-                           data-uib-datepicker-popup="MM-dd-yyyy"
-                           data-ng-model="$ctrl.form.dateEnd"
-                           data-is-open="isEndOpen"
-                           placeholder="mm-dd-yyyy"
-                           data-date-picker-options="dateOptions"
-                           data-date-disabled="disabled(date, mode)"
-                           data-close-text="Close"
-                           class="form-control"
-                           style="width: 25%; display:inline-block;" />
-                    <span class="input-group-btn">
-                        <button type="button"
-                                class="btn btn-default"
-                                data-ng-click="isEndOpen = !isEndOpen">
-                            <i class="glyphicon glyphicon-calendar"></i>
-                        </button>
-                    </span>
+                <div style="display:flex; width:50%;">
+                    <input  class="form-control"
+                            type="date"
+                            ng-model="$ctrl.form.dateStart"
+                            ng-required="true">
+                    <span style="padding:6px;">&#8213;</span>
+                    <input  class="form-control"
+                            type="date"
+                            ng-model="$ctrl.form.dateEnd"
+                            ng-required="false">
                 </div>
             </div>
             <div class="expAuthors form-group">
@@ -258,7 +227,7 @@
                                 <div class="entity-meta-label">Date of Mission</div>
                                 <div class="entity-meta-data">
                                     <span>{{mission.value.dateStart | date:'MM-dd-yyyy'}}</span>
-                                    <span data-ng-if="mission.value.dateEnd && mission.value.dateEnd !== mission.calue.dateStart">
+                                    <span ng-if="mission.value.dateEnd && mission.value.dateEnd !== mission.value.dateStart">
                                         &#8213; {{mission.value.dateEnd | date:'MM-dd-yyyy' }}
                                     </span>
                                 </div>

--- a/designsafe/static/scripts/projects/components/manage-field-recon/missions/manage-field-recon-missions.component.js
+++ b/designsafe/static/scripts/projects/components/manage-field-recon/missions/manage-field-recon-missions.component.js
@@ -223,13 +223,17 @@ class ManageFieldReconMissionsCtrl {
             title: this.form.title,
             event: this.form.event,
             dateStart: this.form.dateStart,
-            dateEnd: (this.form.dateEnd ? this.form.dateEnd : this.form.dateStart),
+            dateEnd: this.form.dateEnd,
             authors: this.form.authors,
             location: this.form.location,
             longitude: this.form.longitude,
             latitude: this.form.latitude,
             description: this.form.description
         };
+
+        if (isNaN(Date.parse(mission.dateEnd))) {
+            mission.dateEnd = new Date(mission.dateStart);
+        }
 
         this.ProjectEntitiesService.create({
             data: {
@@ -251,12 +255,9 @@ class ManageFieldReconMissionsCtrl {
     editMission(mission) {
         document.getElementById('modal-header').scrollIntoView({ behavior: 'smooth' });
         this.data.editMission = Object.assign({}, mission);
-        if (this.data.editMission.value.dateEnd && this.data.editMission.value.dateEnd !== 'None') {
-            if (this.data.editMission.value.dateEnd === this.data.editMission.value.dateStart) {
-                this.data.editMission.value.dateEnd = '';
-            } else {
+        if (this.data.editMission.value.dateEnd &&
+            this.data.editMission.value.dateEnd !== this.data.editMission.value.dateStart) {
                 this.data.editMission.value.dateEnd = new Date(this.data.editMission.value.dateEnd);
-            }
         } else {
             this.data.editMission.value.dateEnd = '';
         }
@@ -285,11 +286,16 @@ class ManageFieldReconMissionsCtrl {
         this.data.editMission.value.title = this.form.title;
         this.data.editMission.value.event = (this.form.event ? this.form.event : '');
         this.data.editMission.value.dateStart = this.form.dateStart;
-        this.data.editMission.value.dateEnd = (this.form.dateEnd ? this.form.dateEnd : this.form.dateStart);
+        this.data.editMission.value.dateEnd = this.form.dateEnd;
         this.data.editMission.value.location = this.form.location;
         this.data.editMission.value.longitude = this.form.longitude;
         this.data.editMission.value.latitude = this.form.latitude;
         this.data.editMission.value.description = this.form.description;
+
+        if (isNaN(Date.parse(this.data.editMission.value.dateEnd))) {
+            this.data.editMission.value.dateEnd = new Date(this.data.editMission.value.dateStart);
+        }
+
         this.ProjectEntitiesService.update({
             data: {
                 uuid: this.data.editMission.uuid,

--- a/designsafe/static/scripts/projects/components/manage-project/amend-project.template.html
+++ b/designsafe/static/scripts/projects/components/manage-project/amend-project.template.html
@@ -238,46 +238,15 @@
                             </span>
                         </label>
                         <div style="display:flex;">
-                            <span class="input-group" style="width:45%;">
-                            <input  class="project-form-input"
-                                    type="text" 
-                                    uib-datepicker-popup="MM-dd-yyyy"
+                            <input  class="form-control"
+                                    type="date"
                                     ng-model="$ctrl.form.nhEventStart"
-                                    is-open="isStartOpen"
-                                    placeholder="mm-dd-yyyy"
-                                    autocomplete="chrome-off"
-                                    datepicker-options="dateOptions"
-                                    date-disabled="disabled(date, mode)"
-                                    ng-required="true"
-                                    close-text="Close"
-                                    class="form-control">
-                            <span class="input-group-btn">
-                                <button type="button" class="btn btn-default" ng-click="isStartOpen = !isStartOpen">
-                                <i class="glyphicon glyphicon-calendar"></i>
-                                </button>
-                            </span>
-                            </span>
-                            <span style="padding:6px;">
-                            &#8213;
-                            </span>
-                            <span class="input-group" style="width:45%;">
-                            <input  type="text"
-                                    uib-datepicker-popup="MM-dd-yyyy"
+                                    ng-required="true">
+                            <span style="padding:6px;">&#8213;</span>
+                            <input  class="form-control"
+                                    type="date"
                                     ng-model="$ctrl.form.nhEventEnd"
-                                    is-open="isEndOpen"
-                                    placeholder="mm-dd-yyyy"
-                                    autocomplete="chrome-off"
-                                    datepicker-options="dateOptions"
-                                    date-disabled="disabled(date, mode)"
-                                    ng-required="false"
-                                    close-text="Close"
-                                    class="form-control">
-                            <span class="input-group-btn">
-                                <button type="button" class="btn btn-default" ng-click="isEndOpen = !isEndOpen">
-                                <i class="glyphicon glyphicon-calendar"></i>
-                                </button>
-                            </span>
-                            </span>
+                                    ng-required="false">
                         </div>
                     </div>
                 </div>

--- a/designsafe/static/scripts/projects/components/manage-project/manage-project.component.js
+++ b/designsafe/static/scripts/projects/components/manage-project/manage-project.component.js
@@ -43,6 +43,9 @@ class ManageProjectCtrl {
                     : this.form[field] = this.project.value[field])
                 }
             }
+            if (Date.parse(this.form.nhEventStart) == Date.parse(this.form.nhEventEnd)) {
+                this.form.nhEventEnd = null;
+            }
             const usernames = new Set([
                 ...[this.project.value.pi],
                 ...this.project.value.coPis,
@@ -175,6 +178,9 @@ class ManageProjectCtrl {
             projectData.nhTypes = this.form.nhTypes.filter(type => typeof type === 'string' && type.length);
             if (projectData.projectType === 'field_recon') {
                 projectData.frTypes = this.form.frTypes.filter(type => typeof type === 'string' && type.length);
+                if (isNaN(Date.parse(projectData.nhEventEnd))) {
+                    projectData.nhEventEnd = new Date(projectData.nhEventStart);
+                }
             }
         }
         return projectData;

--- a/designsafe/static/scripts/projects/components/manage-project/manage-project.template.html
+++ b/designsafe/static/scripts/projects/components/manage-project/manage-project.template.html
@@ -550,46 +550,15 @@
                                 </span>
                             </label>
                             <div style="display:flex;">
-                                <span class="input-group" style="width:45%;">
-                                <input  class="project-form-input"
-                                        type="text" 
-                                        uib-datepicker-popup="MM-dd-yyyy"
+                                <input  class="form-control"
+                                        type="date"
                                         ng-model="$ctrl.form.nhEventStart"
-                                        is-open="isStartOpen"
-                                        placeholder="mm-dd-yyyy"
-                                        autocomplete="chrome-off"
-                                        datepicker-options="dateOptions"
-                                        date-disabled="disabled(date, mode)"
-                                        ng-required="true"
-                                        close-text="Close"
-                                        class="form-control">
-                                <span class="input-group-btn">
-                                    <button type="button" class="btn btn-default" ng-click="isStartOpen = !isStartOpen">
-                                    <i class="glyphicon glyphicon-calendar"></i>
-                                    </button>
-                                </span>
-                                </span>
-                                <span style="padding:6px;">
-                                &#8213;
-                                </span>
-                                <span class="input-group" style="width:45%;">
-                                <input  type="text"
-                                        uib-datepicker-popup="MM-dd-yyyy"
+                                        ng-required="true">
+                                <span style="padding:6px;">&#8213;</span>
+                                <input  class="form-control"
+                                        type="date"
                                         ng-model="$ctrl.form.nhEventEnd"
-                                        is-open="isEndOpen"
-                                        placeholder="mm-dd-yyyy"
-                                        autocomplete="chrome-off"
-                                        datepicker-options="dateOptions"
-                                        date-disabled="disabled(date, mode)"
-                                        ng-required="false"
-                                        close-text="Close"
-                                        class="form-control">
-                                <span class="input-group-btn">
-                                    <button type="button" class="btn btn-default" ng-click="isEndOpen = !isEndOpen">
-                                    <i class="glyphicon glyphicon-calendar"></i>
-                                    </button>
-                                </span>
-                                </span>
+                                        ng-required="false">
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Overview: ##
Removed the overly complicated bootstrap datepicker from the projects area (Note: I have not removed the dependency yet, because this PR is getting a bit big). I will push up a separate issue for dropping bootstrap datepicker as a dependency.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2143](https://jira.tacc.utexas.edu/browse/DES-2143)

## Summary of Changes: ##
The date input boxes for the `manage-project`, `manage-experiments`, `manage-collections`, and `manage-missions` components have been revised.
1. Fixed an issue related to the project date which would cause the publication process to fail.
2. Fixed a bug preventing the form from notifying the user when a date was not supplied when required (by removing bootstrap datepicker)
3. Fixed a bug where editing an entity with only one date would render incorrectly (two dates would be displayed)
4. Fixed a bug preventing form notifications from appearing on the `manage-collections` component.
5. Fixed a bug where autofilled date inputs could be supplied in the incorrect format causing them to fail without notification.
6. Fixed various typos and formatting issues 

## Testing Steps: ##
The following modals have date input changes:
1. `manage-project`
2. `manage-experiments`
3. `manage-collections`
4. `manage-missions`

Go to an Experimental or Field Research project and play around with creating, editing project data related to the date inputs. You should see notifications and such if the field is empty (just not the end date because that's not required)

