### PR TITLE
des2405-add-comma-to-authorList-in-citationPreview

### DIFF
--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-amend/amend-citation.template.html
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-amend/amend-citation.template.html
@@ -70,7 +70,7 @@
                 <h5 style="font-family: Helvetica Neue">Citation Preview</h5>
                 <div class="well" style="margin-bottom:20px; background-color: white;"  ng-show="!$ctrl.ui.loading">
                     <div>
-                        <ds-author-list format="hname" authors="$ctrl.authors[pubEnt.uuid]"></ds-author-list>
+                        <ds-author-list format="citation" authors="$ctrl.authors[pubEnt.uuid]"></ds-author-list>
                         <span>
                             ({{ $ctrl.publishedDate }}) “{{ pubEnt.value.title }}”, in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI.
                             <a href="{{'https://doi.org/' + $ctrl.pubEnt.value.dois[0]}}">{{'https://doi.org/' + $ctrl.pubEnt.value.dois[0]}}</a>.

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-authors/pipeline-authors.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-authors/pipeline-authors.component.html
@@ -106,7 +106,7 @@
             <h5 style="font-family: Helvetica Neue">Citation Preview</h5>
             <div class="well" style="margin-bottom:20px; background-color: white;">
                 <div>
-                    <ds-author-list format="hname" authors="primEnt.value.authors"></ds-author-list>
+                    <ds-author-list format="citation" authors="primEnt.value.authors"></ds-author-list>
                     <span style="background: #f5f5f5;">
                         ({{ $ctrl.curDate }}) “{{ primEnt.value.title }}”, in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI. <a>https://doi.org/10.12345/ABCDEF</a>.
                     </span>

--- a/designsafe/static/scripts/data-depot/components/projects/pipeline-version/version-citation.template.html
+++ b/designsafe/static/scripts/data-depot/components/projects/pipeline-version/version-citation.template.html
@@ -59,7 +59,7 @@
                 <h5 style="font-family: Helvetica Neue">Citation Preview</h5>
                 <div class="well" style="margin-bottom:20px; background-color: white;" ng-show="!$ctrl.ui.loading">
                     <div>
-                        <ds-author-list format="hname" authors="$ctrl.revisionAuthors[primEnt.uuid]"></ds-author-list>
+                        <ds-author-list format="citation" authors="$ctrl.revisionAuthors[primEnt.uuid]"></ds-author-list>
                         <span style="background: #f5f5f5;">
                             ({{ $ctrl.curDate }}) “{{ primEnt.value.title }}”, in <i>{{ $ctrl.project.value.title }}</i>. DesignSafe-CI. <a>https://doi.org/10.12345/ABCDEF</a>.
                         </span>


### PR DESCRIPTION
## Overview: ##
In the Citation Preview, the comma was missing after the first name leading to the second name. 

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2504](https://jira.tacc.utexas.edu/browse/DES-2504)

## Summary of Changes: ##
The Citation Preview appears when publishing, amending, and versioning. In the controllers for each, the ds-author-list function is used. I changed the format to 'citation' which lists the author with the comma correctly. 

## Testing Steps: ##
For each project type:
1. Attempt to publish a project. 
2. When you get to the citation preview, check for the comma in the author list. 
3. Attempt to amend a project. 
4. When you get to the citation preview, check for the comma in the author list. 
5. Attempt to version a project. 
6. When you get to the citation preview, check for the comma in the author list. 

## UI Photos:
![Screen Shot 2023-07-10 at 12 04 11 PM](https://github.com/DesignSafe-CI/portal/assets/35277477/3fad7fff-9b99-48f5-91df-935c99e09fc8)


## Notes: ##
