### PR TITLE
task/DES-2636: Refactor file move/copy to use non-bulk metadata operations

### DIFF
--- a/designsafe/apps/api/datafiles/operations/agave_operations.py
+++ b/designsafe/apps/api/datafiles/operations/agave_operations.py
@@ -251,12 +251,12 @@ def move(client, src_system, src_path, dest_system, dest_path):
         filePath=urllib.parse.quote(src_path),
         body=body
     )
-    update_meta(
-        src_system=src_system,
-        src_path=src_path,
-        dest_system=dest_system,
-        dest_path=full_dest_path
-    )
+    update_meta.apply_async(kwargs={
+        "src_system": src_system,
+        "src_path": src_path,
+        "dest_system": dest_system,
+        "dest_path": full_dest_path
+    }, queue="indexing")
 
     if os.path.dirname(src_path) != full_dest_path or src_path != full_dest_path:
         agave_indexer.apply_async(kwargs={
@@ -328,12 +328,12 @@ def copy(client, src_system, src_path, dest_system, dest_path):
             urlToIngest=src_url
         )
 
-    copy_meta(
-        src_system=src_system,
-        src_path=src_path,
-        dest_system=dest_system,
-        dest_path=full_dest_path
-    )
+    copy_meta.apply_async(kwargs={
+        "src_system": src_system,
+        "src_path": src_path,
+        "dest_system": dest_system,
+        "dest_path": full_dest_path
+    }, queue='indexing')
 
     if copy_result['nativeFormat'] == 'dir':
         agave_indexer.apply_async(kwargs={
@@ -390,12 +390,12 @@ def rename(client, system, path, new_name):
         filePath=urllib.parse.quote(os.path.join('/', path)),
         body=body
     )
-    update_meta(
-        src_system=system,
-        src_path=path,
-        dest_system=system,
-        dest_path=os.path.join(os.path.dirname(path), new_name)
-    )
+    update_meta.apply_async(kwargs={
+        "src_system": system,
+        "src_path": path,
+        "dest_system": system,
+        "dest_path": os.path.join(os.path.dirname(path), new_name)
+    }, queue="indexing")
 
     # if rename_result['nativeFormat'] == 'dir':
     if listing[0].type == 'dir':

--- a/designsafe/apps/api/datafiles/utils.py
+++ b/designsafe/apps/api/datafiles/utils.py
@@ -3,8 +3,9 @@ import json
 import logging
 import os
 import re
-import copy
+from copy import deepcopy
 import exifread
+from celery import shared_task
 from designsafe.apps.api.agave import service_account
 from PIL import Image
 
@@ -94,7 +95,15 @@ def scrape_metadata_from_file(file):
 
     return metadata
 
+def create_or_update_meta(client, meta_body):
+    existing_meta = query_file_meta(meta_body["value"]["system"], meta_body["value"]["path"])
+    if not existing_meta:
+        return client.meta.addMetadata(body=json.dumps(meta_body))
+    existing_uuid = existing_meta[0]["uuid"]
+    return client.meta.updateMetadata(uuid=existing_uuid, body=meta_body)
 
+
+@shared_task(autoretry_for=(Exception,), retry_kwargs={'max_retries': 3})
 def update_meta(src_system, src_path, dest_system, dest_path):
     """
     Check for and update metadata record(s)
@@ -105,16 +114,24 @@ def update_meta(src_system, src_path, dest_system, dest_path):
     meta_listing = query_file_meta(system=src_system, path=src_path)
     if meta_listing:
         for meta in meta_listing:
-            meta.value['system'] = dest_system
-            meta.value['path'] = meta.value['path'].replace(src_path, dest_path)
-            meta.value['basePath'] = meta.value['basePath'].replace(
-                os.path.dirname(src_path),
-                os.path.dirname(dest_path)
-            )
-            updates.append({"uuid": meta.uuid, "update": meta})
-        sa_client.meta.bulkUpdate(body=json.dumps(updates))
+            meta_dict = deepcopy(dict(meta))
+            new_path = meta_dict['value']['path'].replace(src_path.rstrip("/"), dest_path, 1)
+            if not new_path.startswith("/"):
+                new_path = f"/{new_path}"
+            
+            new_meta_value = {**meta_dict["value"],
+                                   "system": dest_system,
+                                   "path": new_path,
+                                   "basePath": os.path.dirname(new_path)}
+
+            meta_body = {"name": "designsafe.file", "value": new_meta_value}
+            updates.append({"uuid": meta_dict["uuid"], "body": meta_body})
+        
+        for update in updates:
+            sa_client.meta.updateMetadata(uuid=update["uuid"], body=json.dumps(update["body"]))
 
 
+@shared_task(autoretry_for=(Exception,), retry_kwargs={'max_retries': 3})
 def copy_meta(src_system, src_path, dest_system, dest_path):
     """
     Check for and copy metadata record(s)
@@ -125,14 +142,21 @@ def copy_meta(src_system, src_path, dest_system, dest_path):
     meta_listing = query_file_meta(system=src_system, path=src_path)
     if meta_listing:
         for meta in meta_listing:
-            meta_dict = copy.deepcopy(dict(meta))
-            meta_copy = file_meta_obj(
-                path=meta_dict['value']['path'].replace(src_path, dest_path),
-                system=dest_system,
-                meta=meta_dict['value']
-            )
-            copies.append(meta_copy)
-        sa_client.meta.bulkCreate(body=json.dumps(copies))
+            meta_dict = deepcopy(dict(meta))
+            new_path = meta_dict['value']['path'].replace(src_path.rstrip("/"), dest_path, 1)
+            if not new_path.startswith("/"):
+                new_path = f"/{new_path}"
+            
+            copy_meta_value = {**meta_dict["value"],
+                                   "system": dest_system,
+                                   "path": new_path,
+                                   "basePath": os.path.dirname(new_path)}
+
+            meta_body = {"name": "designsafe.file", "value": copy_meta_value}
+            copies.append(meta_body)
+
+        for copy in copies:
+            create_or_update_meta(sa_client, copy)
 
 
 def create_meta(path, system, meta):


### PR DESCRIPTION
## Overview: ##
Refactors bulk metadata operations to use a series of individual create/update calls.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2636](https://tacc-main.atlassian.net/browse/DES-2636)

## Summary of Changes: ##
- Refactor bulk metadata operations to use synchronous create/update calls on individual metadata objects.
- Make bulk operations asynchronous and allow retries (max 3).
- Update the semantics of `copy_metadata` so that if it needs to be retried, it won't create duplicate metadata records attached to the destination path. (in V3 we can use custom UIDs to make duplication impossible).

## Testing Steps: ##
Perform the following operations on a file with associated metadata (from RApp):
- Copy
- Move
- Rename
- Trash
Ensure that the metadata follows the file across each operation.

## UI Photos:

## Notes: ##
