### PR TITLE
Task/DES-2150 - DOI Tombstone Page

### DIFF
--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
@@ -333,7 +333,17 @@
                             <div class="entity-meta-field" ng-if="mission.value.description">
                                 <p>{{ mission.value.description }}</p>
                             </div>
+                            <!-- Tombstone Banner -->
+                            <div class="alert alert-warning flex-container" ng-if="$ctrl.ui.tombstone">
+                                <i class="fa fa-warning notification-icon"></i>
+                                <div>
+                                    <strong>The following Dataset does not exist anymore</strong><br>
+                                    The Dataset with DOI:
+                                    <a href="https://doi.org/{{mission.value.dois[0]}}">{{mission.value.dois[0]}}</a>
+                                    was incomplete and removed. The metadata is still available.
+                                </div>
                             </div>
+                        </div>
                         <files-listing show-select="true" show-tags="true"
                         on-scroll="$ctrl.scrollToBottom()"
                         listing="$ctrl.FileListingService.listings[mission.uuid]"
@@ -461,6 +471,16 @@
                             <p>
                                 <br>{{ mission.value.description }}
                             </p>
+                            <!-- Tombstone Banner -->
+                            <div class="alert alert-warning flex-container" ng-if="$ctrl.ui.tombstone">
+                                <i class="fa fa-warning notification-icon"></i>
+                                <div>
+                                    <strong>The following Dataset does not exist anymore</strong><br>
+                                    The Dataset with DOI:
+                                    <a href="https://doi.org/{{mission.value.dois[0]}}">{{mission.value.dois[0]}}</a>
+                                    was incomplete and removed. The metadata is still available.
+                                </div>
+                            </div>
                             <!-- Old Collections -->
                             <div ng-repeat="collection in $ctrl.browser.project.collection_set | orderBy: 'value.title'" ng-if="$ctrl.matchingGroup(mission, collection)">
                                 <div class="dropdown dropdown-spacer-sm" id="details-{{collection.uuid}}">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
@@ -311,22 +311,31 @@
                             </div>
                         </div>
                         <div class="entity-meta-field">
-                                <div class="entity-meta-label">Data Reuse</div>
-                                <span ng-if="$ctrl.readOnly">
-                                    <a ng-click="$ctrl.entityMetrics(hybsim.doi, 'Hybrid Simulation')">
+                            <div class="entity-meta-label">Data Reuse</div>
+                            <span ng-if="$ctrl.readOnly">
+                                <a ng-click="$ctrl.entityMetrics(hybsim.doi, 'Hybrid Simulation')">
                                     &nbsp;<img src='/static/images/ds-icons/icon-metrics.svg' style="height: 12px;">
                                     <strong>&nbsp;View Hybrid Simulation Metrics</strong>
-                                    </a>
-                                </span>
-                                <div class="entity-meta-data" ng-if="!$ctrl.readOnly">
-                                    <span>(Appears when published)</span>
-                                </div>
-                                </div>
+                                </a>
+                            </span>
+                            <div class="entity-meta-data" ng-if="!$ctrl.readOnly">
+                                <span>(Appears when published)</span>
                             </div>
+                        </div>
+                        <p>
+                            <br>{{ hybsim.value.description }}
+                        </p>
+                        <!-- Tombstone Banner -->
+                        <div class="alert alert-warning flex-container" ng-if="$ctrl.ui.tombstone">
+                            <i class="fa fa-warning notification-icon"></i>
+                            <div>
+                                <strong>The following Dataset does not exist anymore</strong><br>
+                                The Dataset with DOI:
+                                <a href="https://doi.org/{{hybsim.value.dois[0]}}">{{hybsim.value.dois[0]}}</a>
+                                was incomplete and removed. The metadata is still available.
+                            </div>
+                        </div>
                     </div>
-                    <p>
-                        <br>{{ hybsim.value.description }}
-                    </p>
                     <div>
                         <!-- Hybrid Reports -->
                         <div ng-repeat="report in $ctrl.browser.project.report_set | orderBy: 'value.title'"

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.html
@@ -164,6 +164,16 @@
                 </show-more>
             </p>
         </div>
+        <!-- Tombstone Banner -->
+        <div class="alert alert-warning flex-container" ng-if="$ctrl.ui.tombstone">
+            <i class="fa fa-warning notification-icon"></i>
+            <div>
+                <strong>The following Dataset does not exist anymore</strong><br>
+                The Dataset with DOI:
+                <a href="https://doi.org/{{$ctrl.publication.project.value.dois[0]}}">{{$ctrl.publication.project.value.dois[0]}}</a>
+                was incomplete and removed. The metadata is still available.
+            </div>
+        </div>
     </div>
     <!-- Project Header End -->
     <table class="tg" style="table-layout: fixed; width: 100%;"

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
@@ -333,6 +333,16 @@
                     <p>
                         <br>{{ simulation.value.description }}
                     </p>
+                    <!-- Tombstone Banner -->
+                    <div class="alert alert-warning flex-container" ng-if="$ctrl.ui.tombstone">
+                        <i class="fa fa-warning notification-icon"></i>
+                        <div>
+                            <strong>The following Dataset does not exist anymore</strong><br>
+                            The Dataset with DOI:
+                            <a href="https://doi.org/{{simulation.value.dois[0]}}">{{simulation.value.dois[0]}}</a>
+                            was incomplete and removed. The metadata is still available.
+                        </div>
+                    </div>
                     <div>
                         <!-- Simulation Reports -->
                         <div ng-repeat="report in $ctrl.browser.project.report_set | orderBy: 'value.title'"

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
@@ -371,6 +371,16 @@
                     <p>
                         <br>{{ experiment.value.description }}
                     </p>
+                    <!-- Tombstone Banner -->
+                    <div class="alert alert-warning flex-container" ng-if="$ctrl.ui.tombstone">
+                        <i class="fa fa-warning notification-icon"></i>
+                        <div>
+                            <strong>The following Dataset does not exist anymore</strong><br>
+                            The Dataset with DOI:
+                            <a href="https://doi.org/{{experiment.value.dois[0]}}">{{experiment.value.dois[0]}}</a>
+                            was incomplete and removed. The metadata is still available.
+                        </div>
+                    </div>
                     <div>
                         <!-- Experiment Reports -->
                         <div ng-repeat="report in $ctrl.browser.project.report_set | orderBy: 'value.title'" ng-if="$ctrl.matchingGroup(experiment, report)">

--- a/designsafe/static/scripts/data-depot/components/published/published-view.component.js
+++ b/designsafe/static/scripts/data-depot/components/published/published-view.component.js
@@ -39,6 +39,7 @@ class PublishedViewCtrl {
             experimentTypes: experimentalData.experimentTypes,
             fileNav: true,
             loading: true,
+            tombstone: false,
         };
         this.browser = {}
         this.browser.listings = {};
@@ -112,6 +113,7 @@ class PublishedViewCtrl {
         //add metadata to header
         this.type = this.browser.publication.project.value.projectType;
         this.prepProject();
+        this.ui.tombstone = this.publication.status === 'tombstone';
         this.ui.loading = false;
     }
 

--- a/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css
+++ b/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css
@@ -2806,6 +2806,13 @@ input[type="search"] {
   display: flex;
   align-items: center;
 }
+.flex-container {
+  display: flex;
+  align-items: center;
+}
+.notification-icon {
+  width:2em;
+}
 .pipeline-header {
   text-align: center;
   margin-bottom: 40px;


### PR DESCRIPTION
## Overview: ##
We will show a banner above published entities and projects when a published DOI is incomplete and abandoned. This banner is triggered when the publication status is set as `tombstone` instead of `published`. 

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2150](https://jira.tacc.utexas.edu/browse/DES-2150)

## Summary of Changes: ##
Published Project templates have been updated with the alert banner.

## Testing Steps: ##
1. Find a publication and change the status of that publication to `tombstone`. You should see the banner appear in the ui and the publication will drop from the published listing. (You can also just set the `ui` parameter to see it)
