### PR TITLE
fix: DES-2482 cms search icons, role presentation

### DIFF
--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/publications-listing.template.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/publications-listing.template.html
@@ -7,7 +7,7 @@
                 <div class="input-group" style="display:inline-flex; flex:1; align-items: center; min-width:200px;">
                     
                     <button class="btn btn-success" ng-click="$ctrl.browse()" style="width:fit-content; white-space: nowrap; text-align: center; height: 34px;">
-                        <i class="fa fa-search">&nbsp;</i>Search
+                        <i class="fa fa-search" role="none">&nbsp;</i>Search
                     </button>
                     <input type="text" placeholder="Author, Title, Keyword, Description, Natural Hazard Event, Project ID, or DOI" 
                     data-toggle="tooltip" data-placement="top" title="Author, Title, Keyword, Description, Natural Hazard Event, Project ID, or DOI" aria-label="Search Publications"

--- a/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.html
@@ -9,7 +9,7 @@
             <form class="navbar-form navbar-left" ng-submit="$ctrl.ddSearch()" style="display:flex"
             ng-hide="['Dropbox', 'Box', 'Google Drive', 'NEES Published'].includes($ctrl.placeholder())" role="search">
             <input class="form-control" style="width:240px;" placeholder="Find in {{ $ctrl.placeholder() }}" ng-model="$ctrl.search.queryString" aria-label="Find in {{ $ctrl.placeholder() }}">
-                <button class="btn btn-default" style="clear: right;"> <i class="fa fa-search"></i><span class="sr-only">Search</span></button>
+                <button class="btn btn-default" style="clear: right;"> <i class="fa fa-search" role="none"></i><span class="sr-only">Search</span></button>
             </form>
             <div class="btn-toolbar-right">
                 <div class="btn-group-data-depot-toolbar btn-group">

--- a/designsafe/static/scripts/rapid/html/rapid-admin-users.html
+++ b/designsafe/static/scripts/rapid/html/rapid-admin-users.html
@@ -35,7 +35,7 @@
       <div class="row">
         <h2> Add RAPID Admins </h2>
         <div class="input-group input-group-lg">
-          <span class="input-group-addon"><i class="fa fa-search"></i><span class="sr-only">Search</span></span>
+          <span class="input-group-addon"><i class="fa fa-search" role="none"></i><span class="sr-only">Search</span></span>
           <input type="text"
                  class="form-control"
                  id="rapid_admin_user"

--- a/designsafe/static/scripts/search/components/search/search.component.html
+++ b/designsafe/static/scripts/search/components/search/search.component.html
@@ -41,7 +41,7 @@
             <form ng-submit='$ctrl.search_browse()' role="search">
                 <div class="input-group input-group-lg">
                     <span class="input-group-addon">
-                    <span ng-show="!$ctrl.searching"><i class="fa fa-search" ng-show="!$ctrl.searching"> </i></span>
+                    <span ng-show="!$ctrl.searching"><i class="fa fa-search" role="none" ng-show="!$ctrl.searching"> </i></span>
                     <span ng-show="$ctrl.searching"><i class="fa fa-spinner fa-spin" > </i></span>
                     </span>
     

--- a/designsafe/templates/includes/navigation.html
+++ b/designsafe/templates/includes/navigation.html
@@ -32,7 +32,7 @@
          {% show_menu 1 2 100 100 "includes/cms_menu.html" %}
       </ul>
       <form class="navbar-form navbar-right" role="search">
-        <button class="btn btn-default" id="search_button"> <i class="fa fa-search"></i><span class="sr-only">Search</span></button>
+        <button class="btn btn-default" id="search_button"> <i class="fa fa-search" role="none"></i><span class="sr-only">Search</span></button>
         <input class="form-control" id="searchfield" placeholder="Search DesignSafe" aria-label="Search DesignSafe" style="margin-right:1rem">
 
         <input type="radio" name="search-radio" id="search-radio-website" value="website" checked="checked" style="display:table-cell; vertical-align: middle; margin-top:0px;margin-right:0.25rem;">


### PR DESCRIPTION
## Overview / Summary: ##

Add `role="presentation"` to FontAwesome **Search** icons.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2482](https://jira.tacc.utexas.edu/browse/DES-2482)

## Testing Steps: ##

### CMS

1. Open a few **CMS** pages.
2. Search the markup for `fa fa-`.
3. Verify all `<i class="fa fa-search></i>` are now ``<i role="presentation" class="fa fa-search></i>`.

### Portal

1. Open a few **Portal** sections.
2. Search the markup for `fa fa-`.
3. Verify all `<i class="fa fa-search></i>` are now ``<i role="presentation" class="fa fa-search></i>`.

## UI Photos:

Skipped.

## Notes: ##

This does not fix other FontAwesome icons that need `role="none"`. For that, see #1052.

If you are resolving conflicts, know the ARIA `role="none" is synonymous with `role="presentation"`.