### PR TITLE
bug/DES-2188: handle plugin exceptions in the CMS indexer

### DIFF
--- a/designsafe/apps/search/search_indexes.py
+++ b/designsafe/apps/search/search_indexes.py
@@ -61,7 +61,11 @@ class TextPluginIndex(indexes.SearchIndex, indexes.Indexable):
         plugins = CMSPlugin.objects.filter(placeholder__in=obj.page.placeholders.all())
         text = ''
         for base_plugin in plugins:
-            instance, plugin_type = base_plugin.get_plugin_instance()
+            try:
+                instance, plugin_type = base_plugin.get_plugin_instance()
+            except Exception as e:
+                logger.debug(f"{type(e)}: {e}")
+                continue
             if instance is None:
                 # this is an empty plugin
                 continue

--- a/designsafe/apps/search/tasks.py
+++ b/designsafe/apps/search/tasks.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 def update_search_index():
     logger.info("Updating search index")
     if not settings.DEBUG:
-        call_command("update_index", interactive=False)
+        call_command("rebuild_index", interactive=False)
 
 @shared_task(bind=True)
 def index_community_data(self):


### PR DESCRIPTION
## Overview: ##
There seems to be a CMS plugin that can't be serialized for indexing. Because this only affects 1 page so far we should ignore it for now so we can keep the rest of the index up to date.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2188](https://jira.tacc.utexas.edu/browse/DES-2188)

## Summary of Changes: ##
- Handle a plugin serialization exception that was preventing the index from being updated
- replace the `update_index` command with `rebuild_index` in our crontab. I noticed that `update_index` wasn't picking up new content in my local environment.

## Testing Steps: ##
1. Load a recent production database dump into your local environment
2. in the container shell run `python manage.py rebuild_index`


