### PR TITLE
bug/DES-2402: prevent Publication Preview from spinning forever

### DIFF
--- a/designsafe/static/scripts/ng-designsafe/services/file-listing-service.js
+++ b/designsafe/static/scripts/ng-designsafe/services/file-listing-service.js
@@ -550,7 +550,23 @@ export class FileListingService {
 
         const listingObservable$ = from(request).pipe(
             tap(this.abstractListingSuccessCallback(entitiesPerPath)),
-            catchError(() => {})
+            catchError(() => {
+                const children = Object.keys(entitiesPerPath).filter(k => k.startsWith(path))
+                const syntheticListing = children.map(path => {
+                    const type = path.search((/\./)) > 0 ? 'file' : 'dir'
+                    return {
+                        name: path.split('/').slice(-1)[0],
+                        path,
+                        system,
+                        permissions: 'ALL',
+                        type,
+                        format: type === 'dir' ? 'folder' : 'raw'
+                    }
+                })
+                const synthResponse = {data: {listing: syntheticListing}}
+                this.abstractListingSuccessCallback(entitiesPerPath)(synthResponse)
+                return of(null)
+            })
         );
         return listingObservable$;
     }
@@ -594,7 +610,7 @@ export class FileListingService {
             this.addSection(entity.uuid);
             this.listings[entity.uuid].listing = [];
             this.listings[entity.uuid].params = { section: entity.uuid, ...abstractListingParams };
-            entity._filePaths.forEach((path) => {
+            entity._filePaths.filter(s => s !== '/').forEach((path) => {
                 entitiesPerPath[path] = [...(entitiesPerPath[path] || []), entity];
             });
         });

--- a/designsafe/static/scripts/ng-designsafe/services/file-listing-service.js
+++ b/designsafe/static/scripts/ng-designsafe/services/file-listing-service.js
@@ -551,8 +551,10 @@ export class FileListingService {
         const listingObservable$ = from(request).pipe(
             tap(this.abstractListingSuccessCallback(entitiesPerPath)),
             catchError(() => {
+                // If the listing fails, construct a synthetic listing as placeholder.
                 const children = Object.keys(entitiesPerPath).filter(k => k.startsWith(path))
                 const syntheticListing = children.map(path => {
+                    // Assume path is a dir if it doesn't contain a '.' character.
                     const type = path.search((/\./)) > 0 ? 'file' : 'dir'
                     return {
                         name: path.split('/').slice(-1)[0],


### PR DESCRIPTION
## Overview: ##
Abstract listings can fail completely if one of their component listings fails, causing the page to get stuck in a "loading" state. This PR addresses the bug by handling listing exceptions and replacing the missing listing with a "synthetic" listing that uses the Tapis path to infer the file type.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2402](https://jira.tacc.utexas.edu/browse/DES-2402)

## Summary of Changes: ##
- Add better exception handling to the `abstractListing` method in the file listing servce.

## Testing Steps: ##
1. Try to preview a project with a lot of associated files (https://designsafe.dev/data/browser/projects/8748128685492212201-242ac11b-0001-012/preview/exp/ is a good example).
2. Refresh the page a few times to make sure that the listing never ends up spinning forever. If you look in the network tab and see an error, but the preview still loads, then the PR is working as intended:
<img width="1085" alt="image" src="https://user-images.githubusercontent.com/12601812/211389793-9df5bc9d-0361-4ff5-aa96-d0213fc71daf.png">


