### PR TITLE
fix/DES-2251: Change `vncserver` to `tap_`

### DIFF
--- a/designsafe/apps/api/notifications/tests.py
+++ b/designsafe/apps/api/notifications/tests.py
@@ -114,9 +114,8 @@ class TestWebhookViews(TestCase):
 
         self.vnc_event = {
             "event_type": "VNC",
-            "host": "vis.tacc.utexas.edu",
+            "host": "stampede2.tacc.utexas.edu",
             "port": "2234",
-            "address": "vis.tacc.utexas.edu:1234",
             "password": "3373312947011719656-242ac11b-0001-007",
             "owner": "ds_user"
         }
@@ -147,7 +146,7 @@ class TestWebhookViews(TestCase):
     def test_webhook_vnc_post(self):
         self.mock_agave.jobs.get.return_value = self.agave_job_running
 
-        link_from_event = "https://vis.tacc.utexas.edu/no-vnc/vnc.html?hostname=vis.tacc.utexas.edu&port=2234&autoconnect=true&password=3373312947011719656-242ac11b-0001-007"
+        link_from_event = "https://tap.tacc.utexas.edu/noVNC/?host=stampede2.tacc.utexas.edu&port=2234&autoconnect=true&encrypt=true&resize=scale&password=3373312947011719656-242ac11b-0001-007"
 
         response = self.client.post(reverse('interactive_wh_handler'), urlencode(self.vnc_event), content_type='application/x-www-form-urlencoded')
 

--- a/designsafe/apps/notifications/views.py
+++ b/designsafe/apps/notifications/views.py
@@ -54,12 +54,9 @@ def generic_webhook_handler(request):
         if host == 'designsafe-exec-01.tacc.utexas.edu':
             target_uri = 'https://' + address + '&autoconnect=true'
         else:
-            # target_uri = \
-            #     'https://vis.tacc.utexas.edu/no-vnc/vnc.html?' \
-            #     'hostname=%s&port=%s&autoconnect=true&password=%s' % (host, port, password)
             target_uri = \
-                'https://{host}/no-vnc/vnc.html?'\
-                'hostname={host}&port={port}&autoconnect=true&password={pw}' \
+                'https://tap.tacc.utexas.edu/noVNC/?'\
+                'host={host}&port={port}&autoconnect=true&encrypt=true&resize=scale&password={pw}' \
                 .format(host=host, port=port, pw=password)
         event_data = {
             Notification.EVENT_TYPE: event_type,

--- a/designsafe/static/scripts/workspace/controllers/application-form.js
+++ b/designsafe/static/scripts/workspace/controllers/application-form.js
@@ -210,12 +210,12 @@ export default function ApplicationFormCtrl($scope, $rootScope, $localStorage, $
             });
 
             /* To ensure that DCV and VNC server is alive, name of job
-            needs to contain 'dcvserver' or 'vncserver' respectively */
+            needs to contain 'dcvserver' or 'tap_' respectively */
             if ($scope.data.app.tags.includes('DCV')) {
                 jobData.name += '-dcvserver';
             }
             if ($scope.data.app.tags.includes('VNC')) {
-                jobData.name += '-vncserver';
+                jobData.name += 'tap_';
             }
 
             // Calculate processorsPerNode if nodeCount parameter submitted


### PR DESCRIPTION
## Overview: ##
Substring needed is actually `tap_`, not `vncserver`. The tests succeeded in the previous PR because DCV was still launching somehow. That should be fixed in this test.

NOTE: Connection to VNC sessions are still not working, but because of a different issue.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2251](https://jira.tacc.utexas.edu/browse/DES-2251)


## Testing Steps: ##

1. Find the private app Paraview-Stampede2-VNC-5.10.0 in My Apps
2. Run the app, and confirm you get a VNC session link
