### PR TITLE
Licences not displaying properly for Exp & HybSim

### DIFF
--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
@@ -240,7 +240,7 @@
                         </span>
                     </div>
                     <div class="entity-meta-field">
-                        <div class="entity-meta-label-multi" ng-if="(!$ctrl.readOnly && mission.value.dois.toString() === '') || $ctrl.readOnly">License(s)</div>
+                        <div class="entity-meta-label-multi" ng-if="(!$ctrl.readOnly && hybsim.value.dois.toString() === '') || $ctrl.readOnly">License(s)</div>
                         <div class="entity-meta-data" ng-if="!$ctrl.readOnly && hybsim.value.dois.toString() === ''">
                             <span>(Appears when published)</span>
                         </div>

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
@@ -264,7 +264,7 @@
                         </div>
                     </div>
                     <div class="entity-meta-field">
-                        <div class="entity-meta-label-multi" ng-if="(!$ctrl.readOnly && mission.value.dois.toString() === '') || $ctrl.readOnly">License(s)</div>
+                        <div class="entity-meta-label-multi" ng-if="(!$ctrl.readOnly && experiment.value.dois.toString() === '') || $ctrl.readOnly">License(s)</div>
                         <div class="entity-meta-data" ng-if="!$ctrl.readOnly && experiment.value.dois.toString() === ''">
                             <span>(Appears when published)</span>
                         </div>


### PR DESCRIPTION
## Overview: ##
In Pub Preview, an extra (Appears when published) was appearing. It was determined to be for the "License(s)" section of the metadata.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2554](https://jira.tacc.utexas.edu/browse/DES-2554)

## Summary of Changes: ##
In both cases, a conditional statement that would display "License(s)" was not working correctly because one of the conditions was from the wrong project type (FR), rather than HybSim or Exp. 

## Testing Steps: ##
For all project types, find a project with a License and make sure the correct text appears. 

## UI Photos:
**BEFORE**
![Screen Shot 2023-08-01 at 12 33 27 PM](https://github.com/DesignSafe-CI/portal/assets/35277477/ced30f58-7c75-4938-a15a-01155ac10b28)

**AFTER**
![Screen Shot 2023-08-01 at 12 34 11 PM](https://github.com/DesignSafe-CI/portal/assets/35277477/1d31c886-4829-4e51-b370-4e0b138386fc)

## Notes: ##
