### PR TITLE
bug/DES-2663: Fix tags not showing up in non-Other projects

### DIFF
--- a/designsafe/static/scripts/projects/components/file-categories/file-categories.component.js
+++ b/designsafe/static/scripts/projects/components/file-categories/file-categories.component.js
@@ -288,7 +288,10 @@ class FileCategoriesCtrl {
 
         if (this.scheme === 'public') {
             return tags.filter((tag) => {
-                let substring = `/${this.project.value.projectId}`;
+                let substring = `${this.project.value.projectId}`;
+                if (this.file.path.startsWith('/')) {
+                    substring = `/${substring}`
+                }
                 if (this.version > 0) {
                     substring = substring + `v${this.version}`;
                 }


### PR DESCRIPTION
## Overview: ##
Fix a string formatting issue that was preventing tags from showing up on non-Other type projects.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2663](https://tacc-main.atlassian.net/browse/DES-2663)

## Summary of Changes: ##

## Testing Steps: ##
1. Go to both Other and non-Other projects in dev and check that tags work.

## UI Photos:

## Notes: ##
