### PR TITLE
Bug/DES-2205 - Fix limit and offset for file metadata query

### DIFF
--- a/designsafe/apps/api/datafiles/utils.py
+++ b/designsafe/apps/api/datafiles/utils.py
@@ -59,12 +59,10 @@ def query_file_meta(system, path):
     offset = 0
 
     while True:
-        # Need to find out what the hard limit is on this... Steve T mentioned it might
-        # be related to the byte size of the response object.
-        result = sa_client.meta.listMetadata(q=json.dumps(query), limit=500, offset=offset)
+        result = sa_client.meta.listMetadata(q=json.dumps(query), limit=300, offset=offset)
         all_results = all_results + result
-        offset += 500
-        if len(result) != 500:
+        offset += 300
+        if len(result) != 300:
             break
     
     return all_results


### PR DESCRIPTION
## Overview: ##
The limit and offset for the file metadata query was set incorrectly. This should fix issues related to the iterative retrieval of file metadata in large quantities.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2205](https://jira.tacc.utexas.edu/browse/DES-2205)

## Testing Steps: ##
1. Open a shell within the Django container and try to make a large metadata query.

```
    import json
    from designsafe.apps.api.agave import service_account

    sa_client = service_account()
    query = {
        "name": "designsafe.file", # this can be something like 'designsafe.project' too
    }
    
    all_results = []
    offset = 0

    while True:
        result = sa_client.meta.listMetadata(q=json.dumps(query), limit=300, offset=offset)
        all_results = all_results + result
        offset += 300
        if len(result) != 300:
            break
    
    print(len(all_results))
```

