### PR TITLE
task/DES-2248: Allow apps with no metadata record

### DIFF
--- a/designsafe/static/scripts/workspace/components/application-tray/application-tray.component.js
+++ b/designsafe/static/scripts/workspace/components/application-tray/application-tray.component.js
@@ -101,10 +101,15 @@ class AppTrayCtrl {
                                         .parent($('#toast-container')));
                                 }
                             } else {
-                                this.$mdToast.show(this.$mdToast.simple()
-                                    .content(this.$translate.instant('error_app_run'))
-                                    .toastClass('warning')
-                                    .parent($('#toast-container')));
+                                // This app has no metadata, but should be able to be loaded if it exists
+                                this.launchApp({
+                                    value: {
+                                        type: "agave",
+                                        definition: {
+                                            id: appId
+                                        }
+                                    }
+                                })
                             }
                         },
                         (response) => {

--- a/designsafe/static/scripts/workspace/controllers/application-form.js
+++ b/designsafe/static/scripts/workspace/controllers/application-form.js
@@ -92,6 +92,15 @@ export default function ApplicationFormCtrl($scope, $rootScope, $localStorage, $
                         .finally(() => {
                             $scope.resetForm();
                         });
+                }, (err) => {
+                    $scope.data.app = null;
+                    $mdToast.show(
+                        $mdToast
+                            .simple()
+                            .content($translate.instant('error_app_run'))
+                            .toastClass('warning')
+                            .parent($('#toast-container'))
+                    );
                 });
         } else if (app.value.type === 'html') {
             $scope.data.type = app.value.type;


### PR DESCRIPTION
## Overview: ##
Simcenter wants to be able to launch public apps not in public tray. This change makes it more like other portals, where if a valid app id is supplied in the URL, the app will be loaded.

To test, try the public app `quoFEM-frontera-1.0.0u2` which has no metadata record

## PR Status: ##

* [X] Ready.
## Related Jira tickets: ##

* [DES-2248](https://jira.tacc.utexas.edu/browse/DES-2248)

## Testing Steps: ##
1. Go to https://designsafe.dev/rw/workspace/#!/quoFEM-frontera-1.0.0u2
2. Confirm app is loaded

## UI Photos:
![Screen Shot 2022-05-02 at 2 46 25 PM](https://user-images.githubusercontent.com/20326896/166315323-36e0e16e-2f70-4fef-9f2f-165b2f12d296.png)
