### PR TITLE
feat/DES-2725: app card styles

### DIFF
--- a/designsafe/static/styles/app-card.css
+++ b/designsafe/static/styles/app-card.css
@@ -77,7 +77,7 @@
     border: var(--border-width) solid #AFAFAF;
     box-shadow: 3px 2px 2px #00000029;
 }
-a.c-app-card:hover {
+.c-app-card:hover {
     outline: 2px solid #0000FF;
     outline-offset: calc( var(--border-width) * -1 );
     box-shadow: none;

--- a/designsafe/static/styles/app-card.css
+++ b/designsafe/static/styles/app-card.css
@@ -1,7 +1,7 @@
 /* STRUCTURE */
 
 /* To load most structure from Core-Styles */
-@import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@fix/DES-2724-app-card-type-mis-aligned/dist/components/c-app-card.css");
+@import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@v2.25.3/dist/components/c-app-card.css");
 
 /* To support equal-height columns in Bootstrap 3 */
 @import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@v2.25.3/dist/components/bootstrap.row.css");

--- a/designsafe/static/styles/app-card.css
+++ b/designsafe/static/styles/app-card.css
@@ -1,0 +1,109 @@
+/* STRUCTURE */
+
+/* To load most structure from Core-Styles */
+@import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@fix/DES-2724-app-card-type-mis-aligned/dist/components/c-app-card.css");
+
+/* To support equal-height columns in Bootstrap 3 */
+@import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@v2.25.3/dist/components/bootstrap.row.css");
+
+
+
+/* Bootstrap (Custom) */
+
+/* Add expected gap between rows of full-height columns */
+.has-row--col-stretch-content-y {
+    --bootstrap-gap: 30px; /* Bootstrap `.container` & `.row` */;
+}
+.has-row--col-stretch-content-y [class^="col-"] {
+    margin-bottom: var(--bootstrap-gap);
+}
+.has-row--col-stretch-content-y .row:last-child {
+    margin-bottom: calc( var(--bootstrap-gap) * -1 );
+}
+
+
+
+/* Card */
+/* To stretch card to fill column height */
+[class^="col-"] .c-app-card {
+    height: 100%;
+    min-height: 230px;
+}
+
+/* Title */
+.c-app-card__title {
+    margin-top: 0.5em;
+    margin-bottom: 0;
+}
+.c-app-card__title > .icon::before {
+    font-size: unset; /* to undo 5vw from ng-designsafe.css */
+}
+
+/* Description */
+.c-app-card__desc {
+    padding-inline: 1rem;
+    margin-block: 1.5rem;
+}
+
+/* Types */
+.c-app-card__types {
+    padding: 1em;
+}
+
+/* Flags */
+.c-app-card__flags > * {
+    --buffer--horz: 0.75em;
+    --buffer--vert: 0.50em;
+
+    padding-block: var(--buffer--vert);
+}
+.c-app-card__flags > *:not(:has(strong)) {
+    padding-inline: var(--buffer--horz);
+}
+.c-app-card__flags > *:has(strong) {
+    padding-inline: calc( var(--buffer--horz) * 2 );
+}
+
+
+
+
+
+/* SKIN */
+
+/* Card */
+.c-app-card {
+    --border-width: 1px;
+
+    border: var(--border-width) solid #AFAFAF;
+    box-shadow: 3px 2px 2px #00000029;
+}
+a.c-app-card:hover {
+    outline: 2px solid #0000FF;
+    outline-offset: calc( var(--border-width) * -1 );
+    box-shadow: none;
+}
+a.c-app-card:active {
+    outline-width: 1px;
+}
+
+/* Description */
+.c-app-card__desc {
+    line-height: 1.8;
+    font-size: 1.2rem;
+}
+
+/* Types */
+.c-app-card__types {
+    background-color: #F4F4F4;
+
+    font-weight: 500; /* a.k.a. "medium" */
+    font-size: 1.2rem;
+}
+
+/* Flags */
+.c-app-card__flags {
+    font-size: 1.2rem;
+}
+.c-app-card__flags > *:has(strong) {
+    background-color: #ECE4BF;
+}


### PR DESCRIPTION
## Overview: ##

Add styles for new `.app-card` UI pattern.

## PR Status: ##

* [x] Ready.
* Work in Progress.
* Hold.

## Related Jira tickets: ##

* [DES-2725](https://tacc-main.atlassian.net/browse/DES-2725)

## Summary of Changes: ##

- **added** `.app-card` stylesheet

## Testing Steps: ##

1. Open https://www.designsafe-ci.org/rw/tools-applications/tools-applications-new/?edit.
2. Verify app cards on page look similar to [design](https://xd.adobe.com/view/bab9a62d-3f2a-45f8-be0f-5680c474d9c1-efea/screen/bc798ccd-87fb-4a71-a01f-b9aceb3c914c/).
3. Verify UI changes upon hover and click on cards.

## UI Photos:

https://github.com/DesignSafe-CI/portal/assets/62723358/bec01b71-aca0-46f1-ac85-48b6f8cdfc8e

<img width="1024" alt="DES-2725" src="https://github.com/DesignSafe-CI/portal/assets/62723358/64f88964-8ec6-4d77-9444-1d95c9584ef5">

## Notes: ##

Uses structural CSS from Core-Styles, then adds DesignSafe-specific skin CSS.