### PR TITLE
Additional tweaks for Published search

### DIFF
--- a/designsafe/apps/api/publications/operations.py
+++ b/designsafe/apps/api/publications/operations.py
@@ -79,6 +79,10 @@ def search(offset=0, limit=100, query_string='', limit_fields=True, *args):
     if search_string:
         query_filters.append(search_utils.search_string_query(search_string))
 
+    pub_year = query_dict['queries']['publicationYear']
+    if pub_year:
+        query_filters.append(search_utils.pub_date_query(pub_year))
+
     # Experimental advanced filters
     facility = query_dict['advancedFilters']['experimental']['experimentalFacility']
     experiment_type = query_dict['advancedFilters']['experimental']['experimentType']

--- a/designsafe/apps/api/publications/search_utils.py
+++ b/designsafe/apps/api/publications/search_utils.py
@@ -140,6 +140,15 @@ def fr_date_query(year):
         'format': 'yyyy'}
     }})
 
+def pub_date_query(year): 
+    if not year:
+        return None
+    return Q({'range': {'created': {
+        "gte": f"{year}||/y",
+        "lte": f"{year}||/y", 
+        'format': 'yyyy'}
+    }})
+
 def fr_type_query(fr_type):
     if not fr_type:
         return None

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
@@ -35,8 +35,8 @@ class PublicationListingCtrl {
         this.currentYear = new Date(Date.now()).getUTCFullYear();
         //Show events going back 10 years
         this.datesInRange = []
-        for (var i = 0; i <= 10; i++) {
-            this.datesInRange.push(this.currentYear - i);
+        for (var i = this.currentYear; i >=2015; i--) {
+            this.datesInRange.push(i);
         }
         this.nhYears = this.datesInRange.map((type) => ({ name: type, label: type }));
         this.nhYears = [{ name: '', label: 'All Years' }, ...this.nhYears];
@@ -65,7 +65,8 @@ class PublicationListingCtrl {
 
         this.params = currentParams || {
             queries: {
-                searchString: ''
+                searchString: '',
+                publicationYear: '',
             },
             typeFilters: {
                 experimental: false,

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/publications-listing.template.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/publications-listing.template.html
@@ -4,23 +4,36 @@
     <div class="table-row">
         <div class="table-column-l">
             <div style="display:inline-flex; width:100%; padding-bottom: 10px;">
-                <div class="input-group" style="display:inline-flex; flex:1; align-items: center;">
+                <div class="input-group" style="display:inline-flex; flex:1; align-items: center; min-width:200px;">
                     
                     <button class="btn btn-success" ng-click="$ctrl.browse()" style="width:fit-content; white-space: nowrap; text-align: center; height: 34px;">
                         <i class="fa fa-search">&nbsp;</i>Search
                     </button>
-                    <input type="text" placeholder="Author, Title, Keyword, or Description" class="form-control" ng-model="$ctrl.params.queries.searchString" class="form-control" id="author-input" ng-keydown="$event.keyCode === 13 && $ctrl.browse()">
+                    <input type="text" placeholder="Author, Title, Keyword, Description, Natural Hazard Event, Project ID, or DOI" 
+                    data-toggle="tooltip" data-placement="top" title="Author, Title, Keyword, Description, Natural Hazard Event, Project ID, or DOI"
+                        class="form-control" ng-model="$ctrl.params.queries.searchString" class="form-control" id="author-input" ng-keydown="$event.keyCode === 13 && $ctrl.browse()">
                 </div>
                 
-                <div style="display:flex; align-items: center; flex:1; justify-content: end;">
+                <div style="display:flex; align-items: center; justify-content: end;">
                     <div class="input-group" style="display:inline-flex; align-items: center; padding-left: 15px;">
                         <label for="nh-type-select" style="margin-bottom: 0px;">Natural Hazard Type&nbsp;</label>
                         <select
-                            style="width: fit-content; border-radius: 5px;"
+                            style="max-width:100px; border-radius: 5px;"
                             id="nh-type-select"
                             ng-model="$ctrl.params.advancedFilters.field_recon.naturalHazardType"
                             ng-change="$ctrl.browse()"
                             ng-options="opt.name as opt.label for opt in $ctrl.rapidEventTypes"
+                            class="form-control"
+                            ></select>
+                        </div>
+                    <div class="input-group" style="display:inline-flex; align-items: center; padding-left: 15px;">
+                        <label for="pub-year-select" style="margin-bottom: 0px;">Year Published&nbsp;</label>
+                        <select
+                            style="max-width:fit-content; border-radius: 5px;"
+                            id="pub-year-select"
+                            ng-model="$ctrl.params.queries.publicationYear"
+                            ng-change="$ctrl.browse()"
+                            ng-options="opt.name as opt.label for opt in $ctrl.nhYears"
                             class="form-control"
                             ></select>
                         </div>
@@ -38,9 +51,9 @@
                         <thead>
                             <th style="width: 350px;">Project Title</th>
                             <th style="width: 100px;">Project PI</th>
-                            <th style="width: 100px;">Project Description</th>
+                            <th style="width: 100px;">Description</th>
                             <th style="width: 150px;">Keywords</th>
-                            <th style="width: 100px;">Date of Publication</th>
+                            <th style="width: 100px;">Date Published</th>
                             </thead>
             
                         <tbody>
@@ -52,7 +65,8 @@
                               <a ng-href="{{ $ctrl.href(item) }}">
                                   {{ item.project.value.title }}
                               </a>
-                              <span style="text-transform:capitalize;">({{item.project.value.dataType ||  $ctrl.getType(item.project.value.projectType) }})</span>
+                              <br/>
+                              <div style="text-transform:capitalize; margin-top:0.5rem">{{item.project.value.dataType ||  $ctrl.getType(item.project.value.projectType) }}</div>
                           </td>
                           <td >
                             <span ng-show="item.pi">{{ item.pi }}</span>

--- a/designsafe/static/scripts/data-depot/components/main/main.template.html
+++ b/designsafe/static/scripts/data-depot/components/main/main.template.html
@@ -1,12 +1,12 @@
 <div class="row">
-    <div class="col-sm-3 col-md-2">
+    <div class="col-sm-3 col-md-2" style="max-width:200px; padding-left:0px;">
         <h1 class="headline headline-research" id="headline-data-depot">
             <span class="hl hl-research">Data Depot</span>
         </h1>
         <ddnew></ddnew> 
         <ddnav></ddnav>
     </div>
-    <div class="col-sm-9 col-md-10">
+    <div style="display:flex; flex:1">
         <ddtoolbar></ddtoolbar>
         <ui-view></ui-view>
     </div>

--- a/designsafe/static/styles/ng-designsafe.css
+++ b/designsafe/static/styles/ng-designsafe.css
@@ -356,7 +356,10 @@
 * DATA BROWSER TABLE WRAPPER CSS
 *
 **/
-
+input:placeholder-shown {
+    text-overflow: ellipsis;
+  }
+  
 .ds-table-display-wrapper {
     height:600px;
     overflow:scroll;

--- a/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css
+++ b/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css
@@ -206,13 +206,13 @@ th {
 }
 .table-column-l {
   float: left;
-  width: 80%;
+  width: 85%;
   padding: 5px;
 }
 .table-column-r {
   float: left;
-  width: 20%;
-  padding: 5px;
+  width: 15%;
+  padding: 5px 0px 5px 5px;
 }
 /*! Source: https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css */
 @media print {


### PR DESCRIPTION
## Overview: ##
Fixes for Craig/Maria's notes:
- In the string search, “Natural Hazard Event, Project ID, or DOI” need to be searched
- There needs to be a global filter for Year Published. This is common on all repositories.
- For fitting these extra items and refining the space a bit,
- The left-hand Data Depot navigation does not need to be as wide as it is right now, there is ~30% extra space than there needs to be
- Bring the left to align with where “Workplace” in the navigation starts and the right to align with the “Search DesignSafe” in the nav bar ends
- To increase the table height, shorten “Project Description” -> “Description” and “Date of Publication” -> “Date Published”
- Don’t forget to put the Experimental, Simulation, Field Research labels on a new line beneath the title

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.


## UI Photos:
![image](https://user-images.githubusercontent.com/12601812/231051363-d43b9d04-aefd-49e0-a4b0-0a11bd23b0b6.png)


## Notes: ##
