### PR TITLE
bug/des-2574: coor-output not appearing in Pub

### DIFF
--- a/designsafe/static/scripts/data-depot/components/published/published-view.component.js
+++ b/designsafe/static/scripts/data-depot/components/published/published-view.component.js
@@ -271,7 +271,7 @@ class PublishedViewCtrl {
             this.browser.project.coordinator_set = this.browser.publication.coordinators;
             this.browser.project.simsubstructure_set = this.browser.publication.sim_substructures;
             this.browser.project.expsubstructure_set = this.browser.publication.exp_substructures;
-            this.browser.project.coordinatoroutput_set = this.browser.publication.coordintaor_outputs;
+            this.browser.project.coordinatoroutput_set = this.browser.publication.coordinator_outputs;
             this.browser.project.simoutput_set = this.browser.publication.sim_outputs;
             this.browser.project.expoutput_set = this.browser.publication.exp_outputs;
             this.browser.project.analysis_set = this.browser.publication.analysiss;


### PR DESCRIPTION
## Overview: ##
Coordinator Output was not appearing in 'Published' 
All other categories appear fine. 

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2574](https://jira.tacc.utexas.edu/browse/DES-2574)

## Summary of Changes: ##
In published-view.component.js, there was a typo where `coordinator_outputs` was misspelled `coordintaor_outputs`
Fixing this resolved the issue.

## Testing Steps: ##
1. Find a Hybrid Simulation project with all categories (Report, Global Model, Coordinator, Coordinator Output, Simulation Substructure, Simulation Output, Experimental Substructure, Experimental Output, and Analysis)
2. Make sure ALL categories appear in My Projects & Published. 

## UI Photos:
<img width="900" alt="Screen Shot 2023-08-18 at 1 34 05 PM" src="https://github.com/DesignSafe-CI/portal/assets/35277477/02786221-a874-4853-9a96-3e7b4755e2b0">

## Notes: ##
