### PR TITLE
task/DES-2557: Allow EF sites to be displayed using recent Designsafe releases

### DIFF
--- a/designsafe/static/styles/main-ef.css
+++ b/designsafe/static/styles/main-ef.css
@@ -1,0 +1,864 @@
+body {
+    background-image: url(../images/Map-BG.jpg);
+    background-repeat: no-repeat;
+    background-size: 100% auto;
+  }
+  
+  body.navbar-fixed {
+    padding-top: 73px;
+  }
+  
+  #sitewide_search {
+    /*margin-top: 0.75em;*/
+  }
+  
+  .cms-toolbar-expanded .navbar-ds.navbar-fixed-top {
+    top: 29px;
+  }
+  
+  .slick-prev {
+    left:0px;
+  }
+  .slick-next {
+    right:10px;
+  }
+  .slick-prev, .slick-next {
+    line-height: 2em;
+    font-size: 2em;
+    z-index: 1500;
+  
+  }
+  
+  .slick-prev:before, .slick-next:before {
+      color: #d3d3d3;
+      font-size: 2em;
+  }
+  
+  .slick-prev:before {
+    content: '<';
+  }
+  
+  .slick-next:before {
+    content: '>';
+  }
+  .modal-full .modal-dialog {
+    width: 100%;
+    min-height:100vh;
+    padding: 0;
+    margin: 0;
+  }
+  
+  .modal-full .modal-content {
+    min-height:100vh;
+  
+  }
+  
+  .img-responsive.img-preview {
+    max-height: calc(100vh - 225px);
+    margin: auto;
+  }
+  
+  .ef-site-title a {
+    text-decoration: none;
+    color: #333;
+  }
+  
+  .ef-site-title a:hover {
+    color: #444;
+  }
+  
+  .ef-site-title a h1 {
+    margin: 0;
+    line-height: 0.8;
+  }
+  
+  .site-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-top: 1.5em;
+    padding-bottom: 1em;
+  }
+  
+  .site-banner-right {
+    flex-grow: 2;
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .user-menu {
+    text-align: right;
+    margin-bottom: 20px;
+  }
+  
+  .user-menu .btn {
+    padding: 2px 8px;
+  }
+  
+  .tagline {
+    color: #136ac9;
+    text-transform: uppercase;
+  }
+  
+  .wf-active {
+    font-family: futura-pt, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  }
+  
+  .tagline h2 {
+    font-weight: 400;
+    font-size: 18px;
+    max-width: 421px;
+  }
+  
+  .wf-active .tagline h2 {
+    font-size: 20px;
+  }
+  
+  @media (min-width: 768px) and (max-width: 991px) {
+    .site-banner-right {
+      margin-right: -1px
+    }
+  }
+  
+  @media (min-width: 768px) {
+    .tagline {
+      text-align: right;
+    }
+  
+    .tagline h2 {
+      float: right;
+      margin: 0;
+    }
+  }
+  
+  @media (max-width: 767px) {
+    .site-banner {
+      flex-direction: column;
+    }
+  
+    .tagline {
+      text-align: center;
+    }
+  
+    .user-menu {
+      text-align: center;
+      margin: 0;
+      order: 1;
+    }
+  }
+  
+  .navbar-ds {
+    font-stretch: condensed;
+    font-family: futura-pt, "HelveticaNeue-CondensedBold", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    background-color: #fff;
+    border-top: 1px solid #ccc;
+    border-bottom: 2px solid #ccc;
+  }
+  
+  .navbar-ds .navbar-brand {
+    color: #878787;
+    font-size: 1.2em;
+  }
+  
+  .navbar-ds .navbar-nav > li > a {
+    color: #494d4e;
+    font-size: 1.2em;
+  }
+  
+  @media (min-width: 768px) {
+  .navbar-ds .navbar-nav > li > a:after {
+    content: '';
+    height: 4px;
+    position: absolute;
+    width: 0;
+    bottom: -1px;
+    left: 50%;
+    background: #a5a4a4;
+    -moz-transition: width 100ms ease-in-out, left 100ms ease-in-out;
+    -o-transition: width 100ms ease-in-out, left 100ms ease-in-out;
+    -webkit-transition: width 100ms ease-in-out, left 100ms ease-in-out;
+    transition: width 100ms ease-in-out, left 100ms ease-in-out;
+  }
+  
+  .navbar-ds .navbar-nav > li > a.hl-community:after {
+    background: #6caa39;
+  }
+  .navbar-ds .navbar-nav > li > a.hl-research:after {
+    background: #136ac9;
+  }
+  .navbar-ds .navbar-nav > li > a.hl-ef:after {
+    background: #ca463e;
+  }
+  .navbar-ds .navbar-nav > li > a.hl-learning:after {
+    background: #a5a4a4;
+  }
+  }
+  
+  .navbar-ds .navbar-nav > li > a:hover:after,
+  .navbar-ds .navbar-nav > li > a:focus:after {
+    width: 100%;
+    left: 0;
+  }
+  
+  .navbar-ds .navbar-nav > .active > a,
+  .navbar-ds .navbar-nav > .active > a:hover,
+  .navbar-ds .navbar-nav > .active > a:focus {
+    background: inherit;
+  }
+  
+  .navbar-ds .navbar-nav > .active > a:after,
+  .navbar-ds .navbar-nav > .active > a:hover:after,
+  .navbar-ds .navbar-nav > .active > a:focus:after {
+    width: 100%;
+    left: 0;
+  }
+  
+  @media (min-width: 768px) and (max-width: 991px) {
+    .navbar-ds .navbar-nav > li > a {
+      padding-left: 8px;
+      padding-right: 8px;
+      font-size: 1.05em;
+    }
+  }
+  
+  @media (max-width: 767px) {
+    .global-nav {
+      background-color: #eee;
+      border-top: 2px solid #ddd;
+    }
+  }
+  
+  hr {
+    border-width: 0.16em 0 0 0;
+    border-color: #ccc;
+  }
+  
+  h1, h2 {
+    text-transform: uppercase
+  }
+  
+  h3, h4 {
+    color: #4d4e4e;
+  }
+  
+  h4 {
+    font-style: italic;
+  }
+  
+  .headline {
+    position: relative;
+    margin-bottom: 20px;
+  }
+  
+  #headline-data-depot {
+    font-size:28px;
+    margin-top:16px;
+  }
+  
+  .headline::after {
+    content: "___";
+    color: #333;
+    position: absolute;
+    left: 0;
+    bottom: -0.2em;
+  }
+  
+  .hl-research, .headline-research::after {
+    color: #136ac9;
+  }
+  
+  .hl-ef, .headline-ef::after {
+    color: #ca463e;
+  }
+  
+  .hl-community, .headline-community::after {
+    color: #6caa39;
+  }
+  
+  .hl-learning, .headline-learning::after {
+    color: #a5a4a4;
+  }
+  
+  .hover-text {
+    color: inherit;
+  }
+  
+  .hover-text.hl-research:hover, .hover-text.hl-research:focus {
+    color: #136ac9;
+    border-color: #136ac9;
+  }
+  
+  .hover-text.hl-ef:hover, .hover-text.hl-ef:focus {
+    color: #ca463e;
+    border-color: #ca463e;
+  }
+  
+  .hover-text.hl-community:hover, .hover-text.hl-community:focus {
+    color: #6caa39;
+    border-color: #6caa39;
+  }
+  
+  .hover-text.hl-learning:hover, .hover-text.hl-learning:focus {
+    color: #a5a4a4;
+    border-color: #a5a4a4;
+  }
+  
+  .buttonlinks {
+    background: url(../images/button.jpg) 3px 1px no-repeat;
+    height: 74px;
+    width: auto;
+    text-align: center;
+    padding: 7px;
+    margin: auto;
+  }
+  
+  .buttonlinks a:link, .buttonlinks a:visited, .buttonlinks a:active {
+    font-size: 1.6em;
+    color: #ffffff;
+    text-decoration: none;
+  }
+  
+  .buttonlinks a:hover {
+    font-size: 1.6em;
+    color: #cccccc;
+    text-decoration: none;
+  }
+  
+  #logos {
+    text-align: center;
+  }
+  
+  #logos li {
+    display: inline-block;
+    margin-left: 10px;
+    margin-right: 10px;
+  }
+  
+  label.required:after,
+  .required > label:after,
+  .required > .checkbox > label:after {
+    content: "(required)";
+    font-weight: 300;
+    font-size: .9em;
+    color: #A94442;
+  }
+  
+  .checkboxselectmultiple ul,
+  .radioselect ul {
+    padding-left: 0;
+    list-style: none;
+  }
+  
+  .checkboxselectmultiple ul li label,
+  .radioselect ul li label {
+    font-weight: normal;
+    cursor: pointer;
+  }
+  
+  .error {
+    color: #A94442;
+  }
+  
+  .box {
+    background-color: #fff;
+    border: 1px solid #4a4e4e;
+    margin-bottom: 20px;
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: center;
+  }
+  
+  .box-topper {
+    background-size: cover;
+    padding: 5px;
+  }
+  
+  .box-topper-research {
+    background-image: url('../images/Sub-Nav-Blue.jpg')
+  }
+  
+  .box-topper-ef {
+    background-image: url('../images/Sub-Nav-Red.jpg')
+  }
+  
+  .box-topper-community {
+    background-image: url('../images/Sub-Nav-Green.jpg')
+  }
+  
+  .box-topper-learning {
+    background-image: url('../images/Sub-Nav-Grey.jpg')
+  }
+  
+  .box-content {
+    padding: 10px;
+    height: 160px;
+    overflow: hidden;
+  }
+  
+  .box-content h4 {
+    font-style: normal;
+    font-weight: bold;
+  }
+  
+  .ds-icon {
+    display: inline-block;
+    width: 48px;
+    height: 48px;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: 50% 50%;
+  }
+  
+  .ds-icon-sm {
+    width: 32px;
+    height: 32px;
+  }
+  
+  .ds-icon-lg {
+    width: 64px;
+    height: 64px;
+  }
+  
+  .ds-icon-cloud-disk {
+    background-image: url('../images/ds-icons/Icon-Data-Depot.png');
+  }
+  .ds-icon-desktop-compass {
+    background-image: url('../images/ds-icons/Icon-Disc-Workspace.png');
+  }
+  .ds-icon-portal-eye {
+    background-image: url('../images/ds-icons/Icon-Recon.png');
+  }
+  .ds-icon-portal-code {
+    background-image: url('../images/ds-icons/Icon-Dev-port.png');
+  }
+  .ds-icon-home {
+    background-image: url('../images/ds-icons/Icon-Fac-list.png');
+  }
+  .ds-icon-desktop-calendar {
+    background-image: url('../images/ds-icons/Icon-Schedule.png');
+  }
+  .ds-icon-document-bolt {
+    background-image: url('../images/ds-icons/Icon-Rapid.png');
+  }
+  .ds-icon-group {
+    background-image: url('../images/ds-icons/Icon-Exist-Comm.png');
+  }
+  .ds-icon-group-add {
+    background-image: url('../images/ds-icons/Icon-New-Comm.png');
+  }
+  .ds-icon-toolbox {
+    background-image: url('../images/ds-icons/Icon-Comm-tools.png');
+  }
+  .ds-icon-document-copy {
+    background-image: url('../images/ds-icons/Icon-Train-Resources.png');
+  }
+  .ds-icon-support {
+    background-image: url('../images/ds-icons/Icon-Use-Support.png');
+  }
+  .ds-icon-lightbulb {
+    background-image: url('../images/ds-icons/Icon-Students.png');
+  }
+  
+  /* apply alert-danger style for alert-error */
+  .alert-error {
+    background-color: #F2DEDE;
+    border-color: #EBCCD1;
+    color: #A94442;
+  }
+  
+  /* btn-link-alt */
+  .btn-link-alt {
+    font-weight: bold;
+    border: 2px solid #337AB7;
+    text-decoration: none;
+    background-color: #fff;
+  }
+  
+  .btn-link-alt:hover,
+  .btn-link-alt:focus,
+  .btn-link-alt.focus {
+    border-color: #23527c;
+    color: #23527c;
+  }
+  
+  .btn-group .btn-link-alt + .btn-link-alt,
+  .btn-group .btn-link-alt + .btn-group,
+  .btn-group .btn-group + .btn-link-alt {
+      margin-left: -2px;
+  }
+  
+  .btn-toolbar > .btn-group-data-depot-toolbar {
+    margin-left:0px;
+  }
+  
+  .callout {
+    padding: 1em;
+    border: 1px solid;
+    margin: 20px 0;
+  }
+  
+  .callout-default {
+    background-color: #eeeeee;
+    border-color: #cccccc;
+  }
+  
+  #notification_badge {
+    height: 1.8em;
+    width: 1.8em;
+    line-height: 1.6em;
+    top: -5px;
+    padding: 0;
+    position: absolute;
+  }
+  
+  .label-as-badge {
+    left: 1.8em;
+    border-radius: 30%;
+    border: 1px solid white;
+  }
+  
+  #notification_bell {
+    font-size: 25px;
+    padding-right: 10px;
+  }
+  
+  dd {
+      margin-bottom: .5em;
+  }
+  
+  .toast-close-button {
+    position: relative;
+    right: -0.3em;
+    top: -0.3em;
+    float: right;
+    font-size: 15px;
+    font-weight: bold;
+    color: #FFFFFF;
+    -webkit-text-shadow: 0 1px 0 #ffffff;
+    text-shadow: none;
+    opacity: 0.8;
+  }
+  
+  button.toast-close-button {
+    background-color: #cccccc;
+    color: #333333;
+    border: solid #efefef 1px;
+  }
+  
+  /*#toast-container > .toast-info {
+    background-image: none !important;
+  }
+  
+  #toast-container > .toast-error {
+    background-image: none !important;
+  }
+  
+  #toast-container > .toast-success {
+    background-image: none !important;
+  }
+  
+  #toast-container > .toast-warning {
+    background-image: none !important;
+  }*/
+  
+  ul.metadata-inner-list {
+    list-style:none;
+  }
+  
+  ul.metadata-inner-list li {
+    list-style:none;
+  }
+  
+  ul.metadata-inner-list > li {
+    border-bottom:1px dashed lightgray;
+    margin-bottom:5px;
+  }
+  
+  ul.metadata-inner-list > li:last-child{
+    border-bottom:none;
+  }
+  
+  table.browser-table-files-list {
+      table-layout:fixed;
+  }
+  
+  table .browser-filename-column {
+      width:350px;
+  }
+  
+  table .browser-path-column {
+      width:350px;
+  }
+  
+  table td {
+      word-wrap:break-word;
+  }
+  
+  .arrow-up {
+    width: 0;
+    height: 0;
+    position: relative;
+  }
+  
+  .arrow-up:before, .arrow-up:after {
+    content: '';
+    display: none;
+    position: absolute;
+    z-index: 1001;
+  }
+  
+  .arrow-up:before {
+    border-left: 15px solid transparent;
+    border-right: 15px solid transparent;
+    border-bottom: 15px solid #afafaf;
+    left: -1px;
+    top: 2px;
+  }
+  
+  .arrow-up:after {
+    border-left: 14px solid transparent;
+    border-right: 14px solid transparent;
+    border-bottom: 14px solid #ffffff;
+    top: 3px;
+  }
+  
+  .dropdown.open .arrow-up:before, .dropdown.open .arrow-up:after {
+    display: block;
+  }
+  
+  .dropdown.open .dropdown-menu.notifications{
+    top:140%;
+    padding: 5px 0 0 0;
+  }
+  
+  .notifications {
+    width:35em;
+    left: -25em;
+    white-space: normal;
+  }
+  
+  .notifications-wrapper {
+    overflow:auto;
+    max-height:30em;
+  }
+  
+  .menu-title {
+    color:#337ab7;
+    font-size:1.5rem;
+    display:inline-block;
+    margin: 0;
+  }
+  
+  .glyphicon-circle-arrow-right {
+    margin-left: 10px;
+  }
+  
+  .notification-heading, .notification-footer  {
+   padding: 2px 10px;
+  }
+  
+  .dropdown-menu .divider {
+    margin:0px 0;
+    background-color: #cccccc;
+  }
+  
+  #notification-container {
+    cursor:default;
+  }
+  
+  .item-title {
+    font-size:1.3rem;
+    color:#000;
+  }
+  
+  .notification-item {
+    padding:10px;
+    margin-top:0px;
+    border-radius:1px;
+    border-bottom: 1px solid #c3c3c3;
+    display: flex;
+    justify-content: space-between;
+  }
+  
+  .notification-item:hover {
+    background:#f7f7f7;
+  }
+  
+  .notification-item .dl-horizontal {
+    margin:0;
+    display: inline-block;
+    width: 31em;
+  }
+  
+  .notification-item .dl-horizontal dd {
+    margin: 0 0 0 9em;
+  }
+  
+  #notif-path {
+    color: #909090;
+    direction: rtl;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    text-align: left;
+    margin: 0;
+  }
+  
+  .notification-item .dl-horizontal dt {
+    width: 7em;
+  }
+  
+  .notif-close-wrapper {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  
+  .notif-close {
+    display: block;
+    flex-shrink: 1;
+    margin: 0 auto;
+  }
+  
+  @media (max-width: 767px) {
+    .notifications {
+      left: -6.5em;
+      width: 28.5em;
+    }
+    .notification-item .dl-horizontal {
+      width: 25.5em;
+    }
+    .notification-item .dl-horizontal div {
+      display: none;
+    }
+    .notification-item .dl-horizontal dt {
+      float: left;
+    }
+  }
+  #toast-container {
+    position: fixed;
+    bottom: 0;
+    z-index: 999;
+    overflow: visible !important;
+  }
+  
+  md-toast {
+    padding: 0 !important;
+    margin: 8px;
+  }
+  
+  #toast-container md-toast .custom-toast {
+    display: block;
+  }
+  
+  #toast-container md-toast .custom-toast::before {
+    display: none;
+  }
+  
+  md-toast.ng-leave {
+    visibility: hidden;
+  }
+  
+  md-toast.error .md-toast-content {
+    background: #f44336;
+    color: white;
+  }
+  
+  md-toast.success .md-toast-content {
+    background: #4caf50;
+    color: white;
+  }
+  
+  md-toast.warning .md-toast-content {
+    background: #EEAB2B;
+    color: white;
+  }
+  
+  md-toast.info .md-toast-content {
+    /* background: #4caf50; */
+    color: white;
+  }
+  
+  li .popover.right {
+    width: 185px;
+  }
+  
+  .workspace-tab-title {
+    margin-top: 12px;
+  }
+  
+  .workspace-tab {
+    width: calc((100% - 20px)/6);
+  }
+  
+  #workspace-tabs a h3 {
+      color: #FFFFFF;
+      display: inline-block;
+      margin: auto auto auto -.7em;
+      vertical-align: middle;
+      line-height: normal;
+      font-size: 2vw;
+      font-weight: normal;
+  }
+  
+  #workspace-tabs > .nav-tabs > li.active h3 {
+      color: #000000;
+  }
+  
+  #workspace-tabs {
+    overflow: hidden;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  
+  #workspace-tabs li {
+    z-index: 1;
+  }
+  
+  #workspace-tabs a {
+    background: #303030;
+    padding: 0 0 0 1em;
+    text-align: center;
+    border-radius: 5px 5px 0 0;
+    border: 1px solid rgba(8,8,8,0.6);
+    border-style: solid none none solid;
+    width: calc(100% - 1.1em);
+    height: 3em;
+    line-height: 2.5em;
+  }
+  
+  #workspace-tabs a:hover,
+  #workspace-tabs a:hover::after {
+    background: #525252;
+  }
+  
+  #workspace-tabs > .nav-tabs > li.active > a,
+  #workspace-tabs > .nav-tabs > li.active > a::after {
+    background: #fff;
+  }
+  
+  #workspace-tabs a:focus {
+    outline: 0;
+  }
+  
+  #workspace-tabs a::after {
+    content:'';
+    position:absolute;
+    z-index: 1;
+    top: -.1em;
+    right: -.5em;  
+    bottom: 0;
+    width: 3em;
+    background: #303030;
+    transform: skew(20deg);
+    border-radius: 0 5px 0 0;
+    border: 1px solid rgba(8,8,8,0.5);
+    border-style: solid solid none none;
+    z-index: -1;
+  }
+  
+  #workspace-tabs .nav-tabs {
+    border-bottom: none;
+  }

--- a/designsafe/static/styles/ng-designsafe-ef.css
+++ b/designsafe/static/styles/ng-designsafe-ef.css
@@ -1,0 +1,878 @@
+.btn-toolbar-ds {
+    background-color: #f0f0f0;
+    border: 1px solid #dddddd;
+    margin-bottom: 20px;
+    margin-left: 0;
+    padding: 5px 5px 5px 0;
+}
+
+.btn-toolbar-right {
+    float: right;
+}
+
+.btn-toolbar-right .btn-group {
+    float: none;
+}
+
+.breadcrumb-ds {
+    line-height: 26px;
+    margin-bottom: 5px;
+}
+
+.breadcrumb.breadcrumb-ds .breadcrumb-display {
+    line-height:18px;
+}
+
+.flo-select-btn {
+    border: 0;
+    background: none;
+    outline: 0;
+}
+
+.ds-data-browser-wrapper {
+    position: relative;
+}
+
+.ds-data-browser-loading {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 5px;
+    font-size: 1.5em;
+    border: 1px solid #46B8DA;
+    background-color: #5bc0de;
+    color: #ffffff;
+    z-index:9999;
+}
+
+.ds-data-browser {
+    display: flex;
+    flex-direction: row;
+}
+
+.ds-data-browser-header {}
+
+.ds-data-browser-footer {}
+
+.ds-data-browser-sidebar {
+    flex: 0 0 auto;
+}
+
+.ds-data-browser-sidebar {
+    border: 1px solid #ddd;
+    background-color: #eee;
+}
+
+.ds-data-browser-new {
+    margin: 10px 10px 20px;
+}
+
+.ds-data-browser-main {
+    flex: 1 1 auto;
+}
+
+.ds-drop-target {
+    position: relative;
+}
+
+.ds-drop-target.ds-drop-active {
+    background-color: #d9edf7 !important;
+}
+
+.ds-drag-el {
+    position: absolute;
+    top: -1000em;
+    left: -1000em;
+    display: flex;
+    flex: 1 0 auto;
+    flex-direction: row;
+}
+
+.ds-drag-el .drag-action {
+    padding: .5em;
+    background-color: #5bc0de;
+    border: 1px solid #46B8DA;
+    color: #fff;
+}
+
+.ds-drag-el .drag-info {
+    padding: .5em .75em;
+    border: 1px solid #46B8DA;
+    background-color: #fff;
+}
+
+.ds-data-browser-processing * {
+    color: #eee;
+    border-color: #eee;
+    background-color: #ccc;
+}
+
+.ds-data-browser-processing-success * {
+    background-color: #d6e9c6;
+    border-color: #d6e9c6;
+    color: #3c763d;
+}
+
+.ds-data-browser-processing-danger * {
+    background-color: #ebccd1;
+    border-color: #ebccd1;
+    color: #a94442;
+}
+
+.ds-data-browser table {
+    background-color: #fff;
+}
+
+.ds-data-browser caption {
+    background-color: #fff;
+    border: 1px solid #ddd;
+    padding: 20px;
+}
+
+.ds-data-browser-source-select-list .list-group-item {
+    padding: 0 0 0 5px;
+    background-color: transparent;
+    border: none;
+    color: inherit;
+}
+
+.ds-data-browser-source-select-list .list-group-item:hover,
+.ds-data-browser-source-select-list .list-group-item:focus {
+    background-color: #ccc;
+    color: inherit;
+}
+
+.ds-data-browser-source-select-list .list-group-item.active {
+    background-color: #337ab7;
+    border-color: #ddd;
+}
+
+.ds-data-browser-source-select-list .list-group-item:hover a,
+.ds-data-browser-source-select-list .list-group-item:focus a {
+    background-color: #e1e1e1;
+}
+
+.ds-data-browser-source-select-list .list-group-item.active a {
+    background-color: #fff;
+}
+
+.ds-data-browser-source-select-list a {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+    padding: 10px 15px;
+}
+
+.ds-data-browser-source-select .dropdown-menu {
+    width: 100%;
+}
+
+.files-listing-table .unselectable {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+.files-listing-table .highlight {
+    background-color: #a1d2eb !important;
+}
+
+.files-listing-table tbody tr td div.checkbox {
+    vertical-align: middle !important;
+    display: inline-block;
+    margin: 0;
+}
+
+/**
+*
+* SEARCH BAR CSS
+*
+*/
+
+.search-wrap {
+    position:absolute;
+    top:.4em;
+    right:0em;
+}
+
+.searchbar-wrap:hover, .search-wrap:focus {
+    width:300px;
+}
+
+.searchbar-wrap {
+    position:absolute;
+    right:1em;
+    width:32px;
+    height:32px;
+    overflow:hidden;
+    -webkit-transition: width .55s ease;
+    -moz-transition: width .55s ease;
+    -ms-transition: width .55s ease;
+    -o-transition: width .55s ease;
+    transition: width .55s ease;
+}
+
+.searchbar-wrap .searchbar {
+    width:300px;
+    vertical-align:middle;
+    white-space:nowrap;
+    position: relative;
+}
+
+.searchbar-wrap .search-icon {
+    position: absolute;
+    left:0;
+    top: 50%;
+    margin-left: 1em;
+    margin-top: .5em;
+    z-index: 1;
+}
+
+.searchbar-wrap .search-clear-icon {
+    position: absolute;
+    right:1em;
+    margin-top: .5em;
+    z-index: 1;
+    padding:0;
+}
+
+.searchbar-wrap input#db-search:hover,
+.searchbar-wrap input#db-search:focus {
+    outline: none;
+    background: white;
+    width: 300px;
+}
+
+.searchbar-wrap:hover input#db-search {
+    width: 300px;
+}
+
+.searchbar-wrap input#db-search {
+    width: 32px;
+    height: 32px;
+    background: white;
+    border: none;
+    float: left;
+    color: black;
+    padding-left: 35px;
+    -webkit-border-radius: 5px;
+    -moz-border-radius: 5px;
+    border-radius: 5px;
+
+    -webkit-transition: width .55s ease;
+    -moz-transition: width .55s ease;
+    -ms-transition: width .55s ease;
+    -o-transition: width .55s ease;
+    transition: width .55s ease;
+}
+
+.search-wrap .search-clear-btn {
+    display:inline-block;
+    float:left;
+}
+
+/**
+*
+* METADATA TAGS CSS
+*
+*/
+
+.tags-list {
+    margin-top:10px;
+}
+
+.tag-item input[type="checkbox"]{
+    display:none;
+}
+
+.tag-item button {
+    background:none;
+    padding:0px;
+}
+
+.tag-item label {
+    position:absolute;
+    top:-7px;
+    left: 1px;
+    cursor:pointer;
+}
+
+.tag-item {
+  background: #ececec;
+  border-radius: 3px 0 0 3px;
+  color: black;
+  display: inline-block;
+  height: 26px;
+  line-height: 26px;
+  padding: 0 20px 0 10px;
+  position: relative;
+  margin: 0 10px 10px 0;
+  text-decoration: none;
+  -webkit-transition: color 0.2s;
+  transition: color 0.2s;
+}
+
+.tag-item.deleted {
+  background: #f2dede;
+}
+
+.tag-item span.deleted {
+    text-decoration: line-through;
+}
+
+.tag-item:after {
+  background: #fff;
+  border-bottom: 13px solid transparent;
+  border-left: 10px solid #ececec;
+  border-top: 13px solid transparent;
+  content: '';
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.tag-item.deleted:after {
+  border-left: 10px solid #f2dede;
+}
+
+
+/**
+*
+* DATA BROWSER TABLE WRAPPER CSS
+*
+**/
+
+.ds-table-display-wrapper {
+    height:500px;
+    overflow:scroll;
+}
+
+.ds-table-display-wrapper table tfoot tr td {
+    font-size: 1.5em;
+    border: 1px solid #46B8DA;
+    background-color: #5bc0de;
+    color: #ffffff;
+    z-index:9999;
+}
+
+.path-wrap {
+    max-width:120px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
+    vertical-align:text-bottom;
+    height:18px;
+}
+
+.path-wrap:hover {
+    max-width: initial;
+}
+
+.shared-path-listing {
+    max-width:120px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
+    vertical-align: bottom;
+    color: #ccc;
+}
+
+.files-listing-table td{
+    word-wrap: break-word;
+}
+
+.dd-toolbar-fixed-top {
+    position: fixed;
+    border: 1px black solid;
+    z-index: 1050;
+    top:55px;
+	left:22%;
+	right:10%;
+}
+
+@media (min-width: 768px) {
+    .modal-dialog.modal-md {
+        width:800px;
+    }
+}
+
+tr.experiment-deleted {
+    text-decoration: line-through;
+}
+
+.ds-text-light-blue {
+    color: #5BC0DE;
+}
+
+.ds-text-blue {
+    color: #0567CC;
+}
+
+.ds-text-green {
+    color: #2EA89A;
+}
+
+.ds-text-red {
+    color: #D04348;
+}
+
+.ds-text-black {
+    color: black;
+}
+
+.ds-text-yellow {
+    color: #B59300;
+}
+
+.ds-text-purple {
+    color: #4B3181;
+}
+
+.ds-text-orange {
+    color: #BD5717;
+}
+
+span.label.tag-yellow {
+    border: 2px solid #B59300;
+    color: black;
+}
+
+span.label.tag-yellow.selected {
+    border: 2px solid #B59300;
+    background: #B59300;
+    color: white;
+}
+
+span.label.tag-purple {
+    border: 2px solid #4B3181;
+    color: black;
+}
+
+span.label.tag-purple.selected {
+    border: 2px solid #4B3181;
+    background: #4B3181;
+    color: white;
+}
+
+span.label.tag-orange {
+    border: 2px solid #BD5717;
+    color: black;
+}
+
+span.label.tag-orange.selected {
+    border: 2px solid #BD5717;
+    background: #BD5717;
+    color: white;
+}
+
+span.label.tag-light-blue {
+    border: 2px solid #5BC0DE;
+    color: black;
+}
+
+span.label.tag-light-blue.selected {
+    border: 2px solid #5BC0DE;
+    background: #5BC0DE;
+    color: white;
+}
+
+span.label.tag-black {
+    border: 2px solid #000;
+    color: black;
+}
+
+span.label.tag-black.selected {
+    border: 2px solid #000;
+    background:#000;
+    color: white;
+}
+
+span.label.tag-blue {
+    border: 2px solid #0567CC;
+    color: black;
+}
+
+span.label.tag-blue.selected {
+    border: 2px solid #0567CC;
+    background:#0567CC;
+    color: white;
+}
+
+span.label.tag-green {
+    border: 2px solid #2EA89A;
+    color: black;
+}
+
+span.label.tag-green.selected {
+    border: 2px solid #2EA89A;
+    background:#2EA89A;
+    color: white;
+}
+
+span.label.tag-red {
+    border: 2px solid #D04348;
+    color: black;
+}
+
+span.label.tag-red.selected {
+    border: 2px solid #D04348;
+    background:#D04348;
+    color: white;
+}
+
+.modal-body span.label {
+    float:left;
+}
+
+.add-project-labels span.label {
+    width: 1em;
+    height: 1em;
+    margin-top: 5px;
+    margin-right: 5px;
+}
+
+span.tag-title {
+    word-break: break-word;
+    white-space: normal;
+    text-align: left;
+}
+
+.data-model-tree ul ul.hybrid-sim-coord-output li {
+    margin-left:30px;
+}
+
+.data-model-tree ul, .data-model-tree li {
+    list-style: none; margin: 0; padding: 0;
+}
+
+.data-model-tree ul {
+    padding-left: 1em;
+}
+
+.data-model-tree li {
+    padding-left: 1em;
+    border: 1px solid black;
+    border-width: 0 0 1px 1px;
+}
+
+.data-model-tree li.tree-container {
+    border-bottom: 0px;
+}
+
+.data-model-tree li.empty {
+    font-style: italic;
+    color: silver;
+    border-color: silver;
+}
+
+.data-model-tree li div.tree-el {
+    margin: 0;
+    background: white;
+    position: relative;
+    top: 1em;
+    padding:5px 2px;
+}
+
+.data-model-tree li ul {
+    border-top: 1px solid black;
+    margin-left: -1em;
+    padding-left: 2em;
+}
+.data-model-tree ul li ul {
+    /*border-left: 1px solid black;*/
+    margin-left: -15px;
+}
+
+.data-model-tree ul.event-ul {
+    border-left: 1px solid white;
+}
+
+.data-model-tree.data-model-preview-tree ul.model-config-ul li:last-child ul.sensor-list-ul {
+    border-left: 1px solid white;
+}
+
+.btn-xsm {
+  padding:1px 1.5px;
+}
+
+.preview-wrapper {
+    overflow:visible;
+}
+
+.folder-tick {
+	display: inline-block;
+    /* border: 1px solid lightgrey; */
+    height: 3em;
+    text-align: center;
+    /* vertical-align: bottom; */
+    border-bottom: 30px solid lightgrey;
+    border-right: 30px solid white;
+    border-left: 30px solid white;
+    padding-top: 10px;
+}
+
+.existing-experiments-listing {
+    margin-bottom:10px;
+}
+
+.add-extra-category {
+    margin-top:20px;
+}
+
+.simple-table tbody tr td,
+.simple-table tbody tr th{
+    padding:0px 5px;
+}
+
+.simple-table tbody tr td:first-child,
+.simple-table tbody tr th:first-child {
+    padding-left:0px;
+}
+
+.simple-table tbody tr td:last-child,
+.simple-table tbody tr th:last-child {
+    padding-right:0px;
+}
+
+.tooltip-inner {
+    max-width:350px !important;
+    color: black;
+    background-color: white;
+    border:1px solid black;
+}
+
+.grayed-out {
+    background-color:lightgray;
+    color:#3e3e3e;
+}
+
+.wizard-steps .active {
+    font-weight:bold;
+}
+
+.meta-review {
+    width:100%;
+    background:white;
+    overflow:auto;
+}
+
+.meta-review .header {
+    width:100%;
+    background:white;
+    overflow:auto;
+    margin: 0px;
+    padding: 0px;
+}
+
+.meta-review .title {
+    text-align:center;
+    border-bottom:1px solid black;
+    padding:5px;
+}
+
+.meta-review .content {
+    padding:5px;
+}
+.meta-review .content-wrapper {
+    border-top:1px solid black;
+}
+
+.meta-review .content .meta-row {
+    width:100%;
+    overflow:auto;
+    margin:10px 0px;
+}
+
+.meta-review .content .meta-row .attr {
+    font-weight:bold;
+    font-size: 15;
+}
+
+.meta-review .content .meta-row .value {
+    width:100%;
+    font-size: 15;
+}
+
+.dropdown button.collapsed .dropdown-caret:before {
+    content: "\f078";
+}
+
+.dropdown button .dropdown-caret:before {
+    content: "\f077";
+}
+
+.entity-preview-header > button{
+    background: #e6e6e6;
+    border:1px solid black;
+    white-space:normal;
+}
+
+.modal-body .modal-row {
+    margin-bottom:10px;
+    overflow:auto;
+    text-align:center;
+}
+
+.modal-body .modal-row .det-label {
+    text-align:right;
+}
+
+.modal-body .modal-row .det-val {
+    text-align:left;
+}
+
+a[ng-click]:hover {
+    cursor: pointer;
+}
+
+.squarebrackets:before {
+   content: " ";
+   border-left:1px solid black;
+   border-top:1px solid black;
+   border-bottom:1px solid black;
+   padding:0px 5px 5px 5px;
+}
+
+.squarebrackets:after
+{
+  content:" ";
+  padding:0px 5px 0px 5px;
+  border-right:1px solid black;
+  border-top:1px solid black;
+  border-bottom:1px solid black;
+}
+
+/**
+*
+* Application Icons Font
+*
+**/
+
+@font-face {
+font-family: 'DesignSafe-Apps';
+    src: url('/static/fonts/DesignSafe-App-Icons.ttf') format('truetype');
+    font-weight: normal;
+    font-style: normal;
+}
+
+.icon-letter {
+    font-family: futura-pt, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 6vw;
+    line-height: 1.2;
+}
+
+[class^="icon-"]:before,
+[class*=" icon-"]:before {
+    font-family: 'DesignSafe-Apps';
+    font-style: normal;
+    font-size: 5vw;
+    speak: none;
+    font-weight: normal;
+    -webkit-font-smoothing: antialiased;
+            font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+}
+
+.icon-ngl:before {
+    content: "\e900";
+    font-size: 4vw;
+}
+.icon-compress:before {
+    content: "\e909";
+}
+.icon-extract:before {
+    content: "\e90c";
+}
+.icon-matlab:before {
+    content: "\e90b";
+}
+.icon-paraview:before {
+    content: "\e90a";
+}
+.icon-hazmapper:before {
+    content: "\e904";
+}
+.icon-jupyter:before {
+    content: "\e905";
+}
+.icon-adcirc:before {
+    content: "\e906";
+    font-size: 4vw;
+}
+.icon-qgis:before {
+    content: "\e907";
+}
+i[class^="icon-ls"][class$="dyna"]:before,
+i[class^="icon-ls-pre/post"]:before,
+.icon-ls-dyna:before {
+    content: "\e908";
+}
+.icon-visit:before {
+    content: "\e902";
+}
+.icon-openfoam:before {
+    content: "\e901";
+}
+.icon-opensees:before {
+    content: "\e903";
+}
+
+@font-face {
+    font-family: 'Curation-Icons';
+        src: url('/static/fonts/Curation_Icons.ttf') format('truetype');
+        font-weight: normal;
+        font-style: normal;
+    }
+
+    [class^="curation-"]:before,
+    [class*=" curation-"]:before {
+        font-family: 'Curation-Icons';
+        font-style: normal;
+        /* font-size: 32px; */
+        /* speak: none; */
+        font-weight: normal;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+    }
+
+    .curation-hybrid-icon:before {
+        content: "\e907";
+    }
+    .curation-cc-zero:before {
+        content: "\e900";
+    }
+    .dropdown button.collapsed .curation-chevron:before {
+        content: "\e901";
+    }
+    .dropdown button .curation-chevron:before {
+        content: "\e902";
+    }
+    .curation-close-window:before {
+        content: "\e903";
+    }
+    .curation-cc-share:before {
+        content: "\e904";
+    }
+    .curation-experiment:before {
+        content: "\e905";
+    }
+    .curation-simulation:before {
+        content: "\e911";
+    }
+    .curation-gpl:before {
+        content: "\e906";
+    }
+    .curation-odc:before {
+        content: "\e90e";
+    }
+    .curation-other:before {
+        content: "\e90f";
+    }
+    .curation-req-doi:before {
+        content: "\e910";
+    }

--- a/designsafe/templates/ef_cms_page.html
+++ b/designsafe/templates/ef_cms_page.html
@@ -17,11 +17,11 @@
       <link href="{% static 'vendor/slick-carousel/slick/slick.css' %}" rel="stylesheet" type="text/css">
       <link href="{% static 'vendor/slick-carousel/slick/slick-theme.css' %}" rel="stylesheet" type="text/css">
       <link href="{% static 'styles/typekit.css' %}" rel="stylesheet" type="text/css">
-      <link href="{% static 'styles/main.css' %}" rel="stylesheet" type="text/css">
+      <link href="{% static 'styles/main-ef.css' %}" rel="stylesheet" type="text/css">
       <link href="{% static 'styles/corner-ribbon.css' %}" rel="stylesheet" type="text/css">
       <link href="{% static 'styles/base.css' %}" rel="stylesheet" type="text/css">
       <link href="{% static 'vendor/angular-material/angular-material.css' %}" rel="stylesheet">
-      <link href="{% static 'styles/ng-designsafe.css' %}" rel="stylesheet">
+      <link href="{% static 'styles/ng-designsafe-ef.css' %}" rel="stylesheet">
       {% render_block "css" %}
   </head>
   <body>

--- a/designsafe/templates/includes/ef_navigation.html
+++ b/designsafe/templates/includes/ef_navigation.html
@@ -1,6 +1,6 @@
 {% load menu_tags %}
-<nav class="navbar navbar-default navbar-inverse navbar-ds">
-  <div class="container-fluid">
+<nav class="navbar navbar-default navbar-ds">
+  <div class="container">
     <div class="navbar-header">
       <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#main-navigation" aria-expanded="false">
         <span class="sr-only">Toggle navigation</span>


### PR DESCRIPTION
## Overview: ##
At some point in 2020 we inverted the colors on the main Designsafe menu and stretched the container to fill the screen horizontally. This breaks the EF sites, which still rely on Bootstrap 3 style container styling. This PR adds our old stylesheets back into version control for use on the EF sites.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2557](https://jira.tacc.utexas.edu/browse/DES-2557)

## Summary of Changes: ##
- Use legacy versions of `ng-designsafe.css` and `main.css` when rendering EF site templates.
- Undo color inversion on EF menus.

## Testing Steps: ##
1. In `common.py` edit the SITE_ID setting to anywhere between 2 and 10 to test out the rendering of the EF sties.

## UI Photos:
SimCenter site running in local dev:
<img width="1219" alt="image" src="https://github.com/DesignSafe-CI/portal/assets/12601812/1c8f4710-7bc7-4d3d-a123-d10f48050ba4">


## Notes: ##
