### PR TITLE
bug/DES-2664: Add tombstone messages for type Other

### DIFF
--- a/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.html
+++ b/designsafe/static/scripts/data-depot/components/projects/publication-preview/publication-preview-other.component.html
@@ -2,6 +2,17 @@
     <!-- Project Header Start -->
     <div ng-if="!$ctrl.ui.loading">
 <!-- pub preview metadata -->
+        <div class="alert alert-warning flex-container" ng-if="$ctrl.publication.tombstone.includes($ctrl.project.uuid)">
+            <i role="none" class="fa fa-warning notification-icon"></i>
+            <div>
+                <strong>The following Dataset does not exist anymore</strong><br>
+                The Dataset with DOI:
+                <a href="https://doi.org/{{mission.value.dois[0]}}">https://doi.org/{{$ctrl.project.value.dois[0]}}</a>
+                was incomplete and removed. The metadata is still available.
+                <span ng-if="$ctrl.publication.tombstoneMessage">The authors have provided the following message regarding the status of the dataset: "{{$ctrl.publication.tombstoneMessage}}"</span>
+            </div>
+
+        </div>
         <prj-pub-preview-metadata></prj-pub-preview-metadata>
         <!-- Project Nav -->
         <span class="project-preview-nav" ng-if="!$ctrl.readOnly && !$ctrl.ui.loading">


### PR DESCRIPTION
## Overview: ##
Adds tombstone banners for type Other publications with an optional `tombstoneMessage` set on the publication object in Elasticsearch.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2665](https://tacc-main.atlassian.net/browse/DES-2664)

## Summary of Changes: ##

## Testing Steps: ##
1. Visit publication PRJ-3908 and check that the tombstone banner is displayed.


## UI Photos:
<img width="1458" alt="image" src="https://github.com/DesignSafe-CI/portal/assets/12601812/47327db9-c636-4ec8-88bf-86262ab7902b">


## Notes: ##
