### PR TITLE
task/DES-2111: Add ds-use-case docs container

### DIFF
--- a/conf/deploy/docker-compose.all.yml
+++ b/conf/deploy/docker-compose.all.yml
@@ -15,6 +15,9 @@ services:
       - /etc/ssl/dhparam.pem:/etc/ssl/dhparam.pem
       - /srv/www/designsafe/static:/srv/www/designsafe/static
       - /srv/www/designsafe/media:/srv/www/designsafe/media
+      - /srv/www/designsafe/cms/static:/var/www/portal/cms/static
+      - /var/www/portal/cms/media:/var/www/portal/cms/media
+      - /srv/www/designsafe/ds-use-case:/srv/www/designsafe/ds-use-case
     ports:
       - 80:80
       - 443:443
@@ -25,7 +28,7 @@ services:
         tag: designsafe_nginx
     labels:
       com.centurylinklabs.watchtower.enable: true
-      com.centurylinklabs.watchtower.depends-on: "designsafe_django"
+      com.centurylinklabs.watchtower.depends-on: "designsafe_django, designsafe_docs"
     links:
       - "django"
       - "websocket"
@@ -115,8 +118,24 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
     restart: always
 
+  docs:
+    image: designsafeci/ds-use-case-template:latest
+    volumes:
+      - /srv/www/designsafe/ds-use-case:/docs/site
+    command: ["mkdocs", "build"]
+    container_name: designsafe_use_case
+    logging:
+      driver: syslog
+      options:
+        tag: designsafe_use_case
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+
   watchtower:
     image: containrrr/watchtower
+    environment:
+      - WATCHTOWER_INCLUDE_STOPPED=true
+      - WATCHTOWER_REVIVE_STOPPED=true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     command: --interval 30 --label-enable --cleanup --enable-lifecycle-hooks

--- a/conf/deploy/docker-compose.all.yml
+++ b/conf/deploy/docker-compose.all.yml
@@ -26,10 +26,7 @@ services:
         tag: designsafe_nginx
     labels:
       com.centurylinklabs.watchtower.enable: true
-      com.centurylinklabs.watchtower.depends-on: "designsafe_django, designsafe_use_case"
-    links:
-      - "django"
-      - "websocket"
+      com.centurylinklabs.watchtower.depends-on: "designsafe_django,designsafe_websocket,designsafe_use_case"
     restart: always
 
   websocket:

--- a/conf/deploy/docker-compose.all.yml
+++ b/conf/deploy/docker-compose.all.yml
@@ -26,7 +26,7 @@ services:
         tag: designsafe_nginx
     labels:
       com.centurylinklabs.watchtower.enable: true
-      com.centurylinklabs.watchtower.depends-on: "designsafe_django, designsafe_docs"
+      com.centurylinklabs.watchtower.depends-on: "designsafe_django, designsafe_use_case"
     links:
       - "django"
       - "websocket"

--- a/conf/deploy/docker-compose.all.yml
+++ b/conf/deploy/docker-compose.all.yml
@@ -15,8 +15,6 @@ services:
       - /etc/ssl/dhparam.pem:/etc/ssl/dhparam.pem
       - /srv/www/designsafe/static:/srv/www/designsafe/static
       - /srv/www/designsafe/media:/srv/www/designsafe/media
-      - /srv/www/designsafe/cms/static:/var/www/portal/cms/static
-      - /var/www/portal/cms/media:/var/www/portal/cms/media
       - /srv/www/designsafe/ds-use-case:/srv/www/designsafe/ds-use-case
     ports:
       - 80:80

--- a/conf/deploy/nginx.conf
+++ b/conf/deploy/nginx.conf
@@ -73,14 +73,18 @@ http {
             alias /srv/www/designsafe/robots.txt;
         }
 
+        location /ds-use-case {
+            alias /srv/www/designsafe/ds-use-case;
+        }
+
         location / {
-                proxy_pass http://django:8000;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header Host $host;
-                proxy_redirect off;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_set_header X-Django-Proxy "true";
+            proxy_pass http://django:8000;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $host;
+            proxy_redirect off;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Django-Proxy "true";
         }
 
         location /ws/ {


### PR DESCRIPTION
## Overview: ##

- Adds `designsafe_use_case` container, with watchtower enabled look for updates to `designsafeci/ds-use-case-template`
- Adds flags `WATCHTOWER_INCLUDE_STOPPED` and `WATCHTOWER_REVIVE_STOPPED` to enable watchtower for the stopped `designsafe_use_case` container, as it exits after build

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2111](https://jira.tacc.utexas.edu/browse/DES-2111)
