### PR TITLE
Task/DES-1275(2261) - Remove category selectors and fix form object reference

### DIFF
--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/files-listing.template.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/files-listing.template.html
@@ -50,7 +50,7 @@
                         </a> -->
                         <div class="project-categories">
                             <div class="file-categories"
-                                 data-ng-if="$ctrl.editTags || $ctrl.showTags">
+                                 data-ng-if="item.name != '.Trash' && $ctrl.editTags || $ctrl.showTags">
                                 <file-categories 
                                                  data-file="item"
                                                  data-show-tags="$ctrl.showTags"
@@ -60,7 +60,7 @@
                                 </file-categories>
                             </div>
                             <div class="file-categories-selector"
-                                 data-ng-if="$ctrl.editTags">
+                                 data-ng-if="item.name != '.Trash' && $ctrl.editTags">
                             
                                 <file-category-selector data-project="$ctrl.browser.project"
                                                         data-file="item"

--- a/designsafe/static/scripts/projects/components/manage-project/manage-project.component.js
+++ b/designsafe/static/scripts/projects/components/manage-project/manage-project.component.js
@@ -71,7 +71,6 @@ class ManageProjectCtrl {
         } else {
             this.UserService.authenticate().then((creator) => {
                 this.form = {...this.formDefaults.new};
-                console.log(this.form)
                 this.form.creator = creator
                 this.ui.loading = false;
             });
@@ -89,8 +88,6 @@ class ManageProjectCtrl {
                 }
                 this.$http.post(`/api/projects/`, data).then((resp) => {
                     let project = resp.data;
-                    this.form = {...this.formDefaults.new};
-                    console.log(this.form)
                     this.$state.go(
                         'projects.view',
                         {
@@ -107,8 +104,6 @@ class ManageProjectCtrl {
         } else {
             this.$http.post(`/api/projects/`, data).then((resp) => {
                 let project = resp.data;
-                this.form = {...this.formDefaults.new};
-                console.log(this.form)
                 this.$state.go(
                     'projects.view',
                     {

--- a/designsafe/static/scripts/projects/components/manage-project/manage-project.component.js
+++ b/designsafe/static/scripts/projects/components/manage-project/manage-project.component.js
@@ -31,10 +31,10 @@ class ManageProjectCtrl {
 
         if (this.project) {
             if (this.project.value.projectType in this.formDefaults) {
-                this.form = this.formDefaults[this.project.value.projectType];
+                this.form = {...this.formDefaults[this.project.value.projectType]};
             }
             else {
-                this.form = this.formDefaults.new;
+                this.form = {...this.formDefaults.new};
                 this.ui.hasType = false;
             }
             this.form.uuid = this.project.uuid;
@@ -70,7 +70,8 @@ class ManageProjectCtrl {
             });
         } else {
             this.UserService.authenticate().then((creator) => {
-                this.form = this.formDefaults.new;
+                this.form = {...this.formDefaults.new};
+                console.log(this.form)
                 this.form.creator = creator
                 this.ui.loading = false;
             });
@@ -88,6 +89,8 @@ class ManageProjectCtrl {
                 }
                 this.$http.post(`/api/projects/`, data).then((resp) => {
                     let project = resp.data;
+                    this.form = {...this.formDefaults.new};
+                    console.log(this.form)
                     this.$state.go(
                         'projects.view',
                         {
@@ -104,6 +107,8 @@ class ManageProjectCtrl {
         } else {
             this.$http.post(`/api/projects/`, data).then((resp) => {
                 let project = resp.data;
+                this.form = {...this.formDefaults.new};
+                console.log(this.form)
                 this.$state.go(
                     'projects.view',
                     {


### PR DESCRIPTION
## Overview: ##
1275: There should be no "Select a Category" or "Save" option by the .Trash folder
2261: If doing multiple Add Project in a row, it autofills with the previous new project's information. Check that the modal is properly clearing the data before reopening.

## PR Status: ##

* [x] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1275](https://jira.tacc.utexas.edu/browse/DES-1275)
* [DES-2261](https://jira.tacc.utexas.edu/browse/DES-2261)

## Summary of Changes: ##
Added a condition that looks for the file name '.Trash' If it is .Trash it does not show the drop down and save option. If it is no .Trash, it does show the drop down and save option.

Changed all this.form = this.formDefaults.new
to this.form = {...this.formDefaults.new}

## Testing Steps: ##
1275:
1. Select a project type with categories (Experimental, Simulation, Hybrid Simulation, or Field Research)
2. Add files to this project
3. Click on Curation Directory
4. Select a file and ‘Move to Trash’
5. This creates a .Trash folder

2261:
1. Created a new project
2. Immediately after, created another new project
3. Also opened an existing project to ensure the project type was as expected

## UI Photos:
Before: 
![Screen Shot 2022-07-05 at 11 15 25 AM](https://user-images.githubusercontent.com/35277477/177793897-10776c14-fe76-4e42-af7b-47ca99c94dc0.png)

After:
![Screen Shot 2022-07-07 at 9 06 38 AM](https://user-images.githubusercontent.com/35277477/177793940-4d123161-fb84-4867-871a-057713aef514.png)


## Notes: ##
