### PR TITLE
bug/DES-2586: Hide trash folder for Community Data and published projects

### DIFF
--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/data-depot-listing.component.js
@@ -224,6 +224,7 @@ class FilesListingCtrl {
         this.FileOperationService = FileOperationService;
         this.PublicationService = PublicationService;
         this.handleScroll = this.handleScroll.bind(this);
+        this.filterTrash = this.filterTrash.bind(this);
     }
 
     $onInit() {
@@ -234,6 +235,12 @@ class FilesListingCtrl {
             const { section, api, scheme, system, path } = this.listing.params;
             this.FileListingService.browseScroll({ section, api, scheme, system, path });
         }
+    }
+
+    filterTrash(f) {
+        // Don't display the trash folder in Community listings.
+        return !(['designsafe.storage.community', 'designsafe.storage.published'].includes(this.listing.params.system) 
+            && f.name.toLowerCase() === '.trash')
     }
 
     browse($event, file) {

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/files-listing.template.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/files-listing.template.html
@@ -26,7 +26,7 @@
             </thead>
             <tbody>
                 <tr
-                    data-ng-repeat="item in $ctrl.listing.listing"
+                    data-ng-repeat="item in $ctrl.listing.listing.filter($ctrl.filterTrash)"
                     ng-class="{highlight: item.selected}"
                 >
                     <td class="unselectable">


### PR DESCRIPTION
## Overview: ##
Hide the .Trash folder in Community listings and other public listings.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2586](https://jira.tacc.utexas.edu/browse/DES-2586)

## Summary of Changes: ##

## Testing Steps: ##
1. Navigate to Community Data and confirm that the trash folder doesn't display in the top-level listing.

## UI Photos:
Before:
<img width="1423" alt="image" src="https://github.com/DesignSafe-CI/portal/assets/12601812/70443385-00e5-48b8-8040-0024dd459df2">
After:
<img width="1420" alt="image" src="https://github.com/DesignSafe-CI/portal/assets/12601812/20db2b33-d203-44cb-a601-678fdabe4994">



## Notes: ##
