### PR TITLE
bug/DES-2394: Fix association tags for files at project root

### DIFF
--- a/designsafe/static/scripts/ng-designsafe/services/file-listing-service.js
+++ b/designsafe/static/scripts/ng-designsafe/services/file-listing-service.js
@@ -488,7 +488,7 @@ export class FileListingService {
             // Filter for entities whose associationIds contain a file path matching the provided path.
             return associationIds.some((asc) => {
                 const comps = asc.href.split('project-' + projectId, 2);
-                return comps.length === 2 && path.replace(/^\/+/, '') === comps[1].replace(/^\/+/, '');
+                return path && comps.length === 2 && path.replace(/^\/+/, '') === comps[1].replace(/^\/+/, '');
             });
         });
 


### PR DESCRIPTION
## Overview: ##
The "parent entity" listing has a bug where files/folders in a project's root directory will display as the children of every entity in the project. The logic needs to be updated to reflect the fact that a project's root directory can't be associated with an entity.

## UI Photos:
before (this is wrong, these folders aren't directly associated to any entities):
<img width="967" alt="image" src="https://user-images.githubusercontent.com/12601812/208487513-c449ca5d-1716-412e-87d6-78d60330b5d2.png">

after: 
<img width="968" alt="image" src="https://user-images.githubusercontent.com/12601812/208487332-37fdcc5d-1acf-4560-82e1-4bf3e5729e6f.png">

## Notes: ##
