### PR TITLE
Bug/DES-2333 - Fix Citation and DOI section of published metadata header

### DIFF
--- a/designsafe/static/scripts/ng-designsafe/directives/templates/prj-pub-preview-metadata-template.html
+++ b/designsafe/static/scripts/ng-designsafe/directives/templates/prj-pub-preview-metadata-template.html
@@ -133,51 +133,20 @@
     </tr>
     <!-- end Date of Publication -->
 
-    <!-- DOI Listings -->
-    <!-- non-other doi listing -->
-    <tr ng-if="$ctrl.project.value.projectType !== 'other'" ng-repeat="(uuid, citation) in $ctrl.doiList">
-        <td ng-if="$first">DOI(s) in Project</td>
-        <td ng-if="!$first"></td>
-        <td>
-            <strong>
-                <a
-                    ng-click="$ctrl.goToHash(citation.hash)"
-                    data-toggle="collapse"
-                    data-target="{{ citation.type === 'mission' ? '#data-' : '#files-' }}{{uuid}}"
-                >
-                    {{ citation.doi }}
-                </a>
-            </strong>
-        </td>
-    </tr>
-    <!-- other project type doi listing -->
-    <tr class="prj-row" ng-if="$ctrl.readOnly && $ctrl.publication.project.value.dois.length && $ctrl.project.value.projectType === 'other'">
-        <td>
-            <span>DOI</span>
-            <button class="btn btn-info btn-sm btn-cite" data-ng-click="$ctrl.showCitation()">
-                Citation
-            </button>
-        </td>
-        <td>
-            <strong>{{ $ctrl.publication.project.value.dois[0] }}</strong>
-        </td>
-    </tr>
-    <!-- end DOI Listings -->
-
     <!-- Awards -->
-    <!-- preview version-->
+    <!-- for preview -->
     <tr ng-repeat="award in $ctrl.project.value.awardNumber | orderBy:'order' track by $index"
         ng-if="!$ctrl.readOnly">
         <td ng-if="$first">Awards</td>
         <td ng-if="!$first"></td>
-        <td><strong>{{ award.name }} - {{ award.number }}</strong></td>
+        <td><strong>{{ award.name }} | {{ award.number }}</strong></td>
     </tr>
-    <!-- publication version -->
+    <!-- for publication -->
     <tr ng-repeat="award in $ctrl.project.value.awardNumbers | orderBy:'order' track by $index"
         ng-if="$ctrl.readOnly">
         <td ng-if="$first">Awards</td>
         <td ng-if="!$first"></td>
-        <td><strong>{{ award.name }} - {{ award.number }}</strong></td>
+        <td><strong>{{ award.name }} | {{ award.number }}</strong></td>
     </tr>
     <!-- end Awards-->
 
@@ -205,6 +174,61 @@
         </td>
     </tr>
     <!-- end Hazmapper links -->
+
+    <!-- DOI listing -->
+    <tr ng-if="$ctrl.project.value.projectType !== 'other'" ng-repeat="(uuid, citation) in $ctrl.doiList">
+        <td ng-if="$first">DOIs in Project</td>
+        <td ng-if="!$first"></td>
+        <td>
+            <strong>
+                <a ng-if="$ctrl.project.value.projectType === 'field_recon'"
+                   ng-click="$ctrl.goToHash(citation.hash)"
+                   data-toggle="collapse"
+                   data-target="{{ citation.type === 'mission' ? '#data-' : '#files-' }}{{uuid}}"
+                >
+                    {{ citation.doi }}
+                </a>
+                <a ng-if="$ctrl.project.value.projectType != 'field_recon'"
+                   ng-click="$ctrl.goToHash(citation.hash)"
+                   data-toggle="collapse"
+                   data-target="#data-{{uuid}}"
+                >
+                    {{ citation.doi }}
+                </a>
+            </strong>
+        </td>
+    </tr>
+    <!-- end DOI listing -->
+
+    <!-- Citation Details (other only)-->
+    <tr class="prj-row" ng-if="$ctrl.readOnly && $ctrl.project.value.projectType === 'other'"> <!-- hide this for anything not OTHER -->
+        <td>
+            <span>DOI</span>
+            <button class="btn btn-info btn-sm btn-cite" data-ng-click="$ctrl.showCitation()">
+                Citation
+            </button>
+        </td>
+        <td>
+            <strong>{{ $ctrl.browser.publication.project.value.dois[0] }}</strong>
+        </td>
+    </tr>
+    <!-- Citation Details (other only)-->
+
+    <!-- Version Dropdown -->
+    <tr class="prj-row" ng-if="$ctrl.readOnly && $ctrl.browser.publication.latestRevision">
+        <td>
+            <span>Version</span>
+        </td>
+        <td>
+            <select class="prj-dropdown"
+                    ng-options="version for version in $ctrl.versions"
+                    ng-change="$ctrl.getVersion()"
+                    ng-model="$ctrl.selectedVersion">
+            </select>
+            &nbsp;<a ng-click="$ctrl.showVersionInfo()" ng-if="$ctrl.selectedVersion != '1'"><strong>Version Changes</strong></a>
+        </td>
+    </tr>
+    <!-- Version Dropdown End -->
 
     <!-- Licenses -->
     <!-- type Other only -->
@@ -255,8 +279,7 @@
 <!-- end Description -->
 
 <!-- Tombstone -->
-<!-- type Other only -->
-<!-- this is in other places on non-other projects -->
+<!-- tombstone banners can be displayed over publishable metadata -->
 <div class="alert alert-warning flex-container"
         ng-if="$ctrl.publication.tombstone.includes($ctrl.project.uuid) && $ctrl.project.projectType === 'other'">
     <i class="fa fa-warning notification-icon"></i>


### PR DESCRIPTION
## Overview: ##
This fix should render the following fields correctly in the Publication project metadata header.
- DOIs in Dataset - (for all project types besides OTHER): This should show a list of DOIs which, when clicked, will scroll down and open the corresponding entity.
- Version - (any versioned publication): This should render and allow navigation between published versions.
- DOI [Citation]: This should display for OTHER and should open a modal with citation info now.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2333](https://jira.tacc.utexas.edu/browse/DES-2333)

## Summary of Changes: ##
This fix should render the following fields correctly in the Publication project metadata header.
- DOIs in Dataset - (for all project types besides OTHER): This should show a list of DOIs which, when clicked, will scroll down and open the corresponding entity.
- Version - (any versioned publication): This should render and allow navigation between published versions.
- DOI [Citation]: This should display for OTHER and should open a modal with citation info now.

## Testing Steps: ##
1. Open a publication and look at the project header info. The Citation fields described above should function as expected.
