### PR TITLE
DES-2258: Registration Page Updates

### DIFF
--- a/designsafe/apps/accounts/templates/designsafe/apps/accounts/password_reset.html
+++ b/designsafe/apps/accounts/templates/designsafe/apps/accounts/password_reset.html
@@ -17,13 +17,6 @@
         <em>as a whole</em>, not just at DesignSafe.
     </div>
 
-    <div class="alert alert-warning">
-      If you have not confirmed your email, <strong>DO NOT</strong> use this form to reset your password.
-      Please confirm your email before using this form.  If you need help or cannot remember if you confirmed your email,
-      please submit a <a href="{% url 'djangoRT:ticketcreate' %}">ticket</a>
-      and we will help you.
-    </div>
-
     <form method="post" action="">
       {% csrf_token %}
 

--- a/designsafe/apps/accounts/templates/designsafe/apps/accounts/register.html
+++ b/designsafe/apps/accounts/templates/designsafe/apps/accounts/register.html
@@ -9,51 +9,25 @@
   <h1 class="headline headline-research">Register an Account</h1>
 
   <div class="row">
-    <div class="col-md-5 col-md-push-7">
-      <div class="callout callout-default">
+    <div class="callout callout-default">
         <p class="text-center">
-          <img style="max-width:300px" alt="TACC" src="{% static 'images/tacc-logo-outline.svg'%}">
+          <img style="max-width:200px" alt="TACC" src="{% static 'images/tacc-logo-outline.svg'%}">
         </p>
-        <h3>
-          Already have an Account? <a href="{% url 'designsafe_auth:login' %}">Log in.</a>
-        </h3>
-        <p>
+        <p class="text-center">
           If you already have a TACC account, simply
           <a href="{% url 'designsafe_auth:agave_oauth' %}">log in</a> with your TACC
           username and password to access DesignSafe.
         </p>
-        <p>
-          You may have a TACC account if you have used XSEDE or TeraGrid in the past and
-          had an allocation on a TACC resource.
-        </p>
-      </div>
-
-      <!-- {% include 'designsafe/apps/accounts/nees_migration_block.html' %} -->
     </div>
-    <div class="col-md-7 col-md-pull-5">
-
-      <p class="lead">
-        Users may register for only one account using the form below. DesignSafe
-        uses the TACC Identity Service, thus you will be registering for a TACC
-        account. Upon submitting this form check your email, possibly your Spam
-        folder, for <b>two</b> email messages with the <b>first</b> email containing a link
-        to confirm your email address and then a <b>second</b> email after we have
-        reviewed and accepted your request which will have a link to activate your new account.
-      </p>
-
-      <form method="post" action="">
-        {% csrf_token %}
-        {% bootstrap_form account_form %}
-        <button class="btn btn-primary" type="submit">Register Account</button>
-        <a class="btn btn-link" href="/">Cancel</a>
-        <a class="btn btn-link" href="{% url 'login' %}">Already have an account? Log in.</a>
-      </form>
-
+    <div>
+        <h3 class="text-center">
+            If you do not have an account, please use the
+            <a href="https://portal.tacc.utexas.edu/account-request">TACC User Registration form</a>
+            to request an account.
+            Once your account has been approved, you will then be able to log into Designsafe.
+          </h3>
     </div>
   </div>
 
 </div>
-{% addtoblock 'js' %}
-<script type="text/javascript" src="{% static 'designsafe/apps/accounts/js/new_institution.js' %}"></script>
-{% endaddtoblock %}
 {% endblock %}

--- a/designsafe/apps/accounts/urls.py
+++ b/designsafe/apps/accounts/urls.py
@@ -14,7 +14,6 @@ urlpatterns = [
     url(r'^notifications/settings/$', views.manage_notifications, name='manage_notifications'),
     url(r'^register/$', views.register, name='register'),
     url(r'^nees-account/(?:(?P<step>\d+)/)?$', views.nees_migration, name='nees_migration'),
-    url(r'^registration-successful/$', views.registration_successful, name='registration_successful'),
     url(r'^password-reset/(?:(?P<code>.+)/)?$', views.password_reset, name='password_reset'),
     url(r'^activate/(?:(?P<code>.+)/)?$', views.email_confirmation, name='email_confirmation'),
 

--- a/designsafe/apps/accounts/views.py
+++ b/designsafe/apps/accounts/views.py
@@ -257,67 +257,8 @@ def nees_migration(request, step=None):
                           {'form': form})
     return HttpResponseRedirect(reverse('designsafe_accounts:nees_migration'))
 
-
 def register(request):
-    if request.user.is_authenticated():
-        messages.info(request, 'You are already logged in!')
-        return HttpResponseRedirect('designsafe_accounts:index')
-
-    if request.method == 'POST':
-        account_form = forms.UserRegistrationForm(request.POST)
-        if account_form.is_valid():
-            try:
-                account_form.save()
-                return HttpResponseRedirect(
-                    reverse('designsafe_accounts:registration_successful'))
-            except Exception as e:
-                logger.info('error: {}'.format(e))
-
-                error_type = e.args[1] if len(e.args) > 1 else ''
-
-                if 'DuplicateLoginException' in error_type:
-                    err_msg = (
-                        'The username you chose has already been taken. Please '
-                        'choose another. If you already have an account with TACC, '
-                        'please log in using those credentials.')
-                    account_form._errors.setdefault('username', [err_msg])
-                elif 'DuplicateEmailException' in error_type:
-                    err_msg = (
-                        'This email is already registered. If you already have an '
-                        'account with TACC, please log in using those credentials.')
-                    account_form._errors.setdefault('email', [err_msg])
-                    err_msg = '%s <a href="%s">Did you forget your password?</a>' % (
-                        err_msg,
-                        reverse('designsafe_accounts:password_reset'))
-                elif 'PasswordInvalidException' in error_type:
-                    err_msg = (
-                        'The password you provided did not meet the complexity '
-                        'requirements.')
-                    account_form._errors.setdefault('password', [err_msg])
-                else:
-
-                    safe_data = account_form.cleaned_data.copy()
-                    safe_data['password'] = safe_data['confirmPassword'] = '********'
-                    logger.exception('User Registration Error!', extra=safe_data)
-                    err_msg = (
-                        'An unexpected error occurred. If this problem persists '
-                        'please create a support ticket.')
-                messages.error(request, err_msg)
-        else:
-            messages.error(request, 'There were errors processing your registration. '
-                                    'Please see below for details.')
-    else:
-        account_form = forms.UserRegistrationForm()
-
-    context = {
-        'account_form': account_form
-    }
-    return render(request, 'designsafe/apps/accounts/register.html', context)
-
-
-def registration_successful(request):
-    return render(request, 'designsafe/apps/accounts/registration_successful.html')
-
+    return render(request,'designsafe/apps/accounts/register.html')
 
 @login_required
 def profile_edit(request):


### PR DESCRIPTION
## Overview: ##
Remove Register form and replace with text and link to TUP

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2258](https://jira.tacc.utexas.edu/browse/DES-2258)

## Summary of Changes: ##
Removing the registration page form and replacing it with text and a link to send users to create new accounts on TUP rather than through DesignSafe. 
Removed some text regarding email confirmations from the password reset page.

## Testing Steps: ##
1.  View the account registration page at /accounts/register and confirm that the link to TUP exists and you don't see the form anymore.
2. Confirm that new users are prompted to fill out their account profile on first login.  This code already existed, but the task had a note to confirm that this was still working.

## UI Photos:

## Notes: ##
