### PR TITLE
bug/DES-2645: Fix cleanup for old notifications

### DIFF
--- a/designsafe/apps/auth/tasks.py
+++ b/designsafe/apps/auth/tasks.py
@@ -99,7 +99,7 @@ def new_user_alert(username):
 
 
 @shared_task()
-def clear_old_notifications(self):
+def clear_old_notifications():
     """Delete notifications older than 30 days to prevent them cluttering the db."""
     time_cutoff = datetime.now() - timedelta(days=30)
     Notification.objects.filter(datetime__lte=time_cutoff).delete()


### PR DESCRIPTION
## Overview: ##
Fix a bug with the task definition.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2645](https://tacc-main.atlassian.net/browse/DES-2645)
