### PR TITLE
fix(a11y): DES-2482 cms icons, role as presentation

### DIFF
--- a/designsafe/static/scripts/data-depot/components/data-depot-nav/data-depot-nav.component.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-nav/data-depot-nav.component.html
@@ -32,7 +32,7 @@
     style="width:100%;"
     data-toggle="dropdown"
     href="#">
-    Help<span class="caret"></span>
+    Help<span class="caret" role="presentation"></span>
   </button>
   <ul class="dropdown-menu" style="left:unset; text-align:center; min-width: 165px;">
     <li>

--- a/designsafe/static/scripts/geo/html/map.html
+++ b/designsafe/static/scripts/geo/html/map.html
@@ -239,7 +239,7 @@
         <div class="btn-group" role="group">
           <button class="btn btn-info btn-xs dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             File
-            <span class="caret"></span>
+            <span class="caret" role="presentation"></span>
           </button>
           <ul class="dropdown-menu">
             <!-- <li ng-click="vm.open_existing_project()">Open Existing Project</li> -->
@@ -256,7 +256,7 @@
         <div class="btn-group" role="group">
           <button class="btn btn-default btn-xs dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Import Data
-            <span class="caret"></span>
+            <span class="caret" role="presentation"></span>
           </button>
           <ul class="dropdown-menu">
             <li ng-click="vm.openFileDialog()"> Import data locally</li>

--- a/designsafe/templates/includes/cms_menu.html
+++ b/designsafe/templates/includes/cms_menu.html
@@ -3,7 +3,7 @@
 {% for child in children %}
 <li class="{% if child.ancestor or child.selected or request.get_full_path == child.url %}active{% endif %} {% if child.children %}dropdown{% endif %} {{child.attr.class}}">
     {% if child.children %}
-      <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ child.get_menu_title | safe }} <span class="caret"></span></a>
+      <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ child.get_menu_title | safe }} <span class="caret" role="presentation"></span></a>
       <ul class="dropdown-menu">
         <!--
         <li {%if child.selected %}class="active"{% endif %}>

--- a/designsafe/templates/includes/ef_navigation.html
+++ b/designsafe/templates/includes/ef_navigation.html
@@ -4,9 +4,9 @@
     <div class="navbar-header">
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#main-navigation" aria-expanded="false">
         <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
+        <span class="icon-bar" role="presentation"></span>
+        <span class="icon-bar" role="presentation"></span>
+        <span class="icon-bar" role="presentation"></span>
       </button>
       <a class="navbar-brand" href="/"><i class="fa fa-home"></i></a>
     </div>

--- a/designsafe/templates/includes/header.html
+++ b/designsafe/templates/includes/header.html
@@ -53,7 +53,7 @@
       <a href="{% url 'designsafe_dashboard:index' %}" class="btn btn-link-alt">Welcome, {{ user.first_name }}!</a>
       <button type="button" class="btn btn-link-alt dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
         aria-expanded="false">
-        <span class="caret"></span>
+        <span class="caret" role="presentation"></span>
         <span class="sr-only">Toggle Dropdown</span>
       </button>
       <ul class="dropdown-menu">

--- a/designsafe/templates/includes/homepage_navigation.html
+++ b/designsafe/templates/includes/homepage_navigation.html
@@ -5,9 +5,9 @@
         <li>
           <button class="navbar-toggle" data-toggle="dropdown" aria-expanded="true" style="display:inherit">
             <span class="sr-only">Section navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
+            <span class="icon-bar" role="presentation"></span>
+            <span class="icon-bar" role="presentation"></span>
+            <span class="icon-bar" role="presentation"></span>
           </button>
           <ul class="dropdown-menu">
             {% include 'includes/global_nav.html' %}
@@ -16,9 +16,9 @@
       </ul>
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#main-navigation" aria-expanded="false">
         <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
+        <span class="icon-bar" role="presentation"></span>
+        <span class="icon-bar" role="presentation"></span>
+        <span class="icon-bar" role="presentation"></span>
       </button>
     </div>
     <!-- Collect the nav links, forms, and other content for toggling -->

--- a/designsafe/templates/includes/navigation.html
+++ b/designsafe/templates/includes/navigation.html
@@ -6,9 +6,9 @@
         <li>
           <button class="navbar-toggle hidden-sm hidden-md hidden-lg" data-toggle="dropdown" aria-expanded="true" style="display:inherit">
             <span class="sr-only">Section navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
+            <span class="icon-bar" role="presentation"></span>
+            <span class="icon-bar" role="presentation"></span>
+            <span class="icon-bar" role="presentation"></span>
           </button>
           <ul class="dropdown-menu">
             {% include 'includes/global_nav.html' %}
@@ -20,9 +20,9 @@
       {% endif %} -->
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#main-navigation" aria-expanded="false">
         <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
+        <span class="icon-bar" role="presentation"></span>
+        <span class="icon-bar" role="presentation"></span>
+        <span class="icon-bar" role="presentation"></span>
       </button>
     </div>
 


### PR DESCRIPTION
## Overview / Summary: ##

Add `role="presentation"` to recurring icon elements (which have no text).

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2482](https://jira.tacc.utexas.edu/browse/DES-2482)

## Testing Steps: ##
1. Verify CMS navigation menu dropdown links' `<span class="caret"`s have `role="presentation"`.
2. Verify CMS navigation mobile expand button `<span class="icon-bar"`s have `role="presentation"`.
    <sup>These are only visible when the screen is so narrow the menu changes to mobile layout.</sup>
3. (Optional) If you know where geo map is, check any `<span class="caret"`s have `role="presentation"`.
    <sup>designsafe/static/scripts/data-depot/components/data-depot-nav/data-depot-nav.component.html</sup>
4. (Optional) If you know where data depot nav is, check any `<span class="caret"`s have `role="presentation"`. 
    <sup>designsafe/static/scripts/geo/html/map.html</sup>

## UI Photos:

Skipped.

## Notes: ##

This does not fix the `<i "fa fa…-"></i>` icons. For that, see #1052.