### PR TITLE
hotfix: remove trailing comma from backend

### DIFF
--- a/designsafe/apps/api/decorators.py
+++ b/designsafe/apps/api/decorators.py
@@ -103,7 +103,7 @@ def agave_jwt_login(func):
             user = None
 
         if user is not None:
-            user.backend = 'django.contrib.auth.backends.ModelBackend',
+            user.backend = 'django.contrib.auth.backends.ModelBackend'
             login(request, user)
 
         return func(request, *args, **kwargs)


### PR DESCRIPTION
## Overview: ##

The `agave_jwt_login` decorator is throwing an error affecting Jupyter project mounts as well as app license calls from a Jupyter instance. There was a trailing comma in the `user.backend` string that may be the culprit, removed in this PR.
```
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: [DJANGO] ERROR 2023-06-06 15:39:52,794 log django.request.log_response:228: Internal Server Error: /api/projects/
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: Traceback (most recent call last):
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: File "/usr/local/lib/python3.7/site-packages/django/core/handlers/exception.py", line 34, in inner
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: response = get_response(request)
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py", line 115, in _get_response
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: response = self.process_exception_by_middleware(e, request)
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py", line 113, in _get_response
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: response = wrapped_callback(request, *callback_args, **callback_kwargs)
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: File "/usr/local/lib/python3.7/site-packages/django/views/generic/base.py", line 71, in view
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: return self.dispatch(request, *args, **kwargs)
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: File "/usr/local/lib/python3.7/site-packages/django/utils/decorators.py", line 45, in _wrapper
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: return bound_method(*args, **kwargs)
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: File "./designsafe/apps/api/decorators.py", line 107, in decorated_function
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: login(request, user)
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: File "/usr/local/lib/python3.7/site-packages/django/contrib/auth/__init__.py", line 124, in login
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: raise TypeError('backend must be a dotted import path string (got %r).' % backend)
Jun 6 10:39:52 designsafe01.tacc.utexas.edu designsafe_main[2040]: TypeError: backend must be a dotted import path string (got 'django.contrib.auth.backends.ModelBackend').
```

## PR Status: ##

* [X] Ready.

## Testing Steps: ##
1.  call `login(request, user)` where `user.backend = 'django.contrib.auth.backends.ModelBackend'`
