### PR TITLE
des-2292: Co-Pis now appears without hypertext

### DIFF
--- a/designsafe/static/scripts/ng-designsafe/directives/templates/prj-pub-preview-metadata-template.html
+++ b/designsafe/static/scripts/ng-designsafe/directives/templates/prj-pub-preview-metadata-template.html
@@ -151,9 +151,7 @@
     <tr class="prj-row" ng-if="$ctrl.project.value.coPis.length && $ctrl.project.value.projectType === 'other' && !$ctrl.readOnly">
         <td>Co-PIs</td>
         <td class="prj-data">
-            <span ng-repeat="coPi in $ctrl.authorData.coPis track by $index" ng-if="!$ctrl.loadingUserData.coPis">
-                <a href="javascript:;" ng-click="$ctrl.showAuthor(coPi)">{{ coPi.lname }}, {{ coPi.fname }}</a><span ng-if="!$last">, </span>
-            </span>
+            <ds-user-list usernames="$ctrl.project.value.coPis"></ds-user-list>
         </td>
     </tr>
     <!-- end Co-PI listings -->


### PR DESCRIPTION
## Overview: ##
When on the Publication Preview for a type Other project, the Co-PIs do not appear.
They now appear but like PI, they are NOT hyperlinked. Checked that the citation preview for type Other also has the correct authors list (My Projects & Published).

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2292](https://jira.tacc.utexas.edu/browse/DES-2292)

## Summary of Changes: ##
In prj-pub-preview-metadata-template.html, I used similar code from PIs (type Other) to display Co-PIs (type Other). This is specific for type Other; all other types grab these fields in a different way. 

## Testing Steps: ##
1. Find a type Other project that has Co-PI(s)
2. In My Projects, in Working Directory, verify that Co-PIs appear (should be hyperlinked)
3. Click on Publication Preview, verify that Co-PIs appear (should not be hyperlinked)

## UI Photos:
BEFORE
![Screen Shot 2023-08-10 at 11 59 52 AM](https://github.com/DesignSafe-CI/portal/assets/35277477/6d373596-6ff7-4d30-91de-854c1a3b8050)

AFTER
![Screen Shot 2023-08-10 at 3 45 42 PM](https://github.com/DesignSafe-CI/portal/assets/35277477/777f1a4f-0a69-41ae-8101-dc5221fff6d9)

## Notes: ##
I tried to hyperlink the Co-PIs, but they are displaying as a single unit. So if there are 2+ Co-PIs, there is only 1 hyperlink. Since the PI wasn't hyperlinked, I just left that off of Co-PIs.