### PR TITLE
Prevent user search endpoint from returning all user profiles

### DIFF
--- a/designsafe/apps/api/users/views.py
+++ b/designsafe/apps/api/users/views.py
@@ -110,6 +110,11 @@ class SearchView(View):
         if role:
             logger.info(role)
             user_rs = user_rs.filter(groups__name=role)
+
+        # Prevent endpoint from returning unfiltered user list.
+        if not q and not role:
+            return HttpResponseNotFound()
+
         resp = [model_to_dict(u, fields=resp_fields) for u in user_rs]
         if len(resp):
             return JsonResponse(resp, safe=False)


### PR DESCRIPTION
## Overview: ##
Address endpoint flagged by NSO that could return an unfiltered list of all users.
