### PR TITLE
fix(a11y): DES-2488 `<main>` content

### DIFF
--- a/designsafe/templates/base.j2
+++ b/designsafe/templates/base.j2
@@ -70,11 +70,11 @@
         {% include 'includes/header.html' %}
         {% include 'includes/navigation.html' %}
     </div>
-    <div class="o-site__body">
+    <main class="o-site__body">
         {% include 'includes/messages.html' %}
         {% block breadcrumb %}{% endblock %}
         {% block content %}{% endblock %}
-    </div>
+    </main>
 
     {% block footer %}{% endblock %}
     <div id="toast-container"></div>

--- a/designsafe/templates/ef_base.html
+++ b/designsafe/templates/ef_base.html
@@ -55,10 +55,10 @@
       </header>
       {% include 'includes/ef_navigation.html' %}
     </div>
-    <div class="o-site__body">
+    <main class="o-site__body">
       {% include 'includes/messages.html' %}
       {% block content %}{% endblock %}
-    </div>
+    </main>
     {% include 'includes/footer.html' %}
     <!-- scripts -->
     <script src="{% static 'vendor/modernizr/modernizr.js' %}"></script>


### PR DESCRIPTION
## Overview / Summary: ##

Change `<div>` to `<main>` for main content.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2488](https://jira.tacc.utexas.edu/browse/DES-2488)

## Testing Steps: ##
1. Verify there is 1 and only `<main>` tag on a page.
2. Verify the one `<main>` tag encompasses "main" page content (i.e. not header, not footer).

## UI Photos:

Skipped.