### PR TITLE
Restore previous max width on containers outside Data Depot

### DIFF
--- a/designsafe/apps/data/templates/data/data_depot.j2
+++ b/designsafe/apps/data/templates/data/data_depot.j2
@@ -95,7 +95,7 @@ Data Depot
     <base href="{% url 'designsafe_data:data_depot' %}">
 {% endblock %}
 {% block content %}
-    <div class="container">
+    <div class="container dd-container">
         <ddmain style="position: relative;">    
         </ddmain>
     </div>

--- a/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css
+++ b/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css
@@ -1685,7 +1685,10 @@ pre code {
   }
 }
 @media (min-width: 1200px) {
-  .container {
+  .container:not(.dd-container) {
+    width: 1170px;
+  }
+  .dd-container {
     width: 90%;
   }
 }


### PR DESCRIPTION
## Overview: ##
We styled the Data Depot to fill the screen, but other pages rely on the previous container styling. The Data Depot should use a unique class for setting its width.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2467](https://jira.tacc.utexas.edu/browse/DES-2467)

## Summary of Changes: ##

## Testing Steps: ##
1. Navigate to a CMS page (https://designsafe.dev/learning-center/nheri-graduate-student-council/) and make sure the content doesn't exceed 1170px as the window width increases.

## UI Photos:
Before:
![image](https://user-images.githubusercontent.com/12601812/233484371-1854053c-c83d-4f66-9512-902dd68f72fc.png)
After:
![image](https://user-images.githubusercontent.com/12601812/233484107-0153d2df-515a-4316-9df4-f4b48935c56e.png)


## Notes: ##
