### PR TITLE
Remove TAS calls from user profile; Remove notification setting page

### DIFF
--- a/designsafe/apps/accounts/forms.py
+++ b/designsafe/apps/accounts/forms.py
@@ -240,26 +240,11 @@ class UserProfileForm(forms.Form):
     """
     firstName = forms.CharField(label='First name')
     lastName = forms.CharField(label='Last name')
-    email = forms.EmailField()
-    phone = forms.CharField()
-    institutionId = forms.ChoiceField(
-        label='Institution', choices=(),
-        error_messages={'invalid': 'Please select your affiliated institution'})
-    title = forms.ChoiceField(label='Position/Title', choices=USER_PROFILE_TITLES)
-    countryId = forms.ChoiceField(
-        label='Country of residence', choices=(),
-        error_messages={'invalid': 'Please select your Country of residence'})
-    citizenshipId = forms.ChoiceField(
-        label='Country of citizenship', choices=(),
-        error_messages={'invalid': 'Please select your Country of citizenship'})
     ethnicity = forms.ChoiceField(label='Ethnicity', choices=ETHNICITY_OPTIONS)
     gender = forms.ChoiceField(label='Gender', choices=GENDER_OPTIONS)
 
     def __init__(self, *args, **kwargs):
         super(UserProfileForm, self).__init__(*args, **kwargs)
-        self.fields['institutionId'].choices = get_institution_choices()
-        self.fields['countryId'].choices = get_country_choices()
-        self.fields['citizenshipId'].choices = get_country_choices()
 
 
 class TasUserProfileAdminForm(forms.Form):

--- a/designsafe/apps/accounts/templates/designsafe/apps/accounts/profile.html
+++ b/designsafe/apps/accounts/templates/designsafe/apps/accounts/profile.html
@@ -17,17 +17,11 @@
                     <dt>Email address</dt>
                     <dd>{{profile.email}}</dd>
 
-                    <dt>Phone number</dt>
-                    <dd>{{profile.phone}}</dd>
-
                     <dt>Institution</dt>
                     <dd>{{profile.institution}}</dd>
 
                     <dt>Title</dt>
                     <dd>{{profile.title}}</dd>
-
-                    <dt>Country of residence</dt>
-                    <dd>{{profile.country}}</dd>
 
                     <dt>Country of citizenship</dt>
                     <dd>{{profile.citizenship}}</dd>

--- a/designsafe/apps/accounts/templates/designsafe/apps/accounts/profile_edit.html
+++ b/designsafe/apps/accounts/templates/designsafe/apps/accounts/profile_edit.html
@@ -7,10 +7,9 @@
   <div class="panel-body">
     <h2>Personal Profile</h2>
     <hr>
+    Update your personal profile using the <a href="https://accounts.tacc.utexas.edu/edit_profile" target="_blank">TACC Account Management portal</a>.
     <form method="post" action="">
       {% csrf_token %}
-      {% bootstrap_form form %}
-
       <h2>Professional Profile</h2>
       <hr>
       {% bootstrap_form pro_form %}

--- a/designsafe/apps/accounts/tests.py
+++ b/designsafe/apps/accounts/tests.py
@@ -143,10 +143,10 @@ class AccountsTests(TestCase):
         self.client.login(username='ds_admin', password='admin/password')
 
         data = {'firstName': 'DS',
-                'lastName': 'User', 'email': 'test@test.test',
+                'lastName': 'User',
                 'phone': '555-555-5555', 'institutionId': '1',
                 'title': 'Center Non-Researcher Staff',
-                'countryId': '1', 'citizenshipId': '1',
+                'countryId': '1',
                 'ethnicity': 'White', 'gender': 'Other',
                 'bio': 'NEW TEST BIO',
                 'website': 'NEW_WEBSITE', 'orcid_id': 'NEW_ORCID_ID', 'nh_interests': '13',
@@ -162,8 +162,3 @@ class AccountsTests(TestCase):
         assert 'NEW TEST BIO' in str(resp.content)
         assert 'NEW_WEBSITE' in str(resp.content)
         assert 'NEW_ORCID_ID' in str(resp.content)
-
-        data['email'] = 'error@test.test'
-        resp = self.client.post(edit_url, data)
-        resp = self.client.get(manage_url)
-        assert 'The submitted email already exists! Your email has not been updated!' in str(resp.content)

--- a/designsafe/apps/accounts/urls.py
+++ b/designsafe/apps/accounts/urls.py
@@ -11,7 +11,6 @@ urlpatterns = [
     url(r'^identities/$', views.manage_identities, name='manage_identities'),
     url(r'^licenses/$', views.manage_licenses, name='manage_licenses'),
     url(r'^applications/$', views.manage_applications, name='manage_applications'),
-    url(r'^notifications/settings/$', views.manage_notifications, name='manage_notifications'),
     url(r'^register/$', views.register, name='register'),
     url(r'^nees-account/(?:(?P<step>\d+)/)?$', views.nees_migration, name='nees_migration'),
     url(r'^password-reset/(?:(?P<code>.+)/)?$', views.password_reset, name='password_reset'),

--- a/designsafe/apps/accounts/views.py
+++ b/designsafe/apps/accounts/views.py
@@ -308,48 +308,34 @@ def profile_edit(request):
     pro_form = forms.ProfessionalProfileForm(request.POST or None, instance=ds_profile)
 
     if request.method == 'POST':
-        form = forms.UserProfileForm(request.POST, initial=tas_user)
-        if form.is_valid() and pro_form.is_valid():
-            existing_user = (tas.get_user(email=form.cleaned_data['email']))
-            if existing_user and (existing_user['email'] != tas_user['email']):
-                messages.error(request, 'The submitted email already exists! Your email has not been updated!')
-                return HttpResponseRedirect(reverse('designsafe_accounts:profile_edit'))
+        if pro_form.is_valid():
+
 
             pro_form.save()
 
-            data = form.cleaned_data
             pro_data = pro_form.cleaned_data
             # punt on PI Eligibility for now
-            data['piEligibility'] = tas_user['piEligibility']
 
             # retain original account source
-            data['source'] = tas_user['source']
-            saved_user = tas.save_user(tas_user['id'], data)
             messages.success(request, 'Your profile has been updated!')
 
             try:
                 ds_profile = user.profile
-                ds_profile.ethnicity = data['ethnicity']
-                ds_profile.gender = data['gender']
                 ds_profile.bio = pro_data['bio']
                 ds_profile.website = pro_data['website']
                 ds_profile.orcid_id = pro_data['orcid_id']
                 ds_profile.professional_level = pro_data['professional_level']
                 ds_profile.nh_interests_primary = pro_data['nh_interests_primary']
-                ds_profile.institution = saved_user.get('institution', None)
 
             except ObjectDoesNotExist as e:
                 logger.info('exception e: {} {}'.format(type(e), e ))
                 ds_profile = DesignSafeProfile(
                     user=user,
-                    ethnicity=data['ethnicity'],
-                    gender=data['gender'],
                     bio=pro_data['bio'],
                     website=pro_data['website'],
                     orcid_id=pro_data['orcid_id'],
                     professional_level=pro_data['professional_level'],
                     nh_interests_primary=pro_data['nh_interests_primary'],
-                    institution=saved_user.get('institution', None)
                     )
 
             ds_profile.update_required = False

--- a/designsafe/static/scripts/notifications/html/notification_list.html
+++ b/designsafe/static/scripts/notifications/html/notification_list.html
@@ -93,7 +93,5 @@
   <h2>No unread notifications.</h2>
   <p>
     You have no unread notifications.
-    <a href="/account/notifications/settings/">Click here</a>
-    to manage your notification settings.
   </p>
 </div>


### PR DESCRIPTION
## Overview: ##
- Let's continue to display Full Name, Email address, Institution, Title, Country of Citizenship and the Demographic Data. Pull these in from TAM but DO NOT allow edit profile.

- Do not display Phone number (no longer needed)

- Do not display Country of residence (since TAM is no longer collecting that either)

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2699](https://tacc-main.atlassian.net/browse/DES-2699)

## Summary of Changes: ##

## Testing Steps: ##
1. Attempt to update user profile (professional profile section) and make sure it still works.

## UI Photos:
<img width="1192" alt="image" src="https://github.com/DesignSafe-CI/portal/assets/12601812/7754be45-cdce-426d-972e-4c26636f6e99">


## Notes: ##
