### PR TITLE
bug/DES-2640: Disable copying files into Google Drive

### DIFF
--- a/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-copy/data-browser-service-copy.component.js
+++ b/designsafe/static/scripts/ng-designsafe/components/modals/data-browser-service-copy/data-browser-service-copy.component.js
@@ -36,7 +36,6 @@ class DataBrowserCopyCtrl {
         this.options = [
             { api: 'agave', label: 'My Data' },
             { api: 'projects', label: 'My Projects' },
-            { api: 'googledrive', label: 'Google Drive' },
             { api: 'box', label: 'Box' },
             { api: 'dropbox', label: 'Dropbox' },
         ];


### PR DESCRIPTION
## Overview: ##
We've altered our Google Drive scope to read-only, so copying INTO Drive should no longer be supported.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2640](https://tacc-main.atlassian.net/browse/DES-2640)

