### PR TITLE
hotfix - Change licenses API endpoint regex to accommodate key-value 

### DIFF
--- a/designsafe/apps/api/licenses/urls.py
+++ b/designsafe/apps/api/licenses/urls.py
@@ -2,5 +2,5 @@ from django.conf.urls import url
 from designsafe.apps.api.licenses.views import LicenseView
 
 urlpatterns = [
-    url(r'^(?P<app_name>[a-zA-Z]+)/(?P<username>[a-zA-Z0-9\-_\.]+)/$', LicenseView.as_view(), name='License')
+    url(r'^(?P<app_name>[a-zA-Z]+)/$', LicenseView.as_view(), name='License')
 ]

--- a/designsafe/apps/api/licenses/views.py
+++ b/designsafe/apps/api/licenses/views.py
@@ -10,7 +10,7 @@ from designsafe.apps.data.models.agave.util import AgaveJSONEncoder
 
 class LicenseView(SecureMixin, BaseApiView):
     @profile_fn
-    def get(self, request, app_name, username):
+    def get(self, request, app_name):
         if not request.user.is_staff:
             return HttpResponseForbidden()
 
@@ -18,7 +18,9 @@ class LicenseView(SecureMixin, BaseApiView):
             app_license = apps.get_model('designsafe_licenses', '{}License'.format(app_name))
         except LookupError:
             return HttpResponseNotFound()
-
+        username = request.GET.get('user', None)
+        if not username:
+            return HttpResponseNotFound()
         user = get_user_model().objects.get(username=username)
         licenses = app_license.objects.filter(user=user)
 


### PR DESCRIPTION

## Overview: ##
Needed to change url pattern to allow this url to be caught by jwt decorator.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2330](https://jira.tacc.utexas.edu/browse/DES-2330)

## Summary of Changes: ##
- Removed `username` from url pattern 
- Updated view to look for `user` query string

## Testing Steps: ##
1. Locally, go to https://designsafe.dev/api/licenses/MATLAB/?user=YOUR_USERNAME and https://designsafe.dev/api/licenses/LSDYNA/?user=YOUR_USERNAME
2. Verify that there is a dict reading {'license': ''} or {'license': '<LICENSE_CONTENT_HERE>'}

## UI Photos:

## Notes: ##
