### PR TITLE
Task/des 2305 update upload limit size

### DIFF
--- a/designsafe/static/scripts/data-depot/components/data-depot-new/data-depot-new.component.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-new/data-depot-new.component.html
@@ -29,7 +29,7 @@
                         <i class="fa fa-file-o fa-stack-2x"></i>
                         <i class="fa fa-cloud-upload fa-stack-1x"></i>
                     </span>
-                    <span>File upload: max 100MB</span>
+                    <span>File upload: max 2GB</span>
                 </a>
             </li>
             <li ng-class="{'disabled': ! $ctrl.test.createFiles}">

--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-upload/data-browser-service-upload.template.html
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-upload/data-browser-service-upload.template.html
@@ -11,7 +11,7 @@
     </p>
     <form>
         <div class="form-group">
-            <label for="id-choose-files">Select {{ $ctrl.resolve.directory && $ctrl.directoryUploadSupported ? 'folder' : 'files' }} (for more than 100 MB or 25 files, please use Globus to upload)</label>
+            <label for="id-choose-files">Select {{ $ctrl.resolve.directory && $ctrl.directoryUploadSupported ? 'folder' : 'files' }} (for more than 2GB or 25 files, please use Globus to upload)</label>
             <input type="file" multiple class="form-control" id="id-choose-files" name="choose-files"
                    ng-disabled="state.uploading || state.retry"
                    ng-attr-directory="{{ $ctrl.resolve.directory && 'true' || undefined }}"

--- a/designsafe/static/scripts/ng-designsafe/directives/templates/prj-pub-preview-metadata-template.html
+++ b/designsafe/static/scripts/ng-designsafe/directives/templates/prj-pub-preview-metadata-template.html
@@ -133,51 +133,20 @@
     </tr>
     <!-- end Date of Publication -->
 
-    <!-- DOI Listings -->
-    <!-- non-other doi listing -->
-    <tr ng-if="$ctrl.project.value.projectType !== 'other'" ng-repeat="(uuid, citation) in $ctrl.doiList">
-        <td ng-if="$first">DOI(s) in Project</td>
-        <td ng-if="!$first"></td>
-        <td>
-            <strong>
-                <a
-                    ng-click="$ctrl.goToHash(citation.hash)"
-                    data-toggle="collapse"
-                    data-target="{{ citation.type === 'mission' ? '#data-' : '#files-' }}{{uuid}}"
-                >
-                    {{ citation.doi }}
-                </a>
-            </strong>
-        </td>
-    </tr>
-    <!-- other project type doi listing -->
-    <tr class="prj-row" ng-if="$ctrl.readOnly && $ctrl.publication.project.value.dois.length && $ctrl.project.value.projectType === 'other'">
-        <td>
-            <span>DOI</span>
-            <button class="btn btn-info btn-sm btn-cite" data-ng-click="$ctrl.showCitation()">
-                Citation
-            </button>
-        </td>
-        <td>
-            <strong>{{ $ctrl.publication.project.value.dois[0] }}</strong>
-        </td>
-    </tr>
-    <!-- end DOI Listings -->
-
     <!-- Awards -->
-    <!-- preview version-->
+    <!-- for preview -->
     <tr ng-repeat="award in $ctrl.project.value.awardNumber | orderBy:'order' track by $index"
         ng-if="!$ctrl.readOnly">
         <td ng-if="$first">Awards</td>
         <td ng-if="!$first"></td>
-        <td><strong>{{ award.name }} - {{ award.number }}</strong></td>
+        <td><strong>{{ award.name }} | {{ award.number }}</strong></td>
     </tr>
-    <!-- publication version -->
+    <!-- for publication -->
     <tr ng-repeat="award in $ctrl.project.value.awardNumbers | orderBy:'order' track by $index"
         ng-if="$ctrl.readOnly">
         <td ng-if="$first">Awards</td>
         <td ng-if="!$first"></td>
-        <td><strong>{{ award.name }} - {{ award.number }}</strong></td>
+        <td><strong>{{ award.name }} | {{ award.number }}</strong></td>
     </tr>
     <!-- end Awards-->
 
@@ -205,6 +174,61 @@
         </td>
     </tr>
     <!-- end Hazmapper links -->
+
+    <!-- DOI listing -->
+    <tr ng-if="$ctrl.project.value.projectType !== 'other'" ng-repeat="(uuid, citation) in $ctrl.doiList">
+        <td ng-if="$first">DOIs in Project</td>
+        <td ng-if="!$first"></td>
+        <td>
+            <strong>
+                <a ng-if="$ctrl.project.value.projectType === 'field_recon'"
+                   ng-click="$ctrl.goToHash(citation.hash)"
+                   data-toggle="collapse"
+                   data-target="{{ citation.type === 'mission' ? '#data-' : '#files-' }}{{uuid}}"
+                >
+                    {{ citation.doi }}
+                </a>
+                <a ng-if="$ctrl.project.value.projectType != 'field_recon'"
+                   ng-click="$ctrl.goToHash(citation.hash)"
+                   data-toggle="collapse"
+                   data-target="#data-{{uuid}}"
+                >
+                    {{ citation.doi }}
+                </a>
+            </strong>
+        </td>
+    </tr>
+    <!-- end DOI listing -->
+
+    <!-- Citation Details (other only)-->
+    <tr class="prj-row" ng-if="$ctrl.readOnly && $ctrl.project.value.projectType === 'other'"> <!-- hide this for anything not OTHER -->
+        <td>
+            <span>DOI</span>
+            <button class="btn btn-info btn-sm btn-cite" data-ng-click="$ctrl.showCitation()">
+                Citation
+            </button>
+        </td>
+        <td>
+            <strong>{{ $ctrl.browser.publication.project.value.dois[0] }}</strong>
+        </td>
+    </tr>
+    <!-- Citation Details (other only)-->
+
+    <!-- Version Dropdown -->
+    <tr class="prj-row" ng-if="$ctrl.readOnly && $ctrl.browser.publication.latestRevision">
+        <td>
+            <span>Version</span>
+        </td>
+        <td>
+            <select class="prj-dropdown"
+                    ng-options="version for version in $ctrl.versions"
+                    ng-change="$ctrl.getVersion()"
+                    ng-model="$ctrl.selectedVersion">
+            </select>
+            &nbsp;<a ng-click="$ctrl.showVersionInfo()" ng-if="$ctrl.selectedVersion != '1'"><strong>Version Changes</strong></a>
+        </td>
+    </tr>
+    <!-- Version Dropdown End -->
 
     <!-- Licenses -->
     <!-- type Other only -->
@@ -255,8 +279,7 @@
 <!-- end Description -->
 
 <!-- Tombstone -->
-<!-- type Other only -->
-<!-- this is in other places on non-other projects -->
+<!-- tombstone banners can be displayed over publishable metadata -->
 <div class="alert alert-warning flex-container"
         ng-if="$ctrl.publication.tombstone.includes($ctrl.project.uuid) && $ctrl.project.projectType === 'other'">
     <i class="fa fa-warning notification-icon"></i>


### PR DESCRIPTION
## Overview: ##
The upload modal for uploading files to DesignSafe still says there's a 100MB limit or 25 files despite that the limit in NGINX is set to 2GB. I changed the text in the upload modal from 100MB to 2GB.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2306](https://jira.tacc.utexas.edu/browse/DES-2306)

## Summary of Changes: ##
data-depot-new.component.html, changed 100MB to 2GB.
data-browser-service-upload.template.html, changed 100 MB to 2 GB

## Testing Steps: ##
1. Click +Add, you should see File Upload: max 2 GB
2. Click File Upload, you should see "for more than 2GB..."

## UI Photos:
![Screen Shot 2022-09-19 at 10 10 59 AM](https://user-images.githubusercontent.com/35277477/191051999-07c6314a-1a28-43ee-90bb-f0df8c8030c7.png)

![Screen Shot 2022-09-19 at 9 58 23 AM](https://user-images.githubusercontent.com/35277477/191051352-56ecfc21-ff31-4f30-a937-c3877b2f8bc8.png)
cf8c.png)

## Notes: ##
Reached out to Hedda Prochaska to make similar changes to the data transfer guide: https://www.designsafe-ci.org/rw/user-guides/data-transfer-guide/