### PR TITLE
fix(a11y): DES-2497 `alt` attributes for images

### DIFF
--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-amend/amend-field-recon.template.html
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-amend/amend-field-recon.template.html
@@ -231,7 +231,7 @@
                                     <div class="entity-meta-label">Data Reuse</div>
                                     <span>
                                         <a ng-click="$ctrl.entityMetrics(mainEntity.doi, 'Mission')">
-                                        &nbsp;<img src='/static/images/ds-icons/icon-metrics.svg' style="height: 12px;">
+                                        &nbsp;<img src='/static/images/ds-icons/icon-metrics.svg' style="height: 12px;" alt="icon of line graph with rising line">
                                         <strong>&nbsp;View Metrics</strong>
                                         </a>
                                     </span>
@@ -479,7 +479,7 @@
                                                         <div class="entity-meta-label">Data Reuse</div>
                                                         <span>
                                                             <a ng-click="$ctrl.entityMetrics(collection.doi, 'Collection')">
-                                                                &nbsp;<img src='/static/images/ds-icons/icon-metrics.svg' style="height: 12px;">
+                                                                &nbsp;<img src='/static/images/ds-icons/icon-metrics.svg' style="height: 12px;" alt="icon of line graph with rising line">
                                                                 <strong>&nbsp;View Collection Metrics</strong>
                                                             </a>
                                                         </span>

--- a/designsafe/static/scripts/data-depot/components/published/published.component.html
+++ b/designsafe/static/scripts/data-depot/components/published/published.component.html
@@ -16,11 +16,11 @@
         <strong>&nbsp;Download Project</strong>
       </a>
       <a class="prj-head-download" ng-click="$ctrl.metrics()">
-        <img src='/static/images/ds-icons/icon-metrics.svg' style="width: 20px;">
+        <img src='/static/images/ds-icons/icon-metrics.svg' alt="icon of line graph with rising line" alt="text bubble icon" style="width: 20px;">
         <strong>&nbsp;View Project Metrics</strong>
     </a>
     <a class="prj-head-download" ng-click="$ctrl.leaveFeedback()">
-      <img src='/static/images/ds-icons/icon-feedback.svg' style="width: 20px;">
+      <img src='/static/images/ds-icons/icon-feedback.svg' alt="icon of chat bubble" style="width: 20px;">
       <strong>Leave Feedback</strong>
     </a>
   </div>

--- a/designsafe/static/scripts/ng-designsafe/directives/templates/prj-pub-collections-template.html
+++ b/designsafe/static/scripts/ng-designsafe/directives/templates/prj-pub-collections-template.html
@@ -188,7 +188,7 @@
                       <div class="entity-meta-label">Data Reuse</div>
                       <span ng-if="$ctrl.readOnly">
                           <a ng-click="$ctrl.entityMetrics(collection.doi, 'Collection')">
-                              &nbsp;<img src='/static/images/ds-icons/icon-metrics.svg' style="height: 12px;">
+                              &nbsp;<img src='/static/images/ds-icons/icon-metrics.svg' style="height: 12px;" alt="icon of line graph with rising line">
                               <strong>&nbsp;View Collection Metrics</strong>
                           </a>
                       </span>

--- a/designsafe/static/scripts/ng-designsafe/directives/templates/prj-pub-preview-metadata-template.html
+++ b/designsafe/static/scripts/ng-designsafe/directives/templates/prj-pub-preview-metadata-template.html
@@ -319,11 +319,11 @@
     </a>
     <span ng-if="$ctrl.readOnly">
         |<a ng-click="$ctrl.metrics()">
-            &nbsp;<img src='/static/images/ds-icons/icon-metrics.svg' style="height: 12px;">
+            &nbsp;<img src='/static/images/ds-icons/icon-metrics.svg' alt="icon of line graph with rising line" style="height: 12px;">
             <strong>&nbsp;View Project Metrics</strong>
         </a>
         |<a ng-click="$ctrl.leaveFeedback()">
-            &nbsp;<img src='/static/images/ds-icons/icon-feedback.svg' style="width: 12px;">
+            &nbsp;<img src='/static/images/ds-icons/icon-feedback.svg' alt="icon of chat bubble" style="width: 12px;">
             <strong>&nbsp;Leave Feedback</strong>
         </a>
     </span>

--- a/designsafe/static/scripts/projects/components/manage-project-type/manage-project-type.template.html
+++ b/designsafe/static/scripts/projects/components/manage-project-type/manage-project-type.template.html
@@ -232,7 +232,7 @@
                 <p>
                     <strong>Experiments</strong> contain all the files you want to publish under a single DOI.
                 </p>
-                <img src="/static/images/expExperiment.png" style="width:100%; padding-bottom: 20px;">
+                <img src="/static/images/expExperiment.png" style="width:100%; padding-bottom: 20px;" alt="screenshot of preview of published experiment &quot;Experiment | Impacts on Vertical Cylinders&quot;">
                 <p>
                     Add another experiment <strong>only if</strong>:
                     <li>The experimental facility, experiment type, or equipment type change</li>
@@ -291,7 +291,7 @@
                         entire project or experiment.
                     </div>
                 </p>
-                <img src="/static/images/expCategory.png" style="width:100%; padding-bottom: 20px;">
+                <img src="/static/images/expCategory.png" style="width:100%; padding-bottom: 20px;" alt="screenshot of interface with cursor over &quot;Select a Category&quot; form field">
                 <li>A file or a directory can belong to one or more categories.</li>
                 <li>Every file in a directory inherits the directory's category.</li>
             </div>
@@ -326,7 +326,7 @@
                     If you have trouble organizing your project, attend <a href="/facilities/virtual-office-hours/" target="_blank">Curation office hours</a> at the beginning of the curation process.
                     You can <a>download</a> and print this diagram to sketch and organize your work.
                 </p>
-                <img src="/static/images/expRelateData.png" style="width:100%; padding-bottom: 20px;">
+                <img src="/static/images/expRelateData.png" style="width:100%; padding-bottom: 20px;" alt="hierarchy diagram of required and optional aspects of an experimental project">
                 <div style="width: 100%; text-align: center; padding-bottom: 20px;">
                     <a href="/static/images/expRelateData.png" download="tree_diagram.png">
                         <i class="fa fa-download"></i> <strong>Download Diagram</strong>
@@ -362,7 +362,7 @@
                     Using agreed-upon tags helps other researchers refine their search and discovered specific files in your publication.
                     The natural hazards community has contributed to creating the agreed-upon terms.
                 </p>
-                <img src="/static/images/expFileTag.png" style="width:100%; padding-bottom: 20px;">
+                <img src="/static/images/expFileTag.png" style="width:100%; padding-bottom: 20px;" alt="screenshot of interface with cursor over &quot;Select Event File Tags&quot; form field">
                 <br>
                 <li>The agreed-upon tags available for selection depend on the categories you have selected.</li>
                 <li>If you can't find a tag that describes your file, select other to type in a short tag.</li>
@@ -447,7 +447,7 @@
                 <p>
                     <strong>Simulations</strong> contain all the files you want to publish under a single DOI.
                 </p>
-                <img src="/static/images/simSimulation.png" style="width:100%; padding-bottom: 20px;">
+                <img src="/static/images/simSimulation.png" alt="screenshot of preview of published imulation &quot;Simulation | Typhoon Haiyanin the Philippines and Similar Synthetic Storms&quot;" style="width:100%; padding-bottom: 20px;">
                 <p>
                     Add another simulation <strong>only if</strong>:
                     <li>The simulation type changes</li>
@@ -503,7 +503,7 @@
                         entire project or experiment.
                     </div>
                 </p>
-                <img src="/static/images/simCategory.png" style="width:100%; padding-bottom: 20px;">
+                <img src="/static/images/simCategory.png" style="width:100%; padding-bottom: 20px;" alt="screenshot of interface with cursor over &quot;Select a Category&quot; form field">
                 <li>A file or a directory can belong to one or more categories.</li>
                 <li>Every file in a directory inherits the directory's category.</li>
             </div>
@@ -538,7 +538,7 @@
                     If you have trouble organizing your project, attend <a href="/facilities/virtual-office-hours/" target="_blank">Curation office hours</a> at the beginning of the curation process.
                     You can <a>download</a> and print this diagram to sketch and organize your work.
                 </p>
-                <img src="/static/images/simRelateData.png" style="width:100%; padding-bottom: 20px;">
+                <img src="/static/images/simRelateData.png" style="width:100%; padding-bottom: 20px;" alt="hierarchy diagram of required and optional aspects of an simulation project">
                 <div style="width: 100%; text-align: center; padding-bottom: 20px;">
                     <a href="/static/images/simRelateData.png" download="tree_diagram.png">
                         <i class="fa fa-download"></i> <strong>Download Diagram</strong>
@@ -574,7 +574,7 @@
                     Using agreed-upon tags helps other researchers refine their search and discovered specific files in your publication.
                     The natural hazards community has contributed to creating the agreed-upon terms.
                 </p>
-                <img src="/static/images/simFileTag.png" style="width:100%; padding-bottom: 20px;">
+                <img src="/static/images/simFileTag.png" style="width:100%; padding-bottom: 20px;" alt="screenshot of interface with cursor over &quot;Select Output File Tag&quot; form field">
                 <br>
                 <li>The agreed-upon tags available for selection depend on the categories you have selected.</li>
                 <li>If you can't find a tag that describes your file, select other to type in a short tag.</li>

--- a/designsafe/static/scripts/rapid/html/index.html
+++ b/designsafe/static/scripts/rapid/html/index.html
@@ -15,7 +15,7 @@
     </div>
     <div class="sidebar-content">
       <div class="sidebar-header">
-        <img class="img-responsive" src="/static/scripts/rapid/images/logo.png" height="50px"></img>
+        <img class="img-responsive" src="/static/scripts/rapid/images/logo.png" height="50px" alt="Recon Portal logo"></img>
       </div>
       <div style="padding-left:10px;">
           <a href="/rw/user-guides/tools-applications/recon-portal/"><i class="fa fa-question-circle"></i> <b>Learn more about contributing.</b></a>

--- a/designsafe/templates/includes/footer.html
+++ b/designsafe/templates/includes/footer.html
@@ -1,7 +1,7 @@
 {% load static cms_tags %}
 <footer class="c-footer s-footer o-site__footer">
   <ul id="logos" class="list-unstyled">
-    <li><img class="img-responsive nsflogo" src="{% static 'images/org_logos/nsf-white.png' %}"></li>
+    <li><img class="img-responsive nsflogo" src="{% static 'images/org_logos/nsf-white.png' %}" alt="NSF logo"></li>
   </ul>
   {% static_placeholder 'site_footer' site or %}
   <p class="text-center">


### PR DESCRIPTION
## Overview / Summary: ##

Add `alt` attributes to images.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2497](https://jira.tacc.utexas.edu/browse/DES-2497)

## Testing Steps: ##
1. Verify the following images have `alt` attributes:
    - NSF logo in footer
    - Recon Portal logo… somewhere
    - screenshots illustrating how to `manage-project-type` e.g. experimental project, simulation project
    - any <img height="14px" src="https://www.designsafe-ci.org/static/images/ds-icons/icon-metrics.svg" /> or <img height="14px" src="https://www.designsafe-ci.org/static/images/ds-icons/icon-feedback.svg" /> icons

## UI Photos:

Skipped.