### PR TITLE
task/DES-2253: Set up nightly crontab to clear expired sessions

### DIFF
--- a/designsafe/apps/search/tasks.py
+++ b/designsafe/apps/search/tasks.py
@@ -13,6 +13,14 @@ def update_search_index():
     if not settings.DEBUG:
         call_command("rebuild_index", interactive=False)
 
+
+@shared_task()
+def clear_expired_sessions():
+    logger.info("Clearing expired sessions.")
+    if not settings.DEBUG:
+        call_command("clearsessions", interactive=False)
+
+
 @shared_task(bind=True)
 def index_community_data(self):
     agave_indexer.delay('designsafe.storage.community', paths_to_ignore=['Trash'])

--- a/designsafe/celery.py
+++ b/designsafe/celery.py
@@ -26,6 +26,10 @@ app.conf.update(
             'task': 'designsafe.apps.search.tasks.update_search_index',
             'schedule': crontab(minute=0, hour=0),
         },
+        'clear_expired_sessions': {
+            'task': 'designsafe.apps.search.tasks.clear_expired_sessions',
+            'schedule': crontab(minute=0, hour=0),
+        },
         'reindex_projects': {
             'task': 'designsafe.apps.api.tasks.reindex_projects',
             'schedule': crontab(hour=0, minute=0)


### PR DESCRIPTION
## Overview: ##
Per the Django docs(https://docs.djangoproject.com/en/1.11/topics/http/sessions/#clearing-the-session-store): 

"Django does not provide automatic purging of expired sessions. Therefore, it’s your job to purge expired sessions on a regular basis."

We should set up a simple nightly crontab to do this for us.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2253](https://jira.tacc.utexas.edu/browse/DES-2253)

