### PR TITLE
bug/WP-319: Fix email confirmation for tickets

### DIFF
--- a/designsafe/apps/djangoRT/rtUtil.py
+++ b/designsafe/apps/djangoRT/rtUtil.py
@@ -70,7 +70,7 @@ class DjangoRt:
         :return: The newly created ticket ID
         """
         return self.tracker.create_ticket(
-            Subject=ticket.subject, Requestors=ticket.requestor, Cc=",".join(ticket.cc),
+            Subject=ticket.subject, Requestor=ticket.requestor, Cc=",".join(ticket.cc),
             Text=ticket.problem_description.replace('\n', '\n '))
 
     def replyToTicket(self, ticket_id, text='', files=[]):


### PR DESCRIPTION
## Overview: ##
The rtpy documentation is misleading: https://python-rt.readthedocs.io/en/latest/rest1.html#rt.rest1.Rt.create_ticket 

Specifying "Requestors" instead of "Requestor" as we've been doing causes the requestors to be added AFTER ticket creation, meaning no one gets an email confirmation.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-319](https://jira.tacc.utexas.edu/browse/WP-319)

