### PR TITLE
Prevent user search endpoint from returning all user profiles

### DIFF
--- a/designsafe/apps/api/users/views.py
+++ b/designsafe/apps/api/users/views.py
@@ -110,11 +110,9 @@ class SearchView(View):
         if role:
             logger.info(role)
             user_rs = user_rs.filter(groups__name=role)
-        resp = [model_to_dict(u, fields=resp_fields) for u in user_rs]
-        if len(resp):
-            return JsonResponse(resp, safe=False)
-        else:
-            return HttpResponseNotFound()
+        
+        # Throw error if no filtering is specified.
+        return HttpResponseNotFound()
 
 
 class PublicView(View):


### PR DESCRIPTION
## Overview: ##
Disable endpoint flagged by ISO that would return all user profiles if used without a query string.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

