### PR TITLE
Task/DES-2639 addendum:  Add funder name to project management form.

### DIFF
--- a/designsafe/apps/projects/models/agave/base.py
+++ b/designsafe/apps/projects/models/agave/base.py
@@ -517,11 +517,10 @@ class Project(MetadataModel):
         )
         attributes['fundingReferences'] = []
         for award in awards:
-            if award.get("number", "").lower().startswith("nsf"):
                 attributes['fundingReferences'].append({
                     'awardTitle': award['name'],
                     'awardNumber': award['number'],
-                    "funderName": "National Science Foundation",
+                    "funderName": award.get("fundingSource", "N/A"),
                     })
 
         attributes['relatedIdentifiers'] = []

--- a/designsafe/apps/projects/models/agave/base.py
+++ b/designsafe/apps/projects/models/agave/base.py
@@ -517,11 +517,11 @@ class Project(MetadataModel):
         )
         attributes['fundingReferences'] = []
         for award in awards:
-                attributes['fundingReferences'].append({
-                    'awardTitle': award['name'],
-                    'awardNumber': award['number'],
-                    "funderName": award.get("fundingSource", "N/A"),
-                    })
+            attributes['fundingReferences'].append({
+                'awardTitle': award['name'],
+                'awardNumber': award['number'],
+                "funderName": award.get("fundingSource", "N/A"),
+                })
 
         attributes['relatedIdentifiers'] = []
 

--- a/designsafe/apps/projects/models/agave/experimental.py
+++ b/designsafe/apps/projects/models/agave/experimental.py
@@ -98,12 +98,11 @@ class Experiment(RelatedEntity):
             )
             attributes['fundingReferences'] = []
             for award in awards:
-                if award.get("number", "").lower().startswith("nsf"):
-                    attributes['fundingReferences'].append({
-                        'awardTitle': award['name'],
-                        'awardNumber': award['number'],
-                        "funderName": "National Science Foundation",
-                        })
+                attributes['fundingReferences'].append({
+                    'awardTitle': award['name'],
+                    'awardNumber': award['number'],
+                    "funderName": award.get("fundingSource", "N/A"),
+                    })
         attributes['types']['resourceType'] = "Experiment/{experiment_type}".format(
             experiment_type=self.experiment_type.title()
         )

--- a/designsafe/apps/projects/models/agave/hybrid_simulation.py
+++ b/designsafe/apps/projects/models/agave/hybrid_simulation.py
@@ -117,12 +117,11 @@ class HybridSimulation(RelatedEntity):
             )
             attributes['fundingReferences'] = []
             for award in awards:
-                if award.get("number", "").lower().startswith("nsf"):
-                    attributes['fundingReferences'].append({
-                        'awardTitle': award['name'],
-                        'awardNumber': award['number'],
-                        "funderName": "National Science Foundation",
-                        })
+                attributes['fundingReferences'].append({
+                    'awardTitle': award['name'],
+                    'awardNumber': award['number'],
+                    "funderName": award.get("fundingSource", "N/A"),
+                    })
         # related works are not required, so they can be missing...
         attributes['relatedIdentifiers'] = []
         for r_work in self.related_work:

--- a/designsafe/apps/projects/models/agave/rapid.py
+++ b/designsafe/apps/projects/models/agave/rapid.py
@@ -115,12 +115,11 @@ class Mission(RelatedEntity):
             )
             attributes['fundingReferences'] = []
             for award in awards:
-                if award.get("number", "").lower().startswith("nsf"):
-                    attributes['fundingReferences'].append({
-                        'awardTitle': award['name'],
-                        'awardNumber': award['number'],
-                        "funderName": "National Science Foundation",
-                        })
+                attributes['fundingReferences'].append({
+                    'awardTitle': award['name'],
+                    'awardNumber': award['number'],
+                    "funderName": award.get("fundingSource", "N/A"),
+                    })
         # related works are not required, so they can be missing...
         attributes['relatedIdentifiers'] = []
         for r_work in self.related_work:
@@ -305,12 +304,11 @@ class Report(RelatedEntity):
             )
             attributes['fundingReferences'] = []
             for award in awards:
-                if award.get("number", "").lower().startswith("nsf"):
-                    attributes['fundingReferences'].append({
-                        'awardTitle': award['name'],
-                        'awardNumber': award['number'],
-                        "funderName": "National Science Foundation",
-                        })
+                attributes['fundingReferences'].append({
+                    'awardTitle': award['name'],
+                    'awardNumber': award['number'],
+                    "funderName": award.get("fundingSource", "N/A"),
+                    })
         # related works are not required, so they can be missing...
         attributes['relatedIdentifiers'] = []
         for r_work in self.related_work:

--- a/designsafe/apps/projects/models/agave/simulation.py
+++ b/designsafe/apps/projects/models/agave/simulation.py
@@ -101,12 +101,11 @@ class Simulation(RelatedEntity):
             )
             attributes['fundingReferences'] = []
             for award in awards:
-                if award.get("number", "").lower().startswith("nsf"):
-                    attributes['fundingReferences'].append({
-                        'awardTitle': award['name'],
-                        'awardNumber': award['number'],
-                        "funderName": "National Science Foundation",
-                        })
+                attributes['fundingReferences'].append({
+                    'awardTitle': award['name'],
+                    'awardNumber': award['number'],
+                    "funderName": award.get("fundingSource", "N/A"),
+                    })
         # related works are not required, so they can be missing...
         attributes['relatedIdentifiers'] = []
         for r_work in self.related_work:

--- a/designsafe/static/scripts/projects/components/manage-project/manage-project.component.js
+++ b/designsafe/static/scripts/projects/components/manage-project/manage-project.component.js
@@ -218,7 +218,7 @@ class ManageProjectCtrl {
         }
         if (hasPrjType) {
             projectData.guestMembers = this.validInputs(this.form.guestMembers, ['fname', 'lname']);
-            projectData.awardNumber = this.validInputs(this.form.awardNumber, ['name', 'number']);
+            projectData.awardNumber = this.validInputs(this.form.awardNumber, ['name', 'number', 'fundingSource']);
             if (this.form.projectType === 'other') {
                 projectData.associatedProjects = this.validInputs(this.form.associatedProjects, ['title', 'href']);
                 projectData.referencedData = this.validInputs(this.form.referencedData, ['title', 'doi']);

--- a/designsafe/static/scripts/projects/components/manage-project/manage-project.template.html
+++ b/designsafe/static/scripts/projects/components/manage-project/manage-project.template.html
@@ -541,8 +541,9 @@
                 <div class="form-group">
                     <table class="manage-prj-table">
                         <colgroup>
-                            <col style="width: 60%">
-                            <col style="width: 38%">
+                            <col style="width: 40%">
+                            <col style="width: 30%">
+                            <col style="width: 28%">
                             <col style="width: 2%">
                         </colgroup>
                         <tr>
@@ -564,6 +565,9 @@
                             <td>
                                 Award Number
                             </td>
+                            <td>
+                                Funding Source
+                            </td>
                         </tr>
                         <tr ng-repeat="award in $ctrl.form.awardNumber track by $index">
                             <td class="manage-prj-td">
@@ -582,6 +586,16 @@
                                         id="award-number{{$index}}"
                                         name="award-number"
                                         ng-model="award.number"
+                                        ng-disabled="!$ctrl.ui.require.awardNumber"
+                                        ng-required="$ctrl.ui.require.awardNumber"
+                                        required>
+                            </td>
+                            <td class="manage-prj-td">
+                                <input  class="project-form-input"
+                                        type="text"
+                                        id="award-funder{{$index}}"
+                                        name="award-funder"
+                                        ng-model="award.fundingSource"
                                         ng-disabled="!$ctrl.ui.require.awardNumber"
                                         ng-required="$ctrl.ui.require.awardNumber"
                                         required>


### PR DESCRIPTION
## Overview: ##
Adds "funder name" as a field to the Awards section in the project management form, stored as `fundingSource`. This field is required for projects with award numbers. On publication it is used as the `funderName` in Datacite.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2639](https://tacc-main.atlassian.net/browse/DES-2639)

## Summary of Changes: ##

## Testing Steps: ##
1. Update a project with funding sources.
2. Call `to_datacite_json()` on that project and check that the funder name is piped through.

## UI Photos:

## Notes: ##
