### PR TITLE
task/DES-2605: Add a nightly crontab to delete notifications older than 30 days.

### DIFF
--- a/designsafe/apps/auth/tasks.py
+++ b/designsafe/apps/auth/tasks.py
@@ -1,7 +1,9 @@
+from datetime import datetime, timedelta
 from django.conf import settings
 from django.core.mail import send_mail
 from agavepy.agave import Agave, AgaveException
 from designsafe.apps.api.tasks import agave_indexer
+from designsafe.apps.api.notifications.models import Notification
 from celery import shared_task
 
 from requests import HTTPError
@@ -92,3 +94,11 @@ def new_user_alert(username):
                                                     'Name: ' + user.first_name + ' ' + user.last_name + '\n' +
                                                     'Id: ' + str(user.id) + '\n',
               settings.DEFAULT_FROM_EMAIL, settings.NEW_ACCOUNT_ALERT_EMAILS.split(','),)
+    
+
+@shared_task()
+def clear_old_notifications(self):
+    """Delete notifications older than 30 days to prevent them cluttering the db."""
+    time_cutoff = datetime.now() - timedelta(days=30)
+    Notification.objects.filter(datetime__lte=time_cutoff).delete()
+    

--- a/designsafe/apps/auth/tasks.py
+++ b/designsafe/apps/auth/tasks.py
@@ -101,4 +101,3 @@ def clear_old_notifications(self):
     """Delete notifications older than 30 days to prevent them cluttering the db."""
     time_cutoff = datetime.now() - timedelta(days=30)
     Notification.objects.filter(datetime__lte=time_cutoff).delete()
-    

--- a/designsafe/apps/search/tasks.py
+++ b/designsafe/apps/search/tasks.py
@@ -18,7 +18,7 @@ def update_search_index():
 def clear_expired_sessions():
     logger.info("Clearing expired sessions.")
     if not settings.DEBUG:
-        call_command("clearsessions", interactive=False)
+        call_command("clearsessions")
 
 
 @shared_task(bind=True)

--- a/designsafe/celery.py
+++ b/designsafe/celery.py
@@ -33,6 +33,10 @@ app.conf.update(
         'reindex_projects': {
             'task': 'designsafe.apps.api.tasks.reindex_projects',
             'schedule': crontab(hour=0, minute=0)
+        },
+        'clear_old_notifications': {
+            'task': 'designsafe.auth.tasks.clear_old_notifications',
+            'schedule': crontab(hour=0, minute=1)
         }
     }
 )


### PR DESCRIPTION
## Overview: ##
If left unchecked, multiple gigabytes of old notifications can accumulate in the database. This PR adds a nightly cleanup task that deletes notifications older than 30 days.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2605](https://jira.tacc.utexas.edu/browse/DES-2605)

