### PR TITLE
bug/DES-2401: Fix bug causing versioned Other projects to publish with no files

### DIFF
--- a/designsafe/apps/api/tasks.py
+++ b/designsafe/apps/api/tasks.py
@@ -894,7 +894,7 @@ def email_user_publication_request_confirmation(self, username):
         )
 
 @shared_task(bind=True, max_retries=1, default_retry_delay=60)
-def check_published_files(project_id, revision=None, selected_files=None):
+def check_published_files(self, project_id, revision=None, selected_files=None):
 
     # do not attempt to check for files for local publication attempts
     if getattr(settings, 'DESIGNSAFE_ENVIRONMENT', 'dev') == 'dev':

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-version/pipeline-version-changes.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-version/pipeline-version-changes.component.js
@@ -116,8 +116,8 @@ class PipelineVersionChangesCtrl {
             if (!this.revisionTitles.length) return this.ui.warning = true;
         }
         this.ui.loading = true;
-        let filePaths = (this.selectedListing
-            ? this.selectedListing.listing.map((file) => file.path)
+        let filePaths = (this.selectedListings
+            ? this.selectedListings.listing.map((file) => file.path)
             : null);
         this.$http.post(
             '/api/projects/publication/',


### PR DESCRIPTION
## Overview: ##
Fix a Javascript typo which was causing a `null` value to be sent to `copy_publication_files_to_corral`.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2401](https://jira.tacc.utexas.edu/browse/DES-2401)

