### PR TITLE
task/DES-2536: Use Datacite metrics when displaying view/download counts

### DIFF
--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-field-recon.component.html
@@ -118,15 +118,15 @@
                         <div style="padding-bottom: 5px;"> 
                             <span ng-if="$ctrl.readOnly">
                                 <span style="background-color: #ECE4BF;">
-                                    {{ $ctrl.cumDoiMetrics[mission.value.dois].fileDownloads || 0 }} Downloads
+                                    {{ $ctrl.metricDisplay($ctrl.downloadCounts[mission.value.dois]) }} Downloads
                                 </span>
                                 &nbsp;&nbsp;
                                 <span style="background-color: #ECE4BF;">        
-                                    {{ $ctrl.cumDoiMetrics[mission.value.dois].filePreviews || 0}} Views
+                                    {{ $ctrl.metricDisplay($ctrl.viewCounts[mission.value.dois]) }} Views
                                 </span>
                                 &nbsp;&nbsp;
                                 <span style="background-color: #ECE4BF;">        
-                                    {{ $ctrl.citationCounts[mission.value.dois] || 0}} Citations
+                                    {{ $ctrl.metricDisplay($ctrl.citationCounts[mission.value.dois]) }} Citations
                                 </span>
                                 &nbsp;&nbsp;
                                 <span>
@@ -310,15 +310,15 @@
                         <div style="padding-bottom: 5px;"> 
                             <span ng-if="$ctrl.readOnly">
                                 <span style="background-color: #ECE4BF;">
-                                    {{ $ctrl.cumDoiMetrics[mission.value.dois].fileDownloads || 0 }} Downloads
+                                    {{ $ctrl.metricDisplay($ctrl.downloadCounts[mission.value.dois]) }} Downloads
                                 </span>
                                 &nbsp;&nbsp;
                                 <span style="background-color: #ECE4BF;">        
-                                    {{ $ctrl.cumDoiMetrics[mission.value.dois].filePreviews || 0}} Views
+                                    {{ $ctrl.metricDisplay($ctrl.viewCounts[mission.value.dois]) }} Views
                                 </span>
                                 &nbsp;&nbsp;
                                 <span style="background-color: #ECE4BF;">        
-                                    {{ $ctrl.citationCounts[mission.value.dois] || 0}} Citations
+                                    {{ $ctrl.metricDisplay($ctrl.citationCounts[mission.value.dois]) }} Citations
                                 </span>
                                 &nbsp;&nbsp;
                                 <span>

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-hyb-sim.component.html
@@ -138,15 +138,15 @@
                 <div style="padding-bottom: 5px;"> 
                     <span ng-if="$ctrl.readOnly">
                         <span style="background-color: #ECE4BF;">
-                            {{ $ctrl.cumDoiMetrics[hybsim.value.dois].fileDownloads || 0 }} Downloads
+                            {{ $ctrl.metricDisplay($ctrl.downloadCounts[hybsim.value.dois])}} Downloads
                         </span>
                         &nbsp;&nbsp;
                         <span style="background-color: #ECE4BF;">        
-                            {{ $ctrl.cumDoiMetrics[hybsim.value.dois].filePreviews || 0}} Views
+                            {{ $ctrl.metricDisplay($ctrl.viewCounts[hybsim.value.dois])}} Views
                         </span>
                         &nbsp;&nbsp;
                         <span style="background-color: #ECE4BF;">        
-                            {{ $ctrl.citationCounts[hybsim.value.dois] || 0}} Citations
+                            {{ $ctrl.metricDisplay($ctrl.citationCounts[hybsim.value.dois])}} Citations
                         </span>
                         &nbsp;&nbsp;
                         <span>

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-sim.component.html
@@ -139,15 +139,15 @@
                 <div style="padding-bottom: 5px;"> 
                     <span ng-if="$ctrl.readOnly">
                         <span style="background-color: #ECE4BF;">
-                            {{ $ctrl.cumDoiMetrics[simulation.value.dois].fileDownloads || 0 }} Downloads
+                            {{ $ctrl.metricDisplay($ctrl.downloadCounts[simulation.value.dois]) }} Downloads
                         </span>
                         &nbsp;&nbsp;
                         <span style="background-color: #ECE4BF;">        
-                            {{ $ctrl.cumDoiMetrics[simulation.value.dois].filePreviews || 0}} Views
+                            {{ $ctrl.metricDisplay($ctrl.viewCounts[simulation.value.dois])}} Views
                         </span>
                         &nbsp;&nbsp;
                         <span style="background-color: #ECE4BF;">        
-                            {{ $ctrl.citationCounts[simulation.value.dois] || 0}} Citations
+                            {{ $ctrl.metricDisplay($ctrl.citationCounts[simulation.value.dois])}} Citations
                         </span>
                         &nbsp;&nbsp;
                         <span>

--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview.component.html
@@ -135,15 +135,15 @@
                 <div style="padding-bottom: 5px;"> 
                     <span ng-if="$ctrl.readOnly">
                         <span style="background-color: #ECE4BF;">
-                            {{ $ctrl.cumDoiMetrics[experiment.value.dois].fileDownloads || 0 }} Downloads
+                            {{ $ctrl.metricDisplay($ctrl.downloadCounts[experiment.value.dois]) }} Downloads
                         </span>
                         &nbsp;&nbsp;
                         <span style="background-color: #ECE4BF;">        
-                            {{ $ctrl.cumDoiMetrics[experiment.value.dois].filePreviews || 0}} Views
+                            {{ $ctrl.metricDisplay($ctrl.viewCounts[experiment.value.dois]) }} Views
                         </span>
                         &nbsp;&nbsp;
                         <span style="background-color: #ECE4BF;">        
-                            {{ $ctrl.citationCounts[experiment.value.dois] || 0}} Citations
+                            {{ $ctrl.metricDisplay($ctrl.citationCounts[experiment.value.dois]) }} Citations
                         </span>
                         &nbsp;&nbsp;
                         <span>

--- a/designsafe/static/scripts/data-depot/components/published/published-view.component.js
+++ b/designsafe/static/scripts/data-depot/components/published/published-view.component.js
@@ -92,7 +92,9 @@ class PublishedViewCtrl {
                 });
             });
         }
-        this.citationCounts = {}
+        this.citationCounts = {};
+        this.viewCounts = {};
+        this.downloadCounts = {};
         this.projId = this.$stateParams.filePath.replace(/^\/+/, '').split('/')[0];
         this.versions = this.prepVersions(this.publication);
         this.selectedVersion = this.publication.revision || 1;
@@ -315,6 +317,9 @@ class PublishedViewCtrl {
                 this.doi = this.doiList[ent.uuid];
             });
         }
+        if (this.project.value.projectType === 'other') {
+            this.doiList[this.project.uuid] = {doi: this.project.value.dois[0]};
+        }
         if (this.doiList) {
             const dataciteRequests = Object.values(this.doiList).map(({ doi }) => {
                 return this.$http.get(`/api/publications/data-cite/${doi}`);
@@ -328,6 +333,8 @@ class PublishedViewCtrl {
                 citations.forEach((cite) => {
                     const doiObj = Object.values(this.doiList).find((x) => x.doi === cite.doi);
                     this.citationCounts[cite.doi] = cite.citationCount;
+                    this.downloadCounts[cite.doi] = cite.downloadCount;
+                    this.viewCounts[cite.doi] = cite.viewCount;
                     doiObj.created = cite.created;
                 });
             });
@@ -346,6 +353,12 @@ class PublishedViewCtrl {
             },
             { reload: true }
         );
+    }
+
+    metricDisplay(metric) {
+        if (metric === 0) return 0;
+        if (metric) return metric;
+        return "--";
     }
 
     prepVersions(publication) {

--- a/designsafe/static/scripts/ng-designsafe/directives/templates/prj-pub-preview-metadata-template.html
+++ b/designsafe/static/scripts/ng-designsafe/directives/templates/prj-pub-preview-metadata-template.html
@@ -81,15 +81,15 @@
     <div style="padding-bottom: 5px;"> 
         <span ng-if="$ctrl.readOnly">
             <span style="background-color: #ECE4BF;">
-                {{ $ctrl.cumMetrics.otherTotal || 0 }} Downloads
+                {{ $ctrl.metricDisplay($ctrl.downloadCounts[$ctrl.project.value.dois[0]]) }} Downloads
             </span>
             &nbsp;&nbsp;
-            <span style="background-color: #ECE4BF;">        
-                {{ $ctrl.cumMetrics.filePreviews || 0}} Views
+            <span style="background-color: #ECE4BF;">      
+                {{ $ctrl.metricDisplay($ctrl.viewCounts[$ctrl.project.value.dois[0]]) }} Views
             </span>
             &nbsp;&nbsp;
-            <span style="background-color: #ECE4BF;">        
-                {{ $ctrl.citationCounts[experiment.value.dois] || 0}} Citations
+            <span style="background-color: #ECE4BF;">
+                {{ $ctrl.metricDisplay($ctrl.citationCounts[$ctrl.project.value.dois[0]]) }} Citations
             </span>
             &nbsp;&nbsp;
             <span ng-if="$ctrl.readOnly">


### PR DESCRIPTION
## Overview: ##
- Use Datacite as the source of truth for view/download/citation metrics on publications
- use "--" as a loading indicator instead of defaulting to 0.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2536](https://jira.tacc.utexas.edu/browse/DES-2536)

## Summary of Changes: ##

## Testing Steps: ##
1. Open publications of type Experimental, Simulation, Field Research, Hybrid Sim, and Other. Check that the view/download/citation metrics load in.

## UI Photos:

## Notes: ##
