### PR TITLE
DES-2349: remove password reset forms

### DIFF
--- a/designsafe/apps/accounts/templates/designsafe/apps/accounts/manage_auth.html
+++ b/designsafe/apps/accounts/templates/designsafe/apps/accounts/manage_auth.html
@@ -6,22 +6,8 @@
     <div class="panel-body">
         <h2>Change Your Password</h2>
         <hr>
-        <div class="alert alert-warning">
-            <h4>Changing your TACC Password</h4>
-            <strong>Please Note:</strong> This form requests a reset to your TACC Account
-            password. Changes to this password will affect your TACC Account
-            <em>as a whole</em>, not just at DesignSafe.
-        </div>
-
-        <form method="post" action="">
-            {% csrf_token %}
-
-            {% bootstrap_form form %}
-
-            {% buttons %}
-            <button type="submit" class="btn btn-primary">Change Password</button>
-            {% endbuttons %}
-        </form>
+        To reset your password, go here:
+        <a href="https://portal.tacc.utexas.edu/password-reset">TACC Password Reset</a>
     </div>
 </div>
 

--- a/designsafe/apps/accounts/templates/designsafe/apps/accounts/password_reset.html
+++ b/designsafe/apps/accounts/templates/designsafe/apps/accounts/password_reset.html
@@ -7,28 +7,7 @@
 {% block content %}
 <div class="container">
     <h1>Password Reset</h1>
-
-    <p class="lead">{{ message }}</p>
-
-    <div class="alert alert-warning">
-        <h4>Changing your TACC Password</h4>
-        <strong>Please Note:</strong> This form requests a reset to your TACC Account
-        password. Changes to this password will affect your TACC Account
-        <em>as a whole</em>, not just at DesignSafe.
-    </div>
-
-    <form method="post" action="">
-      {% csrf_token %}
-
-      {% bootstrap_form form %}
-
-      {% buttons %}
-        <button type="submit" class="btn btn-success">Request Password Reset</button>
-      {% endbuttons %}
-    </form>
-    <br>
-    <h1>Forgot Username</h1>
-
-    <a class="btn btn-primary" href="https://portal.tacc.utexas.edu/password-reset/-/password/forgot-username">Request Username</a>
+    To reset your password, go here:
+    <a href="https://portal.tacc.utexas.edu/password-reset">TACC Password Reset</a>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Overview: ##
Remove password reset forms and link to TUP for password resets.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2349](https://jira.tacc.utexas.edu/browse/DES-2349)

## Summary of Changes: ##
Updated templates to remove the use of the password reset form and link users to TUP for password resets.

## Testing Steps: ##
1. Check https://designsafe.dev/account/password-reset/ which should just be a link to TUP.
2. Check https://designsafe.dev/account/authentication/ which should have the same thing as the above link but within the account panel.

## UI Photos:

## Notes: ##