### PR TITLE
fix(a11y): DES-2480 aria-expanded default false cms menu

### DIFF
--- a/designsafe/templates/includes/cms_menu.html
+++ b/designsafe/templates/includes/cms_menu.html
@@ -3,7 +3,7 @@
 {% for child in children %}
 <li class="{% if child.ancestor or child.selected or request.get_full_path == child.url %}active{% endif %} {% if child.children %}dropdown{% endif %} {{child.attr.class}}">
     {% if child.children %}
-      <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ child.get_menu_title | safe }} <span class="caret"></span></a>
+      <a class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false" href="#">{{ child.get_menu_title | safe }} <span class="caret"></span></a>
       <ul class="dropdown-menu">
         <!--
         <li {%if child.selected %}class="active"{% endif %}>


### PR DESCRIPTION
## Overview / Summary: ##

Add `aria-expanded="false"` to CMS dropdown menu links.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2480](https://jira.tacc.utexas.edu/browse/DES-2480)

## Testing Steps: ##
1. Verify `aria-expanded="false"` is on any CMS menu link that would reveal a dropdown menu when pressed.

Do not actually click the link. You test that the attribute is there and is `false` by default (without clicking).

### Regression Test

3. Click such a CMS menu link.
4. Verify the attribute is now `aria-expanded="true"`.
5. Click that link again, or click outside the menu.
6. Verify the attribute is now `aria-expanded="false"`.
7. Repeat indefinitely.

## UI Photos:

Skipped.