### PR TITLE
Remove text indicating that users can search by DOI

### DIFF
--- a/designsafe/apps/api/publications/search_utils.py
+++ b/designsafe/apps/api/publications/search_utils.py
@@ -177,4 +177,4 @@ def search_string_query(search_string):
                                                           'project.value.projectType',
                                                           'project.value.dataType'])
     q2 = Q({'term': {'projectId._exact': search_string}})
-    return q1 | q2 | author_query(search_string)
+    return q1 | q2 | author_query(f"\"{search_string}\"")

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/publications-listing.template.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/publications-listing.template.html
@@ -9,8 +9,8 @@
                     <button class="btn btn-success" ng-click="$ctrl.browse()" style="width:fit-content; white-space: nowrap; text-align: center; height: 34px;">
                         <i class="fa fa-search" role="none">&nbsp;</i>Search
                     </button>
-                    <input type="text" placeholder="Author, Title, Keyword, Description, Natural Hazard Event, Project ID, or DOI" 
-                    data-toggle="tooltip" data-placement="top" title="Author, Title, Keyword, Description, Natural Hazard Event, Project ID, or DOI" aria-label="Search Publications"
+                    <input type="text" placeholder="Author, Title, Keyword, Description, Natural Hazard Event, or Project ID" 
+                    data-toggle="tooltip" data-placement="top" title="Author, Title, Keyword, Description, Natural Hazard Event, or Project ID" aria-label="Search Publications"
                         class="form-control" ng-model="$ctrl.params.queries.searchString" class="form-control" id="author-input" ng-keydown="$event.keyCode === 13 && $ctrl.browse()">
                 </div>
                 


### PR DESCRIPTION
## Overview: ##
- Escape the query string in quotes before passing to the author query, since special characters can cause a 500
- Remove the "DOI" text from the search placeholder, since searching by DOI isn't supported yet.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2585](https://jira.tacc.utexas.edu/browse/DES-2585)
