### PR TITLE
Task/des 2328 modify toolbar within publications

### DIFF
--- a/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.html
@@ -1,9 +1,9 @@
-<div class="clearfix btn-toolbar-ds dd-toolbar" ng-style="{ position: $ctrl.$state.current.name === 'publishedData' ? 'fixed' : none }" ng-hide="$ctrl.$state.current.name === 'publicData'">
-        <div class="btn-toolbar btn-toolbar-left"
-             role="toolbar"
-             aria-label="Data Browser Search"
-             style="width:160px; float:left; margin-left:15px;"
-             ng-if="apiParams.searchState">
+<div class="clearfix btn-toolbar-ds dd-toolbar" ng-class="$ctrl.$state.current.name === 'publishedData' ? 'btn-toolbar-pub' : none" ng-hide="$ctrl.$state.current.name === 'publicData'">
+        <div class="btn-toolbar btn-toolbar-left" 
+            role="toolbar"
+            aria-label="Data Browser Search"
+            style="width:160px; float:left; margin-left:15px;"
+            ng-if="apiParams.searchState">
         </div>
         <div class="btn-toolbar btn-toolbar-left" role="toolbar" aria-label="Data Browser Toolbar">
             <form class="navbar-form navbar-left" ng-submit="$ctrl.ddSearch()" style="display:flex"
@@ -47,7 +47,6 @@
                     </button> -->
                 </div>
                 <div class="btn-group-data-depot-toolbar btn-group">
-
                     <button class="btn btn-sm btn-default" title="Download" ng-click="$ctrl.download()" style="text-align: center;"
                             ng-disabled="!$ctrl.FileOperationService.tests.download">
                         <i class="fa fa-cloud-download"></i><span style="display:block;">Download</span>

--- a/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.html
@@ -14,6 +14,7 @@
             <div class="btn-toolbar-right">
                 <div class="btn-group-data-depot-toolbar btn-group">
                     <button class="btn btn-sm btn-default" title="Rename" ng-click="$ctrl.rename()" style="text-align: center;"
+                            ng-hide="$ctrl.$state.current.name === 'publishedData'"
                             ng-disabled="!$ctrl.FileOperationService.tests.rename ||
                                         $ctrl.browser.project.publicationStatus === 'publishing'">
                         <i class="fa fa-pencil"></i><span style="display:block;">Rename</span>
@@ -21,6 +22,7 @@
                 </div>
                 <div class="btn-group-data-depot-toolbar btn-group">
                     <button class="btn btn-sm btn-default" title="Move" ng-click="$ctrl.move()" style="text-align: center;"
+                            ng-hide="$ctrl.$state.current.name === 'publishedData'"
                             ng-disabled="!$ctrl.FileOperationService.tests.move ||
                                         $ctrl.browser.project.publicationStatus === 'publishing'">
                         <i class="fa fa-arrows"></i><span style="display:block;">Move</span>
@@ -53,6 +55,7 @@
                 </div>
                 <div class="btn-group-data-depot-toolbar btn-group">
                     <button class="btn btn-sm btn-default" title="Move to trash" ng-click="$ctrl.trash()" style="text-align: center;"
+                            ng-hide="$ctrl.$state.current.name === 'publishedData'"
                             ng-disabled="!$ctrl.FileOperationService.tests.trash ||
                                         $ctrl.browser.project.publicationStatus === 'publishing'"
                             ng-if="!$ctrl.browser.tests.canDelete">

--- a/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.html
@@ -1,4 +1,4 @@
-<div class="clearfix btn-toolbar-ds dd-toolbar" ng-class="$ctrl.$state.current.name === 'publishedData' ? 'btn-toolbar-pub' : none" ng-hide="$ctrl.$state.current.name === 'publicData'">
+<div class="clearfix btn-toolbar-ds dd-toolbar" ng-class="$ctrl.$state.current.name === 'publishedData' || $ctrl.$state.current.name === 'publicDataLegacy'? 'btn-toolbar-pub' : none" ng-hide="$ctrl.$state.current.name === 'publicData'">
         <div class="btn-toolbar btn-toolbar-left" 
             role="toolbar"
             aria-label="Data Browser Search"
@@ -14,7 +14,7 @@
             <div class="btn-toolbar-right">
                 <div class="btn-group-data-depot-toolbar btn-group">
                     <button class="btn btn-sm btn-default" title="Rename" ng-click="$ctrl.rename()" style="text-align: center;"
-                            ng-hide="$ctrl.$state.current.name === 'publishedData'"
+                            ng-hide="$ctrl.$state.current.name === 'publishedData' || $ctrl.$state.current.name === 'publicDataLegacy'"
                             ng-disabled="!$ctrl.FileOperationService.tests.rename ||
                                         $ctrl.browser.project.publicationStatus === 'publishing'">
                         <i class="fa fa-pencil"></i><span style="display:block;">Rename</span>
@@ -22,7 +22,7 @@
                 </div>
                 <div class="btn-group-data-depot-toolbar btn-group">
                     <button class="btn btn-sm btn-default" title="Move" ng-click="$ctrl.move()" style="text-align: center;"
-                            ng-hide="$ctrl.$state.current.name === 'publishedData'"
+                            ng-hide="$ctrl.$state.current.name === 'publishedData' || $ctrl.$state.current.name === 'publicDataLegacy'"
                             ng-disabled="!$ctrl.FileOperationService.tests.move ||
                                         $ctrl.browser.project.publicationStatus === 'publishing'">
                         <i class="fa fa-arrows"></i><span style="display:block;">Move</span>
@@ -54,7 +54,7 @@
                 </div>
                 <div class="btn-group-data-depot-toolbar btn-group">
                     <button class="btn btn-sm btn-default" title="Move to trash" ng-click="$ctrl.trash()" style="text-align: center;"
-                            ng-hide="$ctrl.$state.current.name === 'publishedData'"
+                            ng-hide="$ctrl.$state.current.name === 'publishedData' || $ctrl.$state.current.name === 'publicDataLegacy'"
                             ng-disabled="!$ctrl.FileOperationService.tests.trash ||
                                         $ctrl.browser.project.publicationStatus === 'publishing'"
                             ng-if="!$ctrl.browser.tests.canDelete">

--- a/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.html
@@ -1,4 +1,4 @@
-<div class="clearfix btn-toolbar-ds dd-toolbar" ng-hide="$ctrl.$state.current.name === 'publicData'">
+<div class="clearfix btn-toolbar-ds dd-toolbar" ng-style="{ position: $ctrl.$state.current.name === 'publishedData' ? 'fixed' : none }" ng-hide="$ctrl.$state.current.name === 'publicData'">
         <div class="btn-toolbar btn-toolbar-left"
              role="toolbar"
              aria-label="Data Browser Search"

--- a/designsafe/static/scripts/data-depot/components/published/published.html
+++ b/designsafe/static/scripts/data-depot/components/published/published.html
@@ -1,31 +1,29 @@
-<div class="pub-header"> 
-     <div ng-if="$ctrl.ui.loading">
-     Loading... <i class="fa fa-spinner fa-spin"></i>
-     </div>
-
-     <div 
-          data-ng-if="$ctrl.viewToShow() === 'v1'">
-          <published publication=$ctrl.publication></published>
-     </div>
-
-     <div
-          data-ng-if="$ctrl.viewToShow() === 'experimental'" ng-style="{'padding-top': 20%}">
-     <exp-published-view publication=$ctrl.publication></exp-published-view>
-     </div>
-     <div
-          data-ng-if="$ctrl.viewToShow() === 'simulation'">
-     <sim-published-view publication=$ctrl.publication></sim-published-view>
-     </div>
-     <div 
-          data-ng-if="$ctrl.viewToShow() === 'hybrid_simulation'">
-     <sim-hyb-published-view publication=$ctrl.publication></sim-hyb-published-view>
-     </div>
-     <div
-          data-ng-if="$ctrl.viewToShow() === 'field_recon'">
-     <field-recon-published-view publication=$ctrl.publication></field-recon-published-view>
-     </div>
-     <div 
-          data-ng-if="$ctrl.viewToShow() === 'other'">
-     <other-published-view publication=$ctrl.publication></other-published-view>
-     </div> 
+<div ng-if="$ctrl.ui.loading">
+Loading... <i class="fa fa-spinner fa-spin"></i>
 </div>
+
+<div 
+     data-ng-if="$ctrl.viewToShow() === 'v1'">
+     <published publication=$ctrl.publication></published>
+</div>
+
+<div
+     data-ng-if="$ctrl.viewToShow() === 'experimental'" ng-style="{'padding-top': 20%}">
+<exp-published-view publication=$ctrl.publication></exp-published-view>
+</div>
+<div
+     data-ng-if="$ctrl.viewToShow() === 'simulation'">
+<sim-published-view publication=$ctrl.publication></sim-published-view>
+</div>
+<div 
+     data-ng-if="$ctrl.viewToShow() === 'hybrid_simulation'">
+<sim-hyb-published-view publication=$ctrl.publication></sim-hyb-published-view>
+</div>
+<div
+     data-ng-if="$ctrl.viewToShow() === 'field_recon'">
+<field-recon-published-view publication=$ctrl.publication></field-recon-published-view>
+</div>
+<div 
+     data-ng-if="$ctrl.viewToShow() === 'other'">
+<other-published-view publication=$ctrl.publication></other-published-view>
+</div> 

--- a/designsafe/static/scripts/data-depot/components/published/published.html
+++ b/designsafe/static/scripts/data-depot/components/published/published.html
@@ -1,29 +1,31 @@
-<div ng-if="$ctrl.ui.loading">
-Loading... <i class="fa fa-spinner fa-spin"></i>
-</div>
+<div class="pub-header"> 
+     <div ng-if="$ctrl.ui.loading">
+     Loading... <i class="fa fa-spinner fa-spin"></i>
+     </div>
 
-<div 
-     data-ng-if="$ctrl.viewToShow() === 'v1'">
-     <published publication=$ctrl.publication></published>
-</div>
+     <div 
+          data-ng-if="$ctrl.viewToShow() === 'v1'">
+          <published publication=$ctrl.publication></published>
+     </div>
 
-<div
-     data-ng-if="$ctrl.viewToShow() === 'experimental'">
-    <exp-published-view publication=$ctrl.publication></exp-published-view>
+     <div
+          data-ng-if="$ctrl.viewToShow() === 'experimental'" ng-style="{'padding-top': 20%}">
+     <exp-published-view publication=$ctrl.publication></exp-published-view>
+     </div>
+     <div
+          data-ng-if="$ctrl.viewToShow() === 'simulation'">
+     <sim-published-view publication=$ctrl.publication></sim-published-view>
+     </div>
+     <div 
+          data-ng-if="$ctrl.viewToShow() === 'hybrid_simulation'">
+     <sim-hyb-published-view publication=$ctrl.publication></sim-hyb-published-view>
+     </div>
+     <div
+          data-ng-if="$ctrl.viewToShow() === 'field_recon'">
+     <field-recon-published-view publication=$ctrl.publication></field-recon-published-view>
+     </div>
+     <div 
+          data-ng-if="$ctrl.viewToShow() === 'other'">
+     <other-published-view publication=$ctrl.publication></other-published-view>
+     </div> 
 </div>
-<div
-     data-ng-if="$ctrl.viewToShow() === 'simulation'">
-    <sim-published-view publication=$ctrl.publication></sim-published-view>
-</div>
-<div 
-     data-ng-if="$ctrl.viewToShow() === 'hybrid_simulation'">
-    <sim-hyb-published-view publication=$ctrl.publication></sim-hyb-published-view>
-</div>
-<div
-     data-ng-if="$ctrl.viewToShow() === 'field_recon'">
-    <field-recon-published-view publication=$ctrl.publication></field-recon-published-view>
-</div>
-<div 
-     data-ng-if="$ctrl.viewToShow() === 'other'">
-    <other-published-view publication=$ctrl.publication></other-published-view>
-</div> 

--- a/designsafe/static/scripts/data-depot/components/published/published.html
+++ b/designsafe/static/scripts/data-depot/components/published/published.html
@@ -8,7 +8,7 @@ Loading... <i class="fa fa-spinner fa-spin"></i>
 </div>
 
 <div
-     data-ng-if="$ctrl.viewToShow() === 'experimental'" ng-style="{'padding-top': 20%}">
+     data-ng-if="$ctrl.viewToShow() === 'experimental'">
 <exp-published-view publication=$ctrl.publication></exp-published-view>
 </div>
 <div

--- a/designsafe/static/styles/ng-designsafe.css
+++ b/designsafe/static/styles/ng-designsafe.css
@@ -4,7 +4,7 @@
     margin-bottom: 20px;
     margin-left: 0;
     padding: 5px 5px 5px 0;
-    z-index:10;
+    z-index: 10;
 }
 
 .btn-toolbar-right {
@@ -13,6 +13,12 @@
 
 .btn-toolbar-right .btn-group {
     float: none;
+}
+
+.btn-toolbar-pub {
+    position: sticky;
+    top: 20px;
+    overflow: hidden;
 }
 
 .breadcrumb-ds {
@@ -1034,8 +1040,4 @@ i[class^="icon-ls-pre/post"]:before,
 .feedback-item {
     width: 50%;
     padding: 10px;
-}
-
-.pub-header{
-    padding-top: 85px;
 }

--- a/designsafe/static/styles/ng-designsafe.css
+++ b/designsafe/static/styles/ng-designsafe.css
@@ -18,7 +18,6 @@
 .btn-toolbar-pub {
     position: sticky;
     top: 20px;
-    overflow: hidden;
 }
 
 .breadcrumb-ds {

--- a/designsafe/static/styles/ng-designsafe.css
+++ b/designsafe/static/styles/ng-designsafe.css
@@ -4,6 +4,7 @@
     margin-bottom: 20px;
     margin-left: 0;
     padding: 5px 5px 5px 0;
+    z-index:10;
 }
 
 .btn-toolbar-right {
@@ -1033,4 +1034,8 @@ i[class^="icon-ls-pre/post"]:before,
 .feedback-item {
     width: 50%;
     padding: 10px;
+}
+
+.pub-header{
+    padding-top: 85px;
 }


### PR DESCRIPTION
## Overview: ##
Within publications, the toolbar needs to scroll with the user.

Also, the toolbar should only include relevant buttons: Download, Copy, Preview, Preview Images, and Find. I removed Move to Trash, Rename, and Move.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2328](https://jira.tacc.utexas.edu/browse/DES-2328)

## Summary of Changes: ##
data-depot-toolbar.component.html -- added conditional logic to remove Move to Trash, Rename, and Move from the toolbar when displaying Published and Published (NEES)

ng-designsafe.css -- added class to make the toolbar 'sticky.' this means it will remain on the screen when the user scrolls down 
Also added z-index to make sure the toolbar remains in front of components on the page.

## UI Photos:

https://user-images.githubusercontent.com/35277477/206035269-112e6c82-60a3-46f0-981a-aa233f400d1c.mov


## Notes: ##
