### PR TITLE
task/DES-2251: Add `vncserver` to VNC app job names; remove username from user defined `archivePath`

### DIFF
--- a/designsafe/apps/workspace/views.py
+++ b/designsafe/apps/workspace/views.py
@@ -129,10 +129,6 @@ def call_api(request, service):
                         else:
                             archive_path = parsed.path
 
-                        if not archive_path.startswith(request.user.username):
-                            archive_path = '{}/{}'.format(
-                                request.user.username, archive_path)
-
                         job_post['archivePath'] = archive_path
 
                         if parsed.netloc:

--- a/designsafe/static/scripts/workspace/controllers/application-form.js
+++ b/designsafe/static/scripts/workspace/controllers/application-form.js
@@ -209,10 +209,13 @@ export default function ApplicationFormCtrl($scope, $rootScope, $localStorage, $
                 }
             });
 
-            /* To ensure that DCV server is alive, name of job
-            * needs to contain 'dcvserver' */
+            /* To ensure that DCV and VNC server is alive, name of job
+            needs to contain 'dcvserver' or 'vncserver' respectively */
             if ($scope.data.app.tags.includes('DCV')) {
                 jobData.name += '-dcvserver';
+            }
+            if ($scope.data.app.tags.includes('VNC')) {
+                jobData.name += '-vncserver';
             }
 
             // Calculate processorsPerNode if nodeCount parameter submitted


### PR DESCRIPTION
## Overview: ##

- After the TAP Functions updates, VNC server will not be available unless `vncserver` is present in the job name. 
- Allow users to define exactly their own `archivePath`

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2251](https://jira.tacc.utexas.edu/browse/DES-2251)

## Summary of Changes: ##

## Testing Steps: ##
Archive Path:
1. Submit a job with a specific `archivePath`
2. Confirm the job archives to that path, and does not create a subdir with your username

vncserver:
1. Find the private app `Paraview-Stampede2-VNC-5.10.0` in `My Apps`
2. Run the app, and confirm you get a VNC session link