### PR TITLE
Bug/DES-2606: add exponential backoff for websocket retries

### DIFF
--- a/designsafe/apps/signals/static/designsafe/apps/signals/scripts/provider.js
+++ b/designsafe/apps/signals/static/designsafe/apps/signals/scripts/provider.js
@@ -10,7 +10,8 @@ export function wsBusService(){
 
         return service;
 
-        function init(url){
+        function init(url, retry){
+            if (!retry) retry=1000 * Math.random()
             ws = new WebSocket(url);
             logger.log('wss : ', ws)
             ws.onopen = function(){
@@ -25,8 +26,8 @@ export function wsBusService(){
                 logger.log('WS error: ', e);
             };
             ws.onclose = function(e){
-                logger.log('connection closed; reopening');
-                init(url);
+                console.log(`Websocket connection closed, retrying in ${Math.floor(retry/1000.0)}s`)
+                if (retry < 60000) setTimeout(() => init(url, retry * 2), retry);
             };
             service.ws = ws;
         }

--- a/designsafe/static/scripts/ng-designsafe/providers/ws-provider.js
+++ b/designsafe/static/scripts/ng-designsafe/providers/ws-provider.js
@@ -14,7 +14,8 @@ function WSBusService($rootScope, logger, configURL) {
      * @function
      * @param {string} url
      */
-    function init(url) {
+    function init(url, retry) {
+        if (!retry) retry=1000 * Math.random()
         ws = new WebSocket(url);
         ws.onopen = function() {};
         ws.onmessage = function(e) {
@@ -25,7 +26,8 @@ function WSBusService($rootScope, logger, configURL) {
             logger.log('WS error: ', e);
         };
         ws.onclose = function(e) {
-            init(url);
+            console.log(`Websocket connection closed, retrying in ${Math.floor(retry/1000.0)}s`)
+            if (retry < 60000) setTimeout(() => init(url, retry * 2), retry);
         };
         service.ws = ws;
     }


### PR DESCRIPTION
## Overview: ##
Updated:	1 minute ago
Description
Currently if a websocket connection closes, we retry in an infinite loop without any kind of debounce/backoff. This results in the server getting completely slammed with incoming requests if there's any sort of error due to someone's client being stale.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2606](https://jira.tacc.utexas.edu/browse/DES-2606)

## Summary of Changes: ##
Add an exponential backoff to websocket connections. the retry backoff starts at `1000 * Math.random()` to introduce jitter so that if the server restarts every client doesn't try to reconnect simultaneously. Subsequent retry requests double the delay until 1 minute has passed, then the client gives up.

## Testing Steps: ##
1. In `ng-designsafe.js` replace the `/ws/websockets/` URL with `/ws/error`.
2. Check that when you visit designsafe.dev you see attempted reconnects for 1 minute with exponential backoff.

