### PR TITLE
bug/DES-2602: Keep track of DOI when a user browses files in a publication

### DIFF
--- a/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-toolbar/data-depot-toolbar.component.js
@@ -1,9 +1,10 @@
 import dataDepotToolbarTemplate from './data-depot-toolbar.component.html'
 
 class DataDepotToolbarCtrl {
-    constructor($state, $uibModal, Django, UserService, FileListingService, FileOperationService, PublicationService) {
+    constructor($state, $stateParams, $uibModal, Django, UserService, FileListingService, FileOperationService, PublicationService) {
         'ngInject';
         this.$state = $state;
+        this.$stateParams = $stateParams
         this.search = { queryString: '' };
         this.UserService = UserService;
         this.FileListingService = FileListingService
@@ -50,12 +51,14 @@ class DataDepotToolbarCtrl {
             const projectId = this.PublicationService.current.projectId;
             this.FileOperationService.microsurvey({projectId})
         }
-        this.FileOperationService.download({api, scheme, files, doi: this.FileListingService.currentDOI});
+        const doi = this.FileListingService.currentDOI || this.$stateParams.doi
+        this.FileOperationService.download({api, scheme, files, doi});
     }
     preview() {
         const { api, scheme } = this.FileListingService.listings.main.params;
         const file = this.getAllSelected()[0];
-        this.FileOperationService.openPreviewModal({api, scheme, file, doi: this.FileListingService.currentDOI});
+        const doi = this.FileListingService.currentDOI || this.$stateParams.doi
+        this.FileOperationService.openPreviewModal({api, scheme, file, doi});
     }
     previewImages() {
         const { api, scheme, system } = this.FileListingService.listings.main.params;

--- a/designsafe/static/scripts/data-depot/components/published/published-view.component.js
+++ b/designsafe/static/scripts/data-depot/components/published/published-view.component.js
@@ -641,6 +641,7 @@ class PublishedViewCtrl {
     }
 
     onBrowse(file, doi) {
+        if (!doi) {doi = this.$stateParams.doi}
         if (file.type === 'dir') {
             this.$state.go(this.$state.current.name, { filePath: file.path, query_string: null, doi: doi });
         } else {


### PR DESCRIPTION
## Overview: ##
Keep track of the DOI associated to a folder when the user navigates inside of a publication. This prevents undefined DOIs on file operations.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2602](https://jira.tacc.utexas.edu/browse/DES-2602)

