### PR TITLE
hotfix: Licenses API Endpoint picking up incorrect account to check for staff permissions

### DIFF
--- a/designsafe/apps/api/decorators.py
+++ b/designsafe/apps/api/decorators.py
@@ -93,7 +93,7 @@ def agave_jwt_login(func):
 
         jwt_username = jwt_payload.get(settings.AGAVE_JWT_USER_CLAIM_FIELD, '')
         if jwt_username == settings.AGAVE_JWT_SERVICE_ACCOUNT:
-            username = request.GET.get('user', None)
+            username = request.GET.get('user', jwt_username)
         else:
             username = jwt_username
 

--- a/designsafe/apps/api/licenses/views.py
+++ b/designsafe/apps/api/licenses/views.py
@@ -6,6 +6,9 @@ from django.http.response import HttpResponseForbidden, HttpResponseNotFound
 from django.http import JsonResponse
 from django.apps import apps
 from designsafe.apps.data.models.agave.util import AgaveJSONEncoder
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class LicenseView(SecureMixin, BaseApiView):
@@ -18,7 +21,7 @@ class LicenseView(SecureMixin, BaseApiView):
             app_license = apps.get_model('designsafe_licenses', '{}License'.format(app_name))
         except LookupError:
             return HttpResponseNotFound()
-        username = request.GET.get('user', None)
+        username = request.GET.get('username', None)
         if not username:
             return HttpResponseNotFound()
         user = get_user_model().objects.get(username=username)


### PR DESCRIPTION
## Overview: ##
Resolved variable name conflict between license API endpoint view and JWT auth
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2330](https://jira.tacc.utexas.edu/browse/DES-2330)

## Summary of Changes: ##
- Changed url param for user to get licenses for to not conflict with JWT auth url param
- Changed default value for JWT auth url user lookup to user associated with included JWT

## Testing Steps: ##
1. Use the JWT provided independently for testing (in these testing steps, it is set as environment variable `JWT_TEST`)
2. Use the following cURL commands and confirm you get back a 200 response and a license for the first and no license for the second (i.e. `{'license': ''}`):
- `curl -i -H "X-Jwt-Assertion-Designsafe: $JWT_TEST" "https://designsafe.dev/api/licenses/MATLAB/?username=gedmonds"`
- `curl -i -H "X-Jwt-Assertion-Designsafe: $JWT_TEST" "https://designsafe.dev/api/licenses/MATLAB/?username=gedtest2"`

## UI Photos:

## Notes: ##
