### PR TITLE
bug/DES-2634: Fix NEES description endpoint

### DIFF
--- a/designsafe/apps/api/publications/urls.py
+++ b/designsafe/apps/api/publications/urls.py
@@ -10,5 +10,6 @@ urlpatterns = [
     #     GET     /listing/<file_mgr_name>/<system_id>/<file_path>/
     url(r'^data-cite/(?P<doi>[ \S]*)$', PublicationDataCiteView.as_view(), name='publication_datacite'),
     url(r'^(?P<operation>[\w.-]+)/$', PublicationListingView.as_view(), name='publication_listing'),
-    url(r'^(?P<operation>[\w.-]+)/(?P<project_id>[A-Z\-]+-[0-9]+)(v(?P<revision>[0-9]+))?/$', PublicationDetailView.as_view(), name='publication_detail')
+    url(r'^(?P<operation>[\w.-]+)/(?P<project_id>[A-Z\-]+-[0-9]+)(v(?P<revision>[0-9]+))?/$', PublicationDetailView.as_view(), name='publication_detail'),
+    url(r'^(?P<operation>[\w.-]+)/(?P<project_id>[\w.-]+)/$', PublicationDetailView.as_view(), name='legacy-publication_detail')
 ]


### PR DESCRIPTION
## Overview: ##
Fix a URL bug preventing NEES project IDs from being parsed.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2634](https://tacc-main.atlassian.net/browse/DES-2634)

## Summary of Changes: ##

## Testing Steps: ##
1. Click "View Description" in the NEES listing.
