### PR TITLE
bug/DES-2667: Fix missing params when no inputs present

### DIFF
--- a/designsafe/static/scripts/workspace/controllers/application-form.js
+++ b/designsafe/static/scripts/workspace/controllers/application-form.js
@@ -123,15 +123,17 @@ export default function ApplicationFormCtrl($scope, $rootScope, $localStorage, $
         let items = [];
         if ($scope.form.schema.properties.inputs) {
             items.push('inputs');
+        }
+        if ($scope.form.schema.properties.parameters) {
+            items.push('parameters');
+        }
+        if (items.length) {
             $scope.form.form.push({
                 type: 'fieldset',
                 readonly: readOnly,
                 title: 'Inputs',
                 items: items,
             });
-        }
-        if ($scope.form.schema.properties.parameters) {
-            items.push('parameters');
         }
 
         /* job details */


### PR DESCRIPTION
## Overview: ##
A conditional was preventing app parameters from rendering if no app inputs were defined

## PR Status: ##

* [X] Ready.
## Related Jira tickets: ##

* [DES-2667](https://tacc-main.atlassian.net/browse/DES-2667)

## Summary of Changes: ##

## Testing Steps: ##
1. Go to designsafe.dev/rw/workspace/#!/potree-viewer-0.2u5 and confirm the "Inputs" field is present
