### PR TITLE
task/DES-2696: Improve query string queries in Publications and fix endless spinners

### DIFF
--- a/designsafe/apps/api/publications/search_utils.py
+++ b/designsafe/apps/api/publications/search_utils.py
@@ -128,7 +128,7 @@ def author_query(author):
              {"path": "users",
                  "ignore_unmapped": True,
               "query": {
-                  "query_string": {"fields": ["users.first_name", "users.last_name", "users.username"], "query": author}
+                  "query_string": {"fields": ["users.first_name", "users.last_name", "users.username"], "query": author, "type": "cross_fields"}
               }
 
               }})
@@ -140,7 +140,7 @@ def author_query(author):
                            "authors.fname",
                            "authors.lname", ]
 
-    aq2 = Q('multi_match', query=author, fields=other_author_fields, operator="AND", type="cross_fields")
+    aq2 = Q('query_string', type="cross_fields", query=author, fields=other_author_fields)
 
     return aq1 | aq2
 
@@ -196,11 +196,19 @@ def description_query(description):
 def search_string_query(search_string):
     if not search_string:
         return None
-    q1 =  Q('query_string', query=f"\"{search_string}\"", fields=['project.value.description',
+    q1 =  Q('query_string', query=search_string, default_operator="AND", type="cross_fields", fields=['project.value.description',
                                                           'project.value.keywords',
                                                           'project.value.title',
                                                           'projectId',
                                                           'project.value.projectType',
-                                                          'project.value.dataType'])
+                                                          'project.value.dataType', "project.value.pi",
+                                                          "project.value.teamOrder.fname",
+                                                          "project.value.teamOrder.lname",
+                                                          "project.value.teamOrder.name",
+                                                          "authors.fname",
+                                                          "authors.lname",
+                                                          "authors.email",
+                                                          "authors.inst",
+                                                          "users"])
     q2 = Q({'term': {'projectId._exact': search_string}})
-    return q1 | q2 | author_query(search_string)
+    return q1 | q2


### PR DESCRIPTION
## Overview: ##
- Improve keyword searches in Publications by applying the `cross_fields` operator.
- Add error handling in Publications if a listing/search fails.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2696](https://tacc-main.atlassian.net/browse/DES-2696)
![image](https://github.com/DesignSafe-CI/portal/assets/12601812/802f5781-ce4d-4fbf-b1f4-f1ef29beb81d)
![image](https://github.com/DesignSafe-CI/portal/assets/12601812/fc809013-c695-407c-ba06-4a001b6ebc9f)
![image](https://github.com/DesignSafe-CI/portal/assets/12601812/432a6960-d5d6-4fe1-84c8-d142d1ef9559)




