### PR TITLE
des-2509-sim-type-missing-in-pub-pipeline

### DIFF
--- a/conf/docker/docker-compose-dev.all.debug.yml
+++ b/conf/docker/docker-compose-dev.all.debug.yml
@@ -4,6 +4,7 @@ version: "3"
 services:
   redis:
     image: redis:4.0
+    platform: "linux/amd64"
     volumes:
       - redis_data:/data
       - ../redis.conf:/usr/local/etc/redis/redis.conf
@@ -14,7 +15,7 @@ services:
     hostname: des_redis
 
   rabbitmq:
-    image: rabbitmq:3.6.10-management
+    image: arm64v8/rabbitmq:3.6.14-management
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq/mnesia/rabbit@des_rabbitmq
       - ../rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
@@ -29,11 +30,13 @@ services:
 
   memcached:
     image: memcached:latest
+    platform: "linux/amd64"
     container_name: des_memcached
     hostname: des_memcached
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.4.0
+    platform: "linux/amd64"
     ulimits:
       memlock: -1
     environment:
@@ -49,17 +52,19 @@ services:
 
   mysql:
     image: mysql:5.6
+    platform: "linux/amd64"
     volumes:
       - mysql_data:/var/lib/mysql
       - ../mysql.cnf:/etc/mysql/conf.d/mysql.cnf
     env_file: ../env_files/mysql.env
     ports:
-      -   127.0.0.1:3306:3306
+      - 127.0.0.1:3306:3306
     container_name: des_mysql
     hostname: des_mysql
 
   nginx:
     image: nginx
+    platform: "linux/amd64"
     volumes:
       - ../nginx/nginx.debug.conf:/etc/nginx/nginx.conf
       - ../nginx/gzip.conf:/etc/nginx/gzip.conf
@@ -130,3 +135,4 @@ volumes:
   es_data:
   rabbitmq_data:
   sockets:
+


### PR DESCRIPTION
## Overview: ##
Simulation Type was missing from the Publication Pipeline. 
While I was fixing that, I noticed that 'Date of Publication' was blank when on the Versioning screen. I looked at FR and Exp and noticed that on the Versioning screen, Date of Publication simply wasn't there. I think this was done because getting the correct date for a published versus unpublished project was difficult. So like FR and Exp, I removed Date of Publication

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2509](https://jira.tacc.utexas.edu/browse/DES-2509)

## Summary of Changes: ##
For the Simulation Type, the issue was a bad copy-paste. The code was looking for ‘experimentType’ instead of ‘simulationType’. That's been fixed. 

For the Date of Publication, I commented out that part in the code. 

## Testing Steps: ##
1. Find a Simulation Project
2. Progress down the publication pipeline
3. Check that Sim Type appears correctly
4. Check that in Pub Preview, DoP appears as "Appears in Published" for a published project, and "Appears when Published" for a non-published project. 
5. Check that when amending a Sim Project, the correct date appears for DoP. 
6. Check that when versioning a Sim project, DoP does not appear.

## UI Photos:
![Screen Shot 2023-07-10 at 4 11 19 PM](https://github.com/DesignSafe-CI/portal/assets/35277477/b6ec11ac-9b2f-4b89-9628-36a4de4e3bda)

## Notes: ##
At some point, we need to fix the Date of Publication when Versioning for all project types. (needs a ticket, maybe)
