### PR TITLE
DES-2255: add Last Status Message

### DIFF
--- a/designsafe/static/scripts/workspace/html/jobs-status.html
+++ b/designsafe/static/scripts/workspace/html/jobs-status.html
@@ -70,6 +70,9 @@
             <dt>Finished</dt>
             <dd>{{job.ended | date:'medium'}}</dd>
 
+            <dt>Last Status Message</dt>
+            <dd>{{job.lastStatusMessage}}</dd>
+
             <dt ng-if="job.archiveSystem">Output</dt>
             <dd ng-if="jobFinished && job.archiveSystem">
                 <a href="{{job.archiveUrl}}" target="_blank" class="btn btn-primary" title="agave://{{job.archiveSystem}}/{{job.archivePath}}">View</a>


### PR DESCRIPTION
## Overview: ##
* display the "lastStatusMessage" of a job object in the job detail modal.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2255](https://jira.tacc.utexas.edu/browse/DES-2255)

## Summary of Changes: ##
* Added a row under "Finished", called "Last Status Message"
* Added a row under that being the contents of the "lastStatusMessage" field of a job object

## Testing Steps: ##
1. Run designsafe.dev and view the Last Status Message in the job details modal

## UI Photos:
![Screen Shot 2022-06-27 at 8 42 29 AM](https://user-images.githubusercontent.com/35277477/175956280-8642c231-730b-46aa-ad17-efd35e9eb1a3.png)

## Notes: ##
