### PR TITLE
Fix: Disable elasticsearch socket options in dev/test envs

### DIFF
--- a/designsafe/apps/data/apps.py
+++ b/designsafe/apps/data/apps.py
@@ -20,12 +20,13 @@ class KeepAliveConnection(Urllib3HttpConnection):
     """
     def __init__(self, *args, **kwargs):
         super(KeepAliveConnection, self).__init__(*args, **kwargs)
-        self.pool.conn_kw['socket_options'] = HTTPConnection.default_socket_options + [
-            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-            (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60),
-            (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 30),
-            (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3),
-        ]
+        if not (settings.DEBUG or settings.TEST):
+            self.pool.conn_kw['socket_options'] = HTTPConnection.default_socket_options + [
+                (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+                (socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60),
+                (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 30),
+                (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3),
+            ]
 
 
 class DataConfig(AppConfig):

--- a/designsafe/settings/test_settings.py
+++ b/designsafe/settings/test_settings.py
@@ -36,6 +36,7 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
+TEST = True
 
 ALLOWED_HOSTS = ['*']
 # Application definition


### PR DESCRIPTION
This fixes an issue where pylint was breaking in local dev.
