### PR TITLE
fix: DES-2598 text editor too short (⚠️ untested)

### DIFF
--- a/designsafe/static/djangocms_text_ckeditor/css/cms.ckeditor.css
+++ b/designsafe/static/djangocms_text_ckeditor/css/cms.ckeditor.css
@@ -1,0 +1,5 @@
+@import url("../cms.ckeditor.original.css");
+
+/* To stretch source editor textarea height */
+/* https://github.com/django-cms/djangocms-text-ckeditor/pull/590 */
+textarea.cke_source { max-height: inherit; }

--- a/designsafe/static/djangocms_text_ckeditor/css/cms.ckeditor.css
+++ b/designsafe/static/djangocms_text_ckeditor/css/cms.ckeditor.css
@@ -1,4 +1,4 @@
-@import url("../cms.ckeditor.original.css");
+@import url("./cms.ckeditor.original.css");
 
 /* To stretch source editor textarea height */
 /* https://github.com/django-cms/djangocms-text-ckeditor/pull/590 */

--- a/designsafe/static/djangocms_text_ckeditor/css/cms.ckeditor.original.css
+++ b/designsafe/static/djangocms_text_ckeditor/css/cms.ckeditor.original.css
@@ -1,0 +1,109 @@
+/*! https://raw.githubusercontent.com/django-cms/djangocms-text-ckeditor/3.10.0/djangocms_text_ckeditor/static/djangocms_text_ckeditor/css/cms.ckeditor.css */
+
+@charset "utf-8";
+/* everything has to be !important because of the way css is loaded */
+
+/* float left with the label */
+.cke_chrome {
+    float: left !important;
+    width: 100% !important;
+}
+
+/* special case when inside a text plugin */
+.djangocms_text_ckeditor-text .form-row label {
+    display: none !important;
+}
+.djangocms_text_ckeditor-text .cke_chrome {
+    float: none !important;
+}
+
+/* ensure dialog has relative positioning for absolute positioned content */
+.cms-ckeditor-dialog .cke_dialog {
+    position: fixed !important;
+}
+.cke_dialog_contents {
+    user-select: none !important;
+}
+.cke_dialog_contents_body {
+    position: relative !important;
+}
+
+/* show cmsplugin label */
+.cke_button__cmsplugins .cke_button_label {
+    display: inline !important;
+    padding-right: 5px !important;
+    padding-left: 5px !important;
+}
+
+/* make dropdow larger */
+.cke_combopanel,
+.cke_panel {
+    min-width: 200px !important;
+}
+
+
+/* add / edit plugin modal */
+.cke_dialog_body {
+    border: 1px solid #d1d1d1 !important;
+}
+.cms-ckeditor-dialog .cke_dialog_contents_body {
+    padding: 3px 0 !important;
+}
+.cms-ckeditor-dialog .cke_dialog_page_contents {
+    width: 100% !important;
+    height: 100% !important;
+}
+.cms-ckeditor-dialog .cke_dialog_page_contents table {
+    display: block !important;
+    position: absolute !important;
+    top: 0 !important;
+    left: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+}
+.cms-ckeditor-dialog .cke_dialog_page_contents table tbody,
+.cms-ckeditor-dialog .cke_dialog_page_contents table tr,
+.cms-ckeditor-dialog .cke_dialog_page_contents table td {
+    display: block !important;
+    height: 100% !important;
+}
+.cms-ckeditor-dialog .cke_dialog_page_contents table .cke_dialog_ui_vbox_child {
+    display: block !important;
+    overflow-y: auto !important;
+    height: 100% !important;
+    padding: 0 !important;
+
+    -webkit-overflow-scrolling: touch !important;
+}
+.cms-ckeditor-dialog .cke_dialog_page_contents table .cke_dialog_ui_vbox_child iframe {
+    display: block !important;
+    position: static !important;
+    width: 100% !important;
+    height: 100% !important;
+}
+
+/* scrollable dropdowns on touch */
+.cke_panel {
+    overflow-y: auto !important;
+    height: auto !important;
+    max-height: 300px !important;
+
+    -webkit-overflow-scrolling: touch !important;
+}
+.cke_panel .cke_panel_frame {
+    display: block !important;
+    position: static !important;
+    overflow: hidden !important;
+    width: 100% !important;
+    height: 100% !important;
+    min-height: 100% !important;
+}
+
+/* cms-resizer */
+.cms-ckeditor-resizer {
+    overflow: auto !important;
+    font-size: 12px !important;
+    width: auto !important;
+    height: auto !important;
+    border: none !important;
+}


### PR DESCRIPTION
## Overview: ##

Add styles to CMS Text editor stylesheet to prevent field size bug.

## PR Status: ##

* [X] Ready… but untested locally.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2598](https://jira.tacc.utexas.edu/browse/DES-2598)

## Summary of Changes: ##

- **added** custom stylesheet for ckeditor
- **added** clone of original stylesheet for ckeditor
- **added** import of cloned stylesheet

## Testing Steps: ##
1. Open CMS.
2. Login as admin.
3. Create/Edit text on a page.
4. Add so much content, a scrollbar is needed.
5. Make the text editor modal narrow.
6. While editing, view source (click the "[<>] Source" button).
7. Verify all available height in modal for text editor is used to show source.

## UI Photos:

I am unable to provide. I do not have test environemnt.

## Notes: ##

1. stole code from https://github.com/TACC/Core-CMS/pull/573/files#diff-b613bf1b786994b3d51a81e982cf9106f4a09f8adcc65fd9c14f4f8d54bdfa72R6-R8
8. applied code like https://github.com/TACC/Core-CMS/blob/v4.0.0/taccsite_cms/static/djangocms_text_ckeditor/ckeditor/contents.css