### PR TITLE
Date of Publication issue

### DIFF
--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
@@ -99,13 +99,9 @@
                                 (Year of Publication) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                                 (DOI)
                             </span>
-                            <span ng-repeat = "list in $ctrl.dateCreated">
-                                <span ng-if="list.key === mission.value.dois.toString()">
-                                    <span ng-if="mission.value.dois.toString() !== ''">
-                                        ({{ list.value | date:'yyyy' }}) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
-                                        <a href="https://doi.org/{{mission.value.dois.toString()}}">https://doi.org/{{mission.value.dois.toString()}}</a>
-                                    </span>
-                                </span>
+                            <span ng-if="mission.value.dois.toString() !== ''">
+                                (Year appears in Published) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                                <a href="https://doi.org/{{mission.value.dois.toString()}}">https://doi.org/{{mission.value.dois.toString()}}</a>
                             </span>
                         </div>
                         <div class="entity-meta-data" style="padding-bottom: 5px; padding-top: 5px;">
@@ -194,11 +190,7 @@
                                     <span>(Appears when published)</span>
                                 </div>
                                 <div class="entity-meta-data" ng-if="!$ctrl.readOnly && mission.value.dois.toString() !== ''"> 
-                                    <div ng-repeat = "list in $ctrl.dateCreated">
-                                        <div ng-if="list.key === mission.value.dois.toString()">
-                                            <span> {{ list.value | date:'MM-dd-yyyy' }}</span>
-                                        </div>
-                                    </div>
+                                    <span>(Appears in Published)</span>
                                 </div>
                                 <div class="entity-meta-data" ng-if="$ctrl.readOnly && mission.value.dois.toString() !== ''">
                                     <span>{{ $ctrl.doiList[mission.uuid].created | date:'MM-dd-yyyy' }}</span>
@@ -292,13 +284,9 @@
                                 (Year of Publication) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                                 (DOI)
                             </span>
-                            <span ng-repeat = "list in $ctrl.dateCreated">
-                                <span ng-if="list.key === mission.value.dois.toString()">
-                                    <span ng-if="mission.value.dois.toString() !== ''">
-                                        ({{ list.value | date:'yyyy' }}) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
-                                        <a href="https://doi.org/{{mission.value.dois.toString()}}">https://doi.org/{{mission.value.dois.toString()}}</a>
-                                    </span>
-                                </span>
+                            <span ng-if="mission.value.dois.toString() !== ''">
+                                (Year appears in Published) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                                <a href="https://doi.org/{{mission.value.dois.toString()}}">https://doi.org/{{mission.value.dois.toString()}}</a>
                             </span>
                         </div>
 
@@ -419,11 +407,7 @@
                                 <span>(Appears when published)</span>
                             </div>
                             <div class="entity-meta-data" ng-if="!$ctrl.readOnly && mission.value.dois.toString() !== ''"> 
-                                <div ng-repeat = "list in $ctrl.dateCreated">
-                                    <div ng-if="list.key === mission.value.dois.toString()">
-                                        <span> {{ list.value | date:'MM-dd-yyyy' }}</span>
-                                    </div>
-                                </div>
+                                <span>(Appears in Published)</span>
                             </div>
                             <div class="entity-meta-data" ng-if="$ctrl.readOnly && mission.value.dois.toString() !== ''">
                                 <span>{{ $ctrl.doiList[mission.uuid].created | date:'MM-dd-yyyy' }}</span>

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
@@ -189,8 +189,15 @@
                                 <div class="entity-meta-data" ng-if="!$ctrl.readOnly && mission.value.dois.toString() === ''">
                                     <span>(Appears when published)</span>
                                 </div>
-                                <div class="entity-meta-data" ng-if="$ctrl.readOnly || mission.value.dois.toString() !== ''">
-                                    <span>{{ $ctrl.dateCreated | date:'MM-dd-yyyy' }}</span>
+                                <div class="entity-meta-data" ng-if="!$ctrl.readOnly && mission.value.dois.toString() !== ''"> 
+                                    <div ng-repeat = "list in $ctrl.dateCreated">
+                                        <div ng-if="list.key === mission.value.dois.toString()">
+                                            <span> {{ list.value | date:'MM-dd-yyyy' }}</span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="entity-meta-data" ng-if="$ctrl.readOnly && mission.value.dois.toString() !== ''">
+                                    <span>{{ $ctrl.doiList[mission.uuid].created | date:'MM-dd-yyyy' }}</span>
                                 </div>
                             </div>
                             <div class="entity-meta-field">
@@ -402,10 +409,15 @@
                             <div class="entity-meta-data" ng-if="!$ctrl.readOnly && mission.value.dois.toString() === ''">
                                 <span>(Appears when published)</span>
                             </div>
-                            <div class="entity-meta-data" ng-if="$ctrl.readOnly || mission.value.dois.toString() !== ''">
-                                <span>
-                                    {{ $ctrl.dateCreated | date:'MM-dd-yyyy' }}
-                                </span>
+                            <div class="entity-meta-data" ng-if="!$ctrl.readOnly && mission.value.dois.toString() !== ''"> 
+                                <div ng-repeat = "list in $ctrl.dateCreated">
+                                    <div ng-if="list.key === mission.value.dois.toString()">
+                                        <span> {{ list.value | date:'MM-dd-yyyy' }}</span>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="entity-meta-data" ng-if="$ctrl.readOnly && mission.value.dois.toString() !== ''">
+                                <span>{{ $ctrl.doiList[mission.uuid].created | date:'MM-dd-yyyy' }}</span>
                             </div>
                         </div>
                         <div class="entity-meta-field">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
@@ -84,12 +84,12 @@
                         <!-- Refer to publication-citation.template.html to see how projectGen is handled/used -->
                         <div ng-if="$ctrl.projectGen === 1" style="padding-bottom: 5px;  line-height: 1.6;"> 
                             {{ $ctrl.listAuthors(mission.authors) }}
-                            ({{ $ctrl.createdYear }}) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                            ({{ $ctrl.doiList[mission.uuid].created | date:'yyyy' }}) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                             <a href="https://doi.org/{{mission.value.dois.toString()}}">https://doi.org/{{mission.value.dois.toString()}}</a>
                         </div>
                         <div ng-if="$ctrl.projectGen > 1" style="padding-bottom: 5px;  line-height: 1.6;"> 
                             {{ $ctrl.listAuthors(mission.authors) }}
-                            ({{ $ctrl.createdYear }}) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                            ({{ $ctrl.doiList[mission.uuid].created | date:'yyyy' }}) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                             <a href="https://doi.org/{{mission.value.dois.toString()}}">https://doi.org/{{mission.value.dois.toString()}}</a>
                             v{{$ctrl.version}}
                         </div>
@@ -99,9 +99,13 @@
                                 (Year of Publication) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                                 (DOI)
                             </span>
-                            <span ng-if="mission.value.dois.toString() !== ''">
-                                ({{ $ctrl.createdYear }}) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
-                                <a href="https://doi.org/{{mission.value.dois.toString()}}">https://doi.org/{{mission.value.dois.toString()}}</a>
+                            <span ng-repeat = "list in $ctrl.dateCreated">
+                                <span ng-if="list.key === mission.value.dois.toString()">
+                                    <span ng-if="mission.value.dois.toString() !== ''">
+                                        ({{ list.value | date:'yyyy' }}) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                                        <a href="https://doi.org/{{mission.value.dois.toString()}}">https://doi.org/{{mission.value.dois.toString()}}</a>
+                                    </span>
+                                </span>
                             </span>
                         </div>
                         <div class="entity-meta-data" style="padding-bottom: 5px; padding-top: 5px;">
@@ -273,12 +277,12 @@
                         <!-- Refer to publication-citation.template.html to see how projectGen is handled/used -->
                         <div ng-if="$ctrl.projectGen === 1" style="padding-bottom: 5px;  line-height: 1.6;"> 
                             {{ $ctrl.listAuthors(mission.authors) }}
-                            ({{ $ctrl.createdYear }}) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                            ({{ $ctrl.doiList[mission.uuid].created | date:'yyyy' }}) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                             <a href="https://doi.org/{{mission.value.dois.toString()}}">https://doi.org/{{mission.value.dois.toString()}}</a>
                         </div>
                         <div ng-if="$ctrl.projectGen > 1" style="padding-bottom: 5px;  line-height: 1.6;"> 
                             {{ $ctrl.listAuthors(mission.authors) }}
-                            ({{ $ctrl.createdYear }}) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                            ({{ $ctrl.doiList[mission.uuid].created | date:'yyyy' }}) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                             <a href="https://doi.org/{{mission.value.dois.toString()}}">https://doi.org/{{mission.value.dois.toString()}}</a>
                             v{{$ctrl.version}}
                         </div>
@@ -288,11 +292,16 @@
                                 (Year of Publication) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                                 (DOI)
                             </span>
-                            <span ng-if="mission.value.dois.toString() !== ''">
-                                ({{ $ctrl.createdYear }}) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
-                                <a href="https://doi.org/{{mission.value.dois.toString()}}">https://doi.org/{{mission.value.dois.toString()}}</a>
+                            <span ng-repeat = "list in $ctrl.dateCreated">
+                                <span ng-if="list.key === mission.value.dois.toString()">
+                                    <span ng-if="mission.value.dois.toString() !== ''">
+                                        ({{ list.value | date:'yyyy' }}) "{{ mission.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                                        <a href="https://doi.org/{{mission.value.dois.toString()}}">https://doi.org/{{mission.value.dois.toString()}}</a>
+                                    </span>
+                                </span>
                             </span>
                         </div>
+
                         <div class="entity-meta-data" style="padding-bottom: 5px; padding-top: 5px;">
                             <span ng-if="mission.value.dois.toString() !== ''">
                                 Download Citation: 

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.js
@@ -82,12 +82,6 @@ class PublicationPreviewFieldReconCtrl {
                 }
             });
 
-            this.frEnts = [].concat(
-                this.project.mission_set || [],
-                this.project.report_set || [],
-            );
-            this.dateCreated = this.dateCreated(this.frEnts);
-
             const { pi } = this.project.value;
             this.UserService.get(pi).then((res) => {
                 this.authorData.pi = {
@@ -147,19 +141,6 @@ class PublicationPreviewFieldReconCtrl {
             }
             return false;
         }
-    }
-
-    dateCreated(set) {
-        let dateList = [];
-        for (var i = 0; i < set.length; i++) {
-            if (set[i].value.dois.toString() !== '' ){
-                dateList.push({
-                    key:   set[i].value.dois.toString(),
-                    value: set[i].created
-                });
-            }
-        }
-        return dateList;
     }
 
     goWork() {

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.js
@@ -63,7 +63,6 @@ class PublicationPreviewFieldReconCtrl {
                 skipRoot: false
             };
             this.project = project;
-            this.createdYear = new Date(this.project.created).getFullYear();
             this.project.appendEntitiesRel(ents);
 
             this.primaryEnts = [].concat(

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.js
@@ -64,7 +64,6 @@ class PublicationPreviewFieldReconCtrl {
             };
             this.project = project;
             this.createdYear = new Date(this.project.created).getFullYear();
-            this.dateCreated = new Date(this.project.created);
             this.project.appendEntitiesRel(ents);
 
             this.primaryEnts = [].concat(
@@ -83,6 +82,12 @@ class PublicationPreviewFieldReconCtrl {
                     this.orderedSecondary[primEnt.uuid] = this.ordered(primEnt, this.secondaryEnts);
                 }
             });
+
+            this.frEnts = [].concat(
+                this.project.mission_set || [],
+                this.project.report_set || [],
+            );
+            this.dateCreated = this.dateCreated(this.frEnts);
 
             const { pi } = this.project.value;
             this.UserService.get(pi).then((res) => {
@@ -143,6 +148,19 @@ class PublicationPreviewFieldReconCtrl {
             }
             return false;
         }
+    }
+
+    dateCreated(set) {
+        let dateList = [];
+        for (var i = 0; i < set.length; i++) {
+            if (set[i].value.dois.toString() !== '' ){
+                dateList.push({
+                    key:   set[i].value.dois.toString(),
+                    value: set[i].created
+                });
+            }
+        }
+        return dateList;
     }
 
     goWork() {

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
@@ -213,14 +213,19 @@
                     </div>
                     <div class="entity-meta-field">
                         <div class="entity-meta-label">Date of Publication</div>
-                        <span class="entity-meta-data"
-                                data-ng-if="!$ctrl.readOnly">
-                            (Appears when published)
-                        </span>
-                        <span class="entity-meta-data"
-                                data-ng-if="$ctrl.readOnly">
-                            {{ $ctrl.dateCreated | date:'MM-dd-yyyy' }}
-                        </span>
+                        <div class="entity-meta-data" ng-if="!$ctrl.readOnly && hybsim.value.dois.toString() === ''">
+                            <span>(Appears when published)</span>
+                        </div>
+                        <div class="entity-meta-data" ng-if="!$ctrl.readOnly && hybsim.value.dois.toString() !== ''">
+                                <div ng-repeat = "list in $ctrl.dateCreated">
+                                    <div ng-if="list.key === hybsim.value.dois.toString()">
+                                        <span> {{ list.value | date:'MM-dd-yyyy' }}</span>
+                                    </div>
+                                </div>
+                        </div>
+                        <div class="entity-meta-data" ng-if="$ctrl.readOnly && hybsim.value.dois.toString() !== ''">
+                            <span>{{ $ctrl.doiList[hybsim.uuid].created | date:'MM-dd-yyyy' }}</span>
+                        </div>
                     </div>
                     <div class="entity-meta-field">
                         <div class="entity-meta-label">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
@@ -118,13 +118,9 @@
                         (Year of Publication) "{{ hybsim.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                         (DOI)
                     </span>
-                    <span ng-repeat = "list in $ctrl.dateCreated">
-                        <span ng-if="list.key === hybsim.value.dois.toString()">
-                            <span ng-if="hybsim.value.dois.toString() !== ''">
-                                ({{ list.value | date:'yyyy' }}) "{{ hybsim.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
-                                <a href="https://doi.org/{{hybsim.value.dois.toString()}}">https://doi.org/{{hybsim.value.dois.toString()}}</a>
-                            </span>
-                        </span>
+                    <span ng-if="hybsim.value.dois.toString() !== ''">
+                        (Year appears in Published) "{{ hybsim.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                        <a href="https://doi.org/{{hybsim.value.dois.toString()}}">https://doi.org/{{hybsim.value.dois.toString()}}</a>
                     </span>
                 </div>
                 
@@ -222,11 +218,7 @@
                             <span>(Appears when published)</span>
                         </div>
                         <div class="entity-meta-data" ng-if="!$ctrl.readOnly && hybsim.value.dois.toString() !== ''">
-                                <div ng-repeat = "list in $ctrl.dateCreated">
-                                    <div ng-if="list.key === hybsim.value.dois.toString()">
-                                        <span> {{ list.value | date:'MM-dd-yyyy' }}</span>
-                                    </div>
-                                </div>
+                            <span>(Appears in Published)</span>
                         </div>
                         <div class="entity-meta-data" ng-if="$ctrl.readOnly && hybsim.value.dois.toString() !== ''">
                             <span>{{ $ctrl.doiList[hybsim.uuid].created | date:'MM-dd-yyyy' }}</span>

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
@@ -103,26 +103,31 @@
                 <!-- Refer to publication-citation.template.html to see how projectGen is handled/used -->
                 <div ng-if="$ctrl.projectGen === 1" style="padding-bottom: 5px; line-height: 1.6;"> 
                     {{ $ctrl.listAuthors(hybsim.authors) }}
-                    ({{ $ctrl.createdYear }}) "{{ hybsim.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                    ({{ $ctrl.doiList[hybsim.uuid].created | date:'yyyy' }}) "{{ hybsim.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                     <a href="https://doi.org/{{hybsim.value.dois.toString()}}">https://doi.org/{{hybsim.value.dois.toString()}}</a>
                 </div>
                 <div ng-if="$ctrl.projectGen > 1" style="padding-bottom: 5px;  line-height: 1.6;"> 
                     {{ $ctrl.listAuthors(hybsim.authors) }}
-                    ({{ $ctrl.createdYear }}) "{{ hybsim.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                    ({{ $ctrl.doiList[hybsim.uuid].created | date:'yyyy' }}) "{{ hybsim.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                     <a href="https://doi.org/{{hybsim.value.dois.toString()}}">https://doi.org/{{hybsim.value.dois.toString()}}</a>
                     v{{$ctrl.version}}
                 </div>
-                <div ng-if="!$ctrl.readOnly" style="padding-bottom: 5px; line-height: 1.6;">  
+                <div ng-if="!$ctrl.readOnly" style="padding-bottom: 5px; line-height: 1.6;"> 
                     <ds-author-list format="citation" authors="hybsim.value.authors"></ds-author-list>
                     <span ng-if="hybsim.value.dois.toString() === ''">
                         (Year of Publication) "{{ hybsim.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                         (DOI)
                     </span>
-                    <span ng-if="hybsim.value.dois.toString() !== ''">
-                        ({{ $ctrl.createdYear }}) "{{ hybsim.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
-                        <a href="https://doi.org/{{hybsim.value.dois.toString()}}">https://doi.org/{{hybsim.value.dois.toString()}}</a>
+                    <span ng-repeat = "list in $ctrl.dateCreated">
+                        <span ng-if="list.key === hybsim.value.dois.toString()">
+                            <span ng-if="hybsim.value.dois.toString() !== ''">
+                                ({{ list.value | date:'yyyy' }}) "{{ hybsim.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                                <a href="https://doi.org/{{hybsim.value.dois.toString()}}">https://doi.org/{{hybsim.value.dois.toString()}}</a>
+                            </span>
+                        </span>
                     </span>
                 </div>
+                
                 <div class="entity-meta-data" style="padding-bottom: 5px; padding-top: 5px;">
                     <span ng-if="hybsim.value.dois.toString() !== ''">
                         Download Citation: 

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.js
@@ -67,11 +67,6 @@ class PublicationPreviewHybSimCtrl {
                 this.project = project;
                 this.project.appendEntitiesRel(ents);
 
-                this.hybSimEnts = [].concat(
-                    this.project.hybridsimulation_set || []
-                );
-                this.dateCreated = this.dateCreated(this.hybSimEnts);
-
                 this.listing = this.FileListingService.listings.main.listing;
                 this.FileListingService.abstractListing(ents, project.uuid).then((_) => {
                     this.ui.loading = false;
@@ -120,19 +115,6 @@ class PublicationPreviewHybSimCtrl {
             }
             return false;
         }
-    }
-
-    dateCreated(set) {
-        let dateList = [];
-        for (var i = 0; i < set.length; i++) {
-            if (set[i].value.dois.toString() !== '' ){
-                dateList.push({
-                    key:   set[i].value.dois.toString(),
-                    value: set[i].created
-                });
-            }
-        }
-        return dateList;
     }
 
     isValid(ent) {

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.js
@@ -65,8 +65,6 @@ class PublicationPreviewHybSimCtrl {
                     skipRoot: false,
                 };
                 this.project = project;
-                this.createdYear = new Date(this.project.created).getFullYear();
-                // this.dateCreated = new Date(this.project.created);
                 this.project.appendEntitiesRel(ents);
 
                 this.hybSimEnts = [].concat(

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.js
@@ -66,8 +66,14 @@ class PublicationPreviewHybSimCtrl {
                 };
                 this.project = project;
                 this.createdYear = new Date(this.project.created).getFullYear();
-                this.dateCreated = new Date(this.project.created);
+                // this.dateCreated = new Date(this.project.created);
                 this.project.appendEntitiesRel(ents);
+
+                this.hybSimEnts = [].concat(
+                    this.project.hybridsimulation_set || []
+                );
+                this.dateCreated = this.dateCreated(this.hybSimEnts);
+
                 this.listing = this.FileListingService.listings.main.listing;
                 this.FileListingService.abstractListing(ents, project.uuid).then((_) => {
                     this.ui.loading = false;
@@ -116,6 +122,19 @@ class PublicationPreviewHybSimCtrl {
             }
             return false;
         }
+    }
+
+    dateCreated(set) {
+        let dateList = [];
+        for (var i = 0; i < set.length; i++) {
+            if (set[i].value.dois.toString() !== '' ){
+                dateList.push({
+                    key:   set[i].value.dois.toString(),
+                    value: set[i].created
+                });
+            }
+        }
+        return dateList;
     }
 
     isValid(ent) {

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.js
@@ -28,13 +28,11 @@ class PublicationPreviewOtherCtrl {
                 this.ProjectService.get({ uuid: this.projectId }).then((project) => {
                 this.project = project;
                 this.createdYear = new Date(this.project.created).getFullYear();
-                this.dateCreated = new Date(this.project.created);
                 this.ui.loading = false;
             });
         } else {
             this.project = this.data;
             this.createdYear = new Date(this.project.created).getFullYear();
-            this.dateCreated = new Date(this.project.created);
             this.ui.loading = false;
         }    
     }

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.js
@@ -28,11 +28,13 @@ class PublicationPreviewOtherCtrl {
                 this.ProjectService.get({ uuid: this.projectId }).then((project) => {
                 this.project = project;
                 this.createdYear = new Date(this.project.created).getFullYear();
+                this.dateCreated = new Date(this.project.created);
                 this.ui.loading = false;
             });
         } else {
             this.project = this.data;
             this.createdYear = new Date(this.project.created).getFullYear();
+            this.dateCreated = new Date(this.project.created);
             this.ui.loading = false;
         }    
     }

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
@@ -217,8 +217,15 @@
                         <div class="entity-meta-data" ng-if="!$ctrl.readOnly && simulation.value.dois.toString() === ''">
                             <span>(Appears when published)</span>
                         </div>
-                        <div class="entity-meta-data" ng-if="$ctrl.readOnly || simulation.value.dois.toString() !== ''">
-                            <span>{{ $ctrl.dateCreated | date:'MM-dd-yyyy' }}</span>
+                        <div class="entity-meta-data" ng-if="!$ctrl.readOnly && simulation.value.dois.toString() !== ''">  
+                            <div ng-repeat = "list in $ctrl.dateCreated">
+                                <div ng-if="list.key === simulation.value.dois.toString()">
+                                    <span> {{ list.value | date:'MM-dd-yyyy' }}</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="entity-meta-data" ng-if="$ctrl.readOnly && simulation.value.dois.toString() !== ''">
+                            <span>{{ $ctrl.doiList[simulation.uuid].created | date:'MM-dd-yyyy' }}</span>
                         </div>
                     </div>
                     <div class="entity-meta-field">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
@@ -119,13 +119,9 @@
                         (Year of Publication) "{{ simulation.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                         (DOI)
                     </span>
-                    <span ng-repeat = "list in $ctrl.dateCreated">
-                        <span ng-if="list.key === simulation.value.dois.toString()">
-                            <span ng-if="simulation.value.dois.toString() !== ''">
-                                ({{ list.value | date:'yyyy' }}) "{{ simulation.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
-                                <a href="https://doi.org/{{simulation.value.dois.toString()}}">https://doi.org/{{simulation.value.dois.toString()}}</a>
-                            </span>
-                        </span>
+                    <span ng-if="simulation.value.dois.toString() !== ''">
+                        (Year appears in Published) "{{ simulation.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                        <a href="https://doi.org/{{simulation.value.dois.toString()}}">https://doi.org/{{simulation.value.dois.toString()}}</a>
                     </span>
                 </div>
                 
@@ -223,11 +219,7 @@
                             <span>(Appears when published)</span>
                         </div>
                         <div class="entity-meta-data" ng-if="!$ctrl.readOnly && simulation.value.dois.toString() !== ''">  
-                            <div ng-repeat = "list in $ctrl.dateCreated">
-                                <div ng-if="list.key === simulation.value.dois.toString()">
-                                    <span> {{ list.value | date:'MM-dd-yyyy' }}</span>
-                                </div>
-                            </div>
+                            <span>(Appears in Published)</span>
                         </div>
                         <div class="entity-meta-data" ng-if="$ctrl.readOnly && simulation.value.dois.toString() !== ''">
                             <span>{{ $ctrl.doiList[simulation.uuid].created | date:'MM-dd-yyyy' }}</span>

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
@@ -104,12 +104,12 @@
                 <!-- Refer to publication-citation.template.html to see how projectGen is handled/used -->
                 <div ng-if="$ctrl.projectGen === 1" style="padding-bottom: 5px; line-height: 1.6;"> 
                     {{ $ctrl.listAuthors(simulation.authors) }}
-                    ({{ $ctrl.createdYear }}) "{{ simulation.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                    ({{ $ctrl.doiList[simulation.uuid].created | date:'yyyy' }}) "{{ simulation.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                     <a href="https://doi.org/{{simulation.value.dois.toString()}}">https://doi.org/{{simulation.value.dois.toString()}}</a>
                 </div>
                 <div ng-if="$ctrl.projectGen > 1" style="padding-bottom: 5px;  line-height: 1.6;"> 
                     {{ $ctrl.listAuthors(simulation.authors) }}
-                    ({{ $ctrl.createdYear }}) "{{ simulation.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                    ({{ $ctrl.doiList[simulation.uuid].created | date:'yyyy' }}) "{{ simulation.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                     <a href="https://doi.org/{{simulation.value.dois.toString()}}">https://doi.org/{{simulation.value.dois.toString()}}</a>
                     v{{$ctrl.version}}
                 </div>
@@ -119,11 +119,16 @@
                         (Year of Publication) "{{ simulation.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                         (DOI)
                     </span>
-                    <span ng-if="simulation.value.dois.toString() !== ''">
-                        ({{ $ctrl.createdYear }}) "{{ simulation.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
-                        <a href="https://doi.org/{{simulation.value.dois.toString()}}">https://doi.org/{{simulation.value.dois.toString()}}</a>
+                    <span ng-repeat = "list in $ctrl.dateCreated">
+                        <span ng-if="list.key === simulation.value.dois.toString()">
+                            <span ng-if="simulation.value.dois.toString() !== ''">
+                                ({{ list.value | date:'yyyy' }}) "{{ simulation.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                                <a href="https://doi.org/{{simulation.value.dois.toString()}}">https://doi.org/{{simulation.value.dois.toString()}}</a>
+                            </span>
+                        </span>
                     </span>
                 </div>
+                
                 <div class="entity-meta-data" style="padding-bottom: 5px; padding-top: 5px;">
                     <span ng-if="simulation.value.dois.toString() !== ''">
                         Download Citation: 

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.js
@@ -67,11 +67,6 @@ class PublicationPreviewSimCtrl {
             this.project = project;
             this.project.appendEntitiesRel(ents);
 
-            this.simEnts = [].concat(
-                this.project.simulation_set || []
-            );
-            this.dateCreated = this.dateCreated(this.simEnts);
-
             this.listing = this.FileListingService.listings.main.listing;
             this.FileListingService.abstractListing(ents, project.uuid).then((_) => {
                 this.ui.loading = false;
@@ -120,19 +115,6 @@ class PublicationPreviewSimCtrl {
             }
             return false;
         }
-    }
-
-    dateCreated(set) {
-        let dateList = [];
-        for (var i = 0; i < set.length; i++) {
-            if (set[i].value.dois.toString() !== '' ){
-                dateList.push({
-                    key:   set[i].value.dois.toString(),
-                    value: set[i].created
-                });
-            }
-        }
-        return dateList;
     }
 
     isValid(ent) {

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.js
@@ -65,7 +65,6 @@ class PublicationPreviewSimCtrl {
                 skipRoot: false
             };
             this.project = project;
-            this.createdYear = new Date(this.project.created).getFullYear();
             this.project.appendEntitiesRel(ents);
 
             this.simEnts = [].concat(

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.js
@@ -66,8 +66,13 @@ class PublicationPreviewSimCtrl {
             };
             this.project = project;
             this.createdYear = new Date(this.project.created).getFullYear();
-            this.dateCreated = new Date(this.project.created);
             this.project.appendEntitiesRel(ents);
+
+            this.simEnts = [].concat(
+                this.project.simulation_set || []
+            );
+            this.dateCreated = this.dateCreated(this.simEnts);
+
             this.listing = this.FileListingService.listings.main.listing;
             this.FileListingService.abstractListing(ents, project.uuid).then((_) => {
                 this.ui.loading = false;
@@ -116,6 +121,19 @@ class PublicationPreviewSimCtrl {
             }
             return false;
         }
+    }
+
+    dateCreated(set) {
+        let dateList = [];
+        for (var i = 0; i < set.length; i++) {
+            if (set[i].value.dois.toString() !== '' ){
+                dateList.push({
+                    key:   set[i].value.dois.toString(),
+                    value: set[i].created
+                });
+            }
+        }
+        return dateList;
     }
 
     isValid(ent) {

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
@@ -100,12 +100,12 @@
                 <!-- Refer to publication-citation.template.html to see how projectGen is handled/used -->
                 <div ng-if="$ctrl.projectGen === 1" style="padding-bottom: 5px; line-height: 1.6;"> 
                     {{ $ctrl.listAuthors(experiment.authors) }}
-                    ({{ $ctrl.createdYear }}) "{{ experiment.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                    ({{ $ctrl.doiList[experiment.uuid].created | date:'yyyy' }}) "{{ experiment.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                     <a href="https://doi.org/{{experiment.value.dois.toString()}}">https://doi.org/{{experiment.value.dois.toString()}}</a>
                 </div>
                 <div ng-if="$ctrl.projectGen > 1" style="padding-bottom: 5px; line-height: 1.6;"> 
                     {{ $ctrl.listAuthors(experiment.authors) }}
-                    ({{ $ctrl.createdYear }}) "{{ experiment.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                    ({{ $ctrl.doiList[experiment.uuid].created | date:'yyyy' }}) "{{ experiment.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                     <a href="https://doi.org/{{experiment.value.dois.toString()}}">https://doi.org/{{experiment.value.dois.toString()}}</a>
                     v{{$ctrl.version}}
                 </div>
@@ -116,10 +116,15 @@
                         (DOI)
                     </span>
                     <span ng-if="experiment.value.dois.toString() !== ''">
-                        ({{ $ctrl.createdYear }}) "{{ experiment.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
-                        <a href="https://doi.org/{{experiment.value.dois.toString()}}">https://doi.org/{{experiment.value.dois.toString()}}</a>
+                        <span ng-repeat = "list in $ctrl.dateCreated">
+                            <span ng-if="list.key === experiment.value.dois.toString()">
+                                ({{ list.value | date:'yyyy' }}) "{{ experiment.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                                <a href="https://doi.org/{{experiment.value.dois.toString()}}">https://doi.org/{{experiment.value.dois.toString()}}</a>
+                            </span>
+                        </span>
                     </span>
                 </div>
+                
                 <div class="entity-meta-data" style="padding-bottom: 5px; padding-top: 5px;">
                     <span ng-if="experiment.value.dois.toString() !== ''">
                         Download Citation: 

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
@@ -240,8 +240,15 @@
                         <div class="entity-meta-data" ng-if="!$ctrl.readOnly && experiment.value.dois.toString() === ''">
                             <span>(Appears when published)</span>
                         </div>
-                        <div class="entity-meta-data" ng-if="$ctrl.readOnly || experiment.value.dois.toString() !== ''">
-                            <span>{{ $ctrl.dateCreated | date:'MM-dd-yyyy' }}</span>
+                        <div class="entity-meta-data" ng-if="!$ctrl.readOnly && experiment.value.dois.toString() !== ''">
+                            <div ng-repeat = "list in $ctrl.dateCreated">
+                                <div ng-if="list.key === experiment.value.dois.toString()">
+                                    <span> {{ list.value | date:'MM-dd-yyyy' }}</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="entity-meta-data" ng-if="$ctrl.readOnly && experiment.value.dois.toString() !== ''">
+                            <span>{{ $ctrl.doiList[experiment.uuid].created | date:'MM-dd-yyyy' }}</span>
                         </div>
                     </div>
                     <div class="entity-meta-field">

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
@@ -116,12 +116,8 @@
                         (DOI)
                     </span>
                     <span ng-if="experiment.value.dois.toString() !== ''">
-                        <span ng-repeat = "list in $ctrl.dateCreated">
-                            <span ng-if="list.key === experiment.value.dois.toString()">
-                                ({{ list.value | date:'yyyy' }}) "{{ experiment.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
-                                <a href="https://doi.org/{{experiment.value.dois.toString()}}">https://doi.org/{{experiment.value.dois.toString()}}</a>
-                            </span>
-                        </span>
+                        (Year appears in Published) "{{ experiment.value.title }}", in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
+                        <a href="https://doi.org/{{experiment.value.dois.toString()}}">https://doi.org/{{experiment.value.dois.toString()}}</a>
                     </span>
                 </div>
                 
@@ -246,11 +242,7 @@
                             <span>(Appears when published)</span>
                         </div>
                         <div class="entity-meta-data" ng-if="!$ctrl.readOnly && experiment.value.dois.toString() !== ''">
-                            <div ng-repeat = "list in $ctrl.dateCreated">
-                                <div ng-if="list.key === experiment.value.dois.toString()">
-                                    <span> {{ list.value | date:'MM-dd-yyyy' }}</span>
-                                </div>
-                            </div>
+                            <span>(Appears in Published)</span>
                         </div>
                         <div class="entity-meta-data" ng-if="$ctrl.readOnly && experiment.value.dois.toString() !== ''">
                             <span>{{ $ctrl.doiList[experiment.uuid].created | date:'MM-dd-yyyy' }}</span>

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.js
@@ -69,8 +69,13 @@ class PublicationPreviewCtrl {
                 this.breadcrumbParams.root.label = project.value.projectId
                 this.project = project;
                 this.createdYear = new Date(this.project.created).getFullYear();
-                this.dateCreated = new Date(this.project.created);
                 this.project.appendEntitiesRel(ents);
+
+                this.expEnts = [].concat(
+                    this.project.experiment_set || []
+                );
+                this.dateCreated = this.dateCreated(this.expEnts);
+
                 this.listing = this.FileListingService.listings.main.listing;
                 this.FileListingService.abstractListing(ents, project.uuid).then((_) => {
                     this.ui.loading = false;
@@ -119,6 +124,19 @@ class PublicationPreviewCtrl {
             }
             return false;
         }
+    }
+
+    dateCreated(set) {
+        let dateList = [];
+        for (var i = 0; i < set.length; i++) {
+            if (set[i].value.dois.toString() !== '' ){
+                dateList.push({
+                    key:   set[i].value.dois.toString(),
+                    value: set[i].created
+                });
+            }
+        }
+        return dateList;
     }
 
     isValid(ent) {

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.js
@@ -68,7 +68,6 @@ class PublicationPreviewCtrl {
 
                 this.breadcrumbParams.root.label = project.value.projectId
                 this.project = project;
-                this.createdYear = new Date(this.project.created).getFullYear();
                 this.project.appendEntitiesRel(ents);
 
                 this.expEnts = [].concat(

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.js
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.js
@@ -70,11 +70,6 @@ class PublicationPreviewCtrl {
                 this.project = project;
                 this.project.appendEntitiesRel(ents);
 
-                this.expEnts = [].concat(
-                    this.project.experiment_set || []
-                );
-                this.dateCreated = this.dateCreated(this.expEnts);
-
                 this.listing = this.FileListingService.listings.main.listing;
                 this.FileListingService.abstractListing(ents, project.uuid).then((_) => {
                     this.ui.loading = false;
@@ -123,19 +118,6 @@ class PublicationPreviewCtrl {
             }
             return false;
         }
-    }
-
-    dateCreated(set) {
-        let dateList = [];
-        for (var i = 0; i < set.length; i++) {
-            if (set[i].value.dois.toString() !== '' ){
-                dateList.push({
-                    key:   set[i].value.dois.toString(),
-                    value: set[i].created
-                });
-            }
-        }
-        return dateList;
     }
 
     isValid(ent) {

--- a/designsafe/static/scripts/data-depot/components/published/published-view.component.js
+++ b/designsafe/static/scripts/data-depot/components/published/published-view.component.js
@@ -107,8 +107,6 @@ class PublishedViewCtrl {
             skipRoot: true,
         };
 
-        this.createdYear = new Date(this.publication.created).getFullYear();
-        this.dateCreated = new Date(this.publication.created);
         this.projectGen = this.publication.version || 1;
         if (this.projectGen === 1) {
             // early publications - other & experimental

--- a/designsafe/static/scripts/data-depot/components/published/published-view.component.js
+++ b/designsafe/static/scripts/data-depot/components/published/published-view.component.js
@@ -106,7 +106,7 @@ class PublishedViewCtrl {
             path: this.prjBasePath,
             skipRoot: true,
         };
-
+        this.createdYear = new Date(this.publication.created).getFullYear();
         this.projectGen = this.publication.version || 1;
         if (this.projectGen === 1) {
             // early publications - other & experimental

--- a/designsafe/static/scripts/projects/components/published-data-modal/published-data-modal.component.js
+++ b/designsafe/static/scripts/projects/components/published-data-modal/published-data-modal.component.js
@@ -23,7 +23,7 @@ class PublishedDataModalCtrl {
         if (type === 'hybrid_simulation') this.entName = 'Hybrid Simulation';
         if (type === 'field_recon') this.entName = 'Mission';
 
-        this.versionDate = `${date.getMonth()}/${date.getDate()}/${date.getFullYear()}`;
+        this.versionDate = `${date.getMonth()+1}/${date.getDate()}/${date.getFullYear()}`;
         this.version = this.publication.revision;
         this.versionedTitles = this.publication.revisionTitles;
         this.versionDescription = this.publication.revisionText;


### PR DESCRIPTION
## Overview: ##
Date of Publication was always showing the newest date, meaning if a version or amend was done, then the Date of Publication was updated. This is an issue because the Date of Publication should always show the actual date if was published. 

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2492](https://jira.tacc.utexas.edu/browse/DES-2492)

## Summary of Changes: ##
For Simulation, FR, Experimental, and Hybrid Sim, I added a dictionary called dateCreated that stores a DOI : dateCreated. In the html, the dictionary is cycled through, and when the entity DOI matches the dictionary DOI, then the dateCreated is displayed. 
For type Other, the Date of Publication is not displayed on the Project side, so no changes were made. 

## Testing Steps: ##
For each project type:
1. Find a project that has versions. 
2. In both  'My Projects' and 'Published' confirm that each entity has it's proper Date of Publication. If it's versioned, these dates should not be all the same. 

For project type other:
1. Confirm that changes are needed.

## UI Photos:
<img width="1175" alt="Screen Shot 2023-05-31 at 10 02 20 AM" src="https://github.com/DesignSafe-CI/portal/assets/35277477/5a6bfdd8-0c80-464c-a79e-5682e2a23ad0">

## Notes: ##
