### PR TITLE
bug/DES-2695: Community data shows the wrong files being selected

### DIFF
--- a/designsafe/static/scripts/data-depot/components/data-depot-browser/data-depot-browser.component.js
+++ b/designsafe/static/scripts/data-depot/components/data-depot-browser/data-depot-browser.component.js
@@ -60,11 +60,14 @@ class DataDepotBrowserCtrl {
         this.scheme = this.FileListingService.fileMgrMappings[this.apiParams.fileMgr].scheme;
         const system = this.$stateParams.systemId || 'external';
         const path = this.$stateParams.filePath
+        if (system === 'designsafe.storage.community') {
+            this.exclude = ['.Trash']
+        }
 
         this.offset = 0;
         this.limit = 15;
         const queryString = this.$stateParams.query_string;
-        this.FileListingService.browse({section: this.section, api: this.api, scheme: this.scheme, system, path, query_string: queryString});
+        this.FileListingService.browse({section: this.section, api: this.api, scheme: this.scheme, system, path, query_string: queryString, exclude: this.exclude});
     }
 
     onBrowse(file) {

--- a/designsafe/static/scripts/data-depot/components/data-depot-listing/files-listing.template.html
+++ b/designsafe/static/scripts/data-depot/components/data-depot-listing/files-listing.template.html
@@ -26,7 +26,7 @@
             </thead>
             <tbody>
                 <tr
-                    data-ng-repeat="item in $ctrl.listing.listing.filter($ctrl.filterTrash)"
+                    data-ng-repeat="item in $ctrl.listing.listing"
                     ng-class="{highlight: item.selected}"
                 >
                     <td class="unselectable">

--- a/designsafe/static/scripts/ng-designsafe/services/file-listing-service.spec.js
+++ b/designsafe/static/scripts/ng-designsafe/services/file-listing-service.spec.js
@@ -46,7 +46,7 @@ describe('FileListingService', function() {
 
             flush();
             // Fires callback after it emits.
-            expect(FileListingService.listingSuccessCallback).toHaveBeenCalledWith('main');
+            expect(FileListingService.listingSuccessCallback).toHaveBeenCalledWith('main', undefined);
         };
         testScheduler.run(observableTests); 
     });


### PR DESCRIPTION
## Overview: ##
Move filtering of `.Trash` out of the file listing component and into the file listing service, upstream of the point where the listing enters global state.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2695](https://tacc-main.atlassian.net/browse/DES-2695)

