### PR TITLE
fix(a11y): DES-2520 header role attribute

### DIFF
--- a/designsafe/templates/ef_base.html
+++ b/designsafe/templates/ef_base.html
@@ -33,7 +33,7 @@
     {% cms_toolbar %}
     <div>
       {% include 'includes/branding.html' %}
-      <header class="site-banner site-banner-ef">
+      <header class="site-banner site-banner-ef" role="banner">
         <div class="site-banner-left">
           <div class="ef-site-title">
             <a href="/">

--- a/designsafe/templates/includes/header.html
+++ b/designsafe/templates/includes/header.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load auth_extras %}
 {% include 'includes/branding.html' %}
-<header class="site-banner">
+<header class="site-banner" role="banner">
   <div class="site-banner-left">
     <a href="/">
       <img alt="DesignSafe-CI" src="{% static 'images/org_logos/Horizontal-DS.jpg' %}" />


### PR DESCRIPTION
## Overview / Summary: ##

Add a `role="banner"` to any `<header>` that is not a direct child of `<body>`.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2520](https://jira.tacc.utexas.edu/browse/DES-2520)

## Testing Steps: ##
1. Verify `role="banner"` is on a `<header>` that is not a direct child of `<body>`.
    <sup>You can test on of the changes for this on https://designsafeci-dev.tacc.utexas.edu/.</sup>

## UI Photos:

Skipped.

## Notes: ##

I am not sure this solves the problem, but `<header>` was specifically called out on row #34 of [accessiBe report #2](https://acsbace.com/reports/647e36f55a483d0003a37a50?whitelabel=false&utm_medium=email&_hsmi=90649158&utm_source=hs_email).