### PR TITLE
task/DES-2628: Improve searches when users specify a first and last name

### DIFF
--- a/designsafe/apps/api/publications/search_utils.py
+++ b/designsafe/apps/api/publications/search_utils.py
@@ -120,7 +120,7 @@ def author_query(author):
                            "authors.fname",
                            "authors.lname", ]
 
-    aq2 = Q('query_string', query=author, fields=other_author_fields)
+    aq2 = Q('multi_match', query=author, fields=other_author_fields, operator="AND", type="cross_fields")
 
     return aq1 | aq2
 
@@ -177,4 +177,4 @@ def search_string_query(search_string):
                                                           'project.value.projectType',
                                                           'project.value.dataType'])
     q2 = Q({'term': {'projectId._exact': search_string}})
-    return q1 | q2 | author_query(f"\"{search_string}\"")
+    return q1 | q2 | author_query(search_string)


### PR DESCRIPTION
## Overview: ##
Use a cross-fields query on usernames to handle queries where a user wants to do a lookup by first AND last name.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2628](https://tacc-main.atlassian.net/browse/DES-2628)

## Summary of Changes: ##

## Testing Steps: ##
1. Search for "Brady Cox" in the search bar and make sure no one else with the surname "Cox" comes up as a PI.

