### PR TITLE
task/DES-2530: Use service client instead of envision user for public listings

### DIFF
--- a/designsafe/apps/api/datafiles/views.py
+++ b/designsafe/apps/api/datafiles/views.py
@@ -8,6 +8,7 @@ from designsafe.apps.api.datafiles.operations.transfer_operations import transfe
 from designsafe.apps.api.datafiles.notifications import notify
 from designsafe.apps.api.datafiles.models import DataFilesSurveyResult, DataFilesSurveyCounter
 from designsafe.apps.api.views import BaseApiView
+from designsafe.apps.api.agave import service_account
 from dropbox.exceptions import AuthError as DropboxAuthError
 from google.auth.exceptions import GoogleAuthError
 from requests.exceptions import HTTPError
@@ -56,7 +57,7 @@ class DataFilesView(BaseApiView):
             except AttributeError:
                 raise resource_unconnected_handler(api)
         elif api == 'agave':
-            client = get_user_model().objects.get(username='envision').agave_oauth.client
+            client = service_account()
         else:
             return JsonResponse({'message': 'Please log in to access this feature.'}, status=403)
 


### PR DESCRIPTION
## Overview: ##
Relying on the Envision user for listing operations is fragile since the token can expire without warning. There are no security implications to using a service account here, and this is the approach that has been working for us in the Core portals.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2530](https://jira.tacc.utexas.edu/browse/DES-2530)

## Summary of Changes: ##

## Testing Steps: ##
1. Perform file listings in Published and in Community Data.
