### PR TITLE
task/bug-2249: remove SecureMixin from the user lookup view

### DIFF
--- a/designsafe/apps/api/users/views.py
+++ b/designsafe/apps/api/users/views.py
@@ -50,7 +50,7 @@ class AuthenticatedView(View):
         return HttpResponse('Unauthorized', status=401)
 
 
-class SearchView(SecureMixin, View):
+class SearchView(View):
 
     def get(self, request):
         resp_fields = ['first_name', 'last_name', 'email', 'username']

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/modals/author-information-modal.component.js
@@ -8,7 +8,6 @@ class AuthorInformationModalCtrl {
 
     $onInit() {
         this.author = this.resolve.author;
-        console.log(this.author)
         this.first = this.author.fname;
         this.last = this.author.lname;
         this.email = this.author.email;


### PR DESCRIPTION
## Overview: ##
Fix a bug causing ajax requests to the user lookup view to redirect to Tapis Oauth and throw a CORS error.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2249](https://jira.tacc.utexas.edu/browse/DES-2249)

## Summary of Changes: ##

## Testing Steps: ##
1. Navigate to a publication while unauthenticated
2. Click on a user's name in the author list and confirm that the correct name/institution come up.

