### PR TITLE
fix(a11y): DES-2478 remove the `<h1>` before site logo

### DIFF
--- a/designsafe/templates/ef_base.html
+++ b/designsafe/templates/ef_base.html
@@ -48,7 +48,6 @@
         </div>
         <div class="site-banner-right logo">
           <a href="https://www.designsafe-ci.org/">
-            <h1 class="sr-only">DesignSafe-CI: A Natural Hazards Engineering Community</h1>
             <img alt="DesignSafe-CI" src="{% static 'images/org_logos/Horizontal-DS.jpg' %}" width="100%">
           </a>
         </div>

--- a/designsafe/templates/ef_cms_page.html
+++ b/designsafe/templates/ef_cms_page.html
@@ -44,7 +44,6 @@
       <div class="site-banner-right">
         <div class="text-right">
           <a class="logo" href="https://www.designsafe-ci.org/">
-            <h1 class="sr-only">DesignSafe-CI: A Natural Hazards Engineering Community</h1>
             <img alt="DesignSafe-CI" src="{% static 'images/ds-logo-horiz.png' %}" height="60" width="225">
           </a>
         </div>

--- a/designsafe/templates/includes/header.html
+++ b/designsafe/templates/includes/header.html
@@ -5,7 +5,6 @@
 <header class="site-banner">
   <div class="site-banner-left">
     <a href="/">
-      <h1 class="sr-only">DesignSafe-CI: A Natural Hazards Engineering Research Infrastructure (NHERI)</h1>
       <img alt="DesignSafe-CI" src="{% static 'images/org_logos/Horizontal-DS.jpg' %}" />
     </a>
   </div>


### PR DESCRIPTION
## Overview / Summary: ##

Remove the screen-reader–only `<h1>` before the site logo, because there is already an `<h1>` on every page.
<sup>Both Hp. and W.B. from DesignSafe agreed on this. It is also what W.B. did on https://github.com/TACC/Core-CMS long ago.</sup>

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2478](https://jira.tacc.utexas.edu/browse/DES-2478)

## Testing Steps: ##
1. Verify that there is **not** an `<h1>` before the site logo.

## UI Photos:

Skipped.