### PR TITLE
task/DES-2247: Fix large window app icons

### DIFF
--- a/designsafe/static/styles/ng-designsafe.css
+++ b/designsafe/static/styles/ng-designsafe.css
@@ -871,6 +871,12 @@ font-family: 'DesignSafe-Apps';
     line-height: 1.2;
 }
 
+@media (min-width: 1400px) {
+    .icon-letter {
+        font-size: 6em;
+    }
+}
+
 [class^="icon-"]:before,
 [class*=" icon-"]:before {
     font-family: 'DesignSafe-Apps';


### PR DESCRIPTION
## Overview: ##
Adds max size to app icons.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2247](https://jira.tacc.utexas.edu/browse/DES-2247)

## Testing Steps: ##
1. Open https://designsafe.dev/rw/workspace/ in a large view (over 1400px)
2. Confirm icons do not grow further

## UI Photos:

- Before
  - 
![Screen Shot 2022-04-28 at 5 52 12 PM](https://user-images.githubusercontent.com/20326896/165860762-67de5192-cda9-4345-967a-8878936c2fc1.png)
- After
  - 
![Screen Shot 2022-04-28 at 5 52 00 PM](https://user-images.githubusercontent.com/20326896/165860785-60ca8323-a141-483c-ba13-58c51c698291.png)
