### PR TITLE
fix(a11y): DES-2476 role button on cms dropdown menu link

### DIFF
--- a/designsafe/templates/includes/cms_menu.html
+++ b/designsafe/templates/includes/cms_menu.html
@@ -3,7 +3,7 @@
 {% for child in children %}
 <li class="{% if child.ancestor or child.selected or request.get_full_path == child.url %}active{% endif %} {% if child.children %}dropdown{% endif %} {{child.attr.class}}">
     {% if child.children %}
-      <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ child.get_menu_title | safe }} <span class="caret"></span></a>
+      <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">{{ child.get_menu_title | safe }} <span class="caret"></span></a>
       <ul class="dropdown-menu">
         <!--
         <li {%if child.selected %}class="active"{% endif %}>


### PR DESCRIPTION
## Overview / Summary: ##

Add `role="button"` attribute to CMS dropdown menu links.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2476](https://jira.tacc.utexas.edu/browse/DES-2476)

## Testing Steps: ##
1. Verify `role="button"` is on any CMS menu link that, when pressed, reveals a dropdown menu.
1. Verify `role="button"` is **not** on any CMS menu link that, when pressed, opens a page.

## UI Photos:

Skipped.