### PR TITLE
Use Django to serve static files in debug mode

### DIFF
--- a/bin/run-django.sh
+++ b/bin/run-django.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # run django dev server as designsafe community account
-python -m debugpy --listen 0.0.0.0:5678 manage.py runserver --noasgi 0.0.0.0:8000
+python -m debugpy --listen 0.0.0.0:5678 manage.py runserver 0.0.0.0:8000

--- a/conf/docker/docker-compose-dev.all.debug.m1.yml
+++ b/conf/docker/docker-compose-dev.all.debug.m1.yml
@@ -73,10 +73,7 @@ services:
       - ../nginx/certificates/designsafe.dev.crt:/etc/ssl/designsafe.dev.crt
       - ../nginx/certificates/designsafe.dev.key:/etc/ssl/designsafe.dev.key
       - ../nginx/dhparam.pem:/etc/ssl/dhparam.pem
-      - ../../.:/srv/www/designsafe
       - ~/corral-repl/tacc/NHERI:/corral-repl/tacc/NHERI
-      - ../../static:/var/www/designsafe/static
-      - ../../media:/var/www/designsafe/media
     links:
       - django:django
     ports:

--- a/conf/docker/docker-compose-dev.all.debug.m1.yml
+++ b/conf/docker/docker-compose-dev.all.debug.m1.yml
@@ -74,6 +74,8 @@ services:
       - ../nginx/certificates/designsafe.dev.key:/etc/ssl/designsafe.dev.key
       - ../nginx/dhparam.pem:/etc/ssl/dhparam.pem
       - ~/corral-repl/tacc/NHERI:/corral-repl/tacc/NHERI
+      - ../../.:/srv/www/designsafe
+      - ../../data/media:/srv/www/designsafe/media
     links:
       - django:django
     ports:

--- a/conf/docker/docker-compose-dev.all.debug.m1.yml
+++ b/conf/docker/docker-compose-dev.all.debug.m1.yml
@@ -92,6 +92,7 @@ services:
       - elasticsearch:elasticsearch
     volumes:
       - ../../.:/srv/www/designsafe
+      - ../../data/media:/srv/www/designsafe/media
       - ~/corral-repl/tacc/NHERI:/corral-repl/tacc/NHERI
     ports:
       - 127.0.0.1:5678:5678
@@ -107,6 +108,7 @@ services:
     env_file: ../env_files/designsafe.env
     volumes:
       - ../../.:/srv/www/designsafe
+      - ../../data/media:/srv/www/designsafe/media
       - ~/corral-repl/tacc/NHERI:/corral-repl/tacc/NHERI
     container_name: des_websockets
     command: python manage.py runserver 0.0.0.0:9000
@@ -121,6 +123,7 @@ services:
       - elasticsearch:elasticsearch
     volumes:
       - ../../.:/srv/www/designsafe
+      - ../../data/media:/srv/www/designsafe/media
       - ~/corral-repl/tacc/NHERI:/corral-repl/tacc/NHERI
     dns:
       - 8.8.8.8

--- a/conf/docker/docker-compose-dev.all.debug.yml
+++ b/conf/docker/docker-compose-dev.all.debug.yml
@@ -70,8 +70,6 @@ services:
       - ../nginx/certificates/designsafe.dev.key:/etc/ssl/designsafe.dev.key
       - ../nginx/dhparam.pem:/etc/ssl/dhparam.pem
       - ~/corral-repl/tacc/NHERI:/corral-repl/tacc/NHERI
-      - ../../data/static:/var/www/designsafe/static
-      - ../../data/media:/var/www/designsafe/media
     links:
       - django:django
     ports:

--- a/conf/docker/docker-compose-dev.all.debug.yml
+++ b/conf/docker/docker-compose-dev.all.debug.yml
@@ -88,6 +88,7 @@ services:
       - elasticsearch:elasticsearch
     volumes:
       - ../../.:/srv/www/designsafe
+      - ../../data/media:/srv/www/designsafe/media
       - ~/corral-repl/tacc/NHERI:/corral-repl/tacc/NHERI
     ports:
       - 127.0.0.1:5678:5678
@@ -103,6 +104,7 @@ services:
     env_file: ../env_files/designsafe.env
     volumes:
       - ../../.:/srv/www/designsafe
+      - ../../data/media:/srv/www/designsafe/media
       - ~/corral-repl/tacc/NHERI:/corral-repl/tacc/NHERI
     container_name: des_websockets
     command: python manage.py runserver 0.0.0.0:9000
@@ -117,6 +119,7 @@ services:
       - elasticsearch:elasticsearch
     volumes:
       - ../../.:/srv/www/designsafe
+      - ../../data/media:/srv/www/designsafe/media
       - ~/corral-repl/tacc/NHERI:/corral-repl/tacc/NHERI
     dns:
       - 8.8.8.8

--- a/conf/docker/docker-compose-dev.all.debug.yml
+++ b/conf/docker/docker-compose-dev.all.debug.yml
@@ -70,6 +70,8 @@ services:
       - ../nginx/certificates/designsafe.dev.key:/etc/ssl/designsafe.dev.key
       - ../nginx/dhparam.pem:/etc/ssl/dhparam.pem
       - ~/corral-repl/tacc/NHERI:/corral-repl/tacc/NHERI
+      - ../../.:/srv/www/designsafe
+      - ../../data/media:/srv/www/designsafe/media
     links:
       - django:django
     ports:

--- a/conf/docker/docker-compose-dev.all.debug.yml
+++ b/conf/docker/docker-compose-dev.all.debug.yml
@@ -70,8 +70,8 @@ services:
       - ../nginx/certificates/designsafe.dev.key:/etc/ssl/designsafe.dev.key
       - ../nginx/dhparam.pem:/etc/ssl/dhparam.pem
       - ~/corral-repl/tacc/NHERI:/corral-repl/tacc/NHERI
-      - ../../static:/var/www/designsafe/static
-      - ../../media:/var/www/designsafe/media
+      - ../../data/static:/var/www/designsafe/static
+      - ../../data/media:/var/www/designsafe/media
     links:
       - django:django
     ports:

--- a/conf/nginx/nginx.debug.conf
+++ b/conf/nginx/nginx.debug.conf
@@ -75,9 +75,9 @@ http {
             alias /var/www/designsafe/media;
         }
 
-        location /static {
-            alias /var/www/designsafe/static;
-        }
+        #location /static {
+        #    alias /var/www/designsafe/static;
+        #}
 
         location / {
             proxy_pass http://portal_django;

--- a/conf/nginx/nginx.debug.conf
+++ b/conf/nginx/nginx.debug.conf
@@ -57,9 +57,21 @@ http {
         ssl_protocols               TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers                 "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
 
+        location /favicon.ico {
+            alias /srv/www/designsafe/designsafe/static/favicon.ico;
+        }
+
+        location /robots.txt {
+            alias /srv/www/designsafe/conf/nginx/robots.txt;
+        }
+
         location /internal-resource {
             internal;
             alias /corral-repl/tacc/NHERI/;
+        }
+
+        location /media {
+            alias /srv/www/designsafe/media;
         }
 
         location / {

--- a/conf/nginx/nginx.debug.conf
+++ b/conf/nginx/nginx.debug.conf
@@ -57,27 +57,10 @@ http {
         ssl_protocols               TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers                 "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
 
-
-        location /favicon.ico {
-            alias /var/www/designsafe/static/favicon.ico;
-        }
-
-        location /robots.txt {
-            alias /var/www/designsafe/robots.txt;
-        }
-
         location /internal-resource {
             internal;
             alias /corral-repl/tacc/NHERI/;
         }
-
-        location /media {
-            alias /var/www/designsafe/media;
-        }
-
-        #location /static {
-        #    alias /var/www/designsafe/static;
-        #}
 
         location / {
             proxy_pass http://portal_django;
@@ -85,7 +68,6 @@ http {
             proxy_set_header Host $host;
             proxy_redirect off;
         }
-
 
         location /ws {
             proxy_pass http://portal_ws;


### PR DESCRIPTION
## Overview: ##
Revert change to use nginx in local dev to serve static assets. Remove the `--noasgi` flag passed to runserver, which was interfering with static file serving.
