### PR TITLE
feat: DES-2725 app page styles

### DIFF
--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -309,6 +309,7 @@ CMS_TEMPLATES = (
     ('cms_homepage.html', 'Homepage Navigation'),
     ('ef_cms_page.html', 'EF Site Page'),
     ('cms_page.html', 'Main Site Page'),
+    ('cms_page_for_app.html', 'Main Site App Page'),
     ('cms_page_no_footer.html', 'Footerless Page'),
 )
 CMSPLUGIN_CASCADE = {

--- a/designsafe/static/styles/app-card.css
+++ b/designsafe/static/styles/app-card.css
@@ -1,7 +1,7 @@
 /* STRUCTURE */
 
 /* To load most structure from Core-Styles */
-@import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@v2.25.3/dist/components/c-app-card.css");
+@import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@cbc98bb/dist/components/c-app-card.css");
 
 
 

--- a/designsafe/static/styles/app-card.css
+++ b/designsafe/static/styles/app-card.css
@@ -1,7 +1,7 @@
 /* STRUCTURE */
 
 /* To load most structure from Core-Styles */
-@import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@cbc98bb/dist/components/c-app-card.css");
+@import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@v2.26.0/dist/components/c-app-card.css");
 
 
 

--- a/designsafe/static/styles/app-page.css
+++ b/designsafe/static/styles/app-page.css
@@ -19,7 +19,6 @@
 }
 .o-site h2 {
     font-size: 2.0rem;
-    font-weight: 500; /* e.g. "medium", Core-Styles `var(--medium)` */
     text-transform: none;
 
     margin-bottom: 30px;

--- a/designsafe/static/styles/app-page.css
+++ b/designsafe/static/styles/app-page.css
@@ -1,4 +1,5 @@
 @import url("./app-card.css");
+@import url("./app-version-list.css");
 
 
 
@@ -26,47 +27,6 @@
     color: var(--accent);
 
     padding-bottom: 16px;
-    border-bottom: 2px solid var(--accent);
+    border-bottom: 2px solid var(--accent, #47a59d);
     margin-bottom: 30px;
-}
-
-
-
-/* PATTERNS */
-
-/* Version List */
-.s-version-list {
-    background-color: #F4F4F4;
-    padding: 20px;
-}
-.s-version-list > h2 {
-    color: inherit;
-    margin-top: unset;
-    padding-bottom: unset;
-    border-bottom: unset;
-}
-.s-version-list > * {
-    margin-block: 15px;
-    display: grid;
-    grid-template-areas:
-        "name button"
-        "description";
-}
-.s-version-list > *:not(:first-of-type) {
-    border-top: 1px solid #333333;
-}
-.s-version-list > * > h3 {
-    grid-template-name: "name";
-    font-size: 1.6rem;
-    font-weight: 500; /* e.g. "medium", Core-Styles `var(--medium)` */
-}
-.s-version-list > * > p:has(button) {
-    grid-template-name: "button";
-}
-.s-version-list > * > p {
-    grid-template-name: "description";
-}
-/* TODO: Consider making this a global change */
-.s-version-list .btn-success {
-    background-color: var(--accent);
 }

--- a/designsafe/static/styles/app-page.css
+++ b/designsafe/static/styles/app-page.css
@@ -1,7 +1,12 @@
 @import url("./app-card.css");
 @import url("./app-version-list.css");
 
-
+/* To make width of page content line up with width of header. */
+/* TODO: Verify whether this is safe to put into `main.css` */
+/* FAQ: The `main` makes selector win against `main.css` at bottom of page */
+main.o-site__body > .container-fluid {
+  margin: 0 50px;
+}
 
 /* SETTINGS */
 /* TODO: Consider making this a global setting */

--- a/designsafe/static/styles/app-page.css
+++ b/designsafe/static/styles/app-page.css
@@ -32,6 +32,6 @@
     margin-top: 40px; /* double Bootstrap h3 margin-top */
 }
 
-p:where(.o-site__body *):not(.s-version-list *) {
+p:where(.o-site__body *) {
     line-height: 1.8;
 }

--- a/designsafe/static/styles/app-page.css
+++ b/designsafe/static/styles/app-page.css
@@ -1,0 +1,72 @@
+@import url("./app-card.css");
+
+
+
+/* SETTINGS */
+/* TODO: Consider making this a global setting */
+:root {
+    --accent: #47a59d;
+}
+
+
+
+/* ELEMENTS */
+/* FAQ: Each selector is prefixed with an extra-specific selector,
+        because on DesignSafe website <head> is beneath <body>(?!) */
+.o-site h1 {
+    color: var(--accent);
+}
+.o-site h2 {
+    margin-top: 40px;
+
+    font-size: 2.0rem;
+    font-weight: 500; /* e.g. "medium", Core-Styles `var(--medium)` */
+
+    text-transform: none;
+    color: var(--accent);
+
+    padding-bottom: 16px;
+    border-bottom: 2px solid var(--accent);
+    margin-bottom: 30px;
+}
+
+
+
+/* PATTERNS */
+
+/* Version List */
+.s-version-list {
+    background-color: #F4F4F4;
+    padding: 20px;
+}
+.s-version-list > h2 {
+    color: inherit;
+    margin-top: unset;
+    padding-bottom: unset;
+    border-bottom: unset;
+}
+.s-version-list > * {
+    margin-block: 15px;
+    display: grid;
+    grid-template-areas:
+        "name button"
+        "description";
+}
+.s-version-list > *:not(:first-of-type) {
+    border-top: 1px solid #333333;
+}
+.s-version-list > * > h3 {
+    grid-template-name: "name";
+    font-size: 1.6rem;
+    font-weight: 500; /* e.g. "medium", Core-Styles `var(--medium)` */
+}
+.s-version-list > * > p:has(button) {
+    grid-template-name: "button";
+}
+.s-version-list > * > p {
+    grid-template-name: "description";
+}
+/* TODO: Consider making this a global change */
+.s-version-list .btn-success {
+    background-color: var(--accent);
+}

--- a/designsafe/static/styles/app-page.css
+++ b/designsafe/static/styles/app-page.css
@@ -15,18 +15,19 @@
 /* FAQ: Each selector is prefixed with an extra-specific selector,
         because on DesignSafe website <head> is beneath <body>(?!) */
 .o-site h1 {
-    color: var(--accent);
+    color: var(--accent, #47a59d);
 }
 .o-site h2 {
-    margin-top: 40px;
-
     font-size: 2.0rem;
     font-weight: 500; /* e.g. "medium", Core-Styles `var(--medium)` */
-
     text-transform: none;
-    color: var(--accent);
 
+    margin-bottom: 30px;
+}
+.o-site h2:not(.s-version-list *) {
+    color: var(--accent, #47a59d);
+
+    margin-top: 40px;
     padding-bottom: 16px;
     border-bottom: 2px solid var(--accent, #47a59d);
-    margin-bottom: 30px;
 }

--- a/designsafe/static/styles/app-page.css
+++ b/designsafe/static/styles/app-page.css
@@ -9,10 +9,8 @@
     --accent: #47a59d;
 }
 
-
-
 /* ELEMENTS */
-/* FAQ: Each selector is prefixed with an extra-specific selector,
+/* FAQ: Each selector includes `.o-site` to be extra-specific,
         because on DesignSafe website <head> is beneath <body>(?!) */
 .o-site h1 {
     color: var(--accent, #47a59d);
@@ -32,4 +30,8 @@
 }
 .o-site h3:not(.s-version-list *):not(.c-app-card__title) {
     margin-top: 40px; /* double Bootstrap h3 margin-top */
+}
+
+p:where(.o-site__body *):not(.s-version-list *) {
+    line-height: 1.8;
 }

--- a/designsafe/static/styles/app-page.css
+++ b/designsafe/static/styles/app-page.css
@@ -30,6 +30,6 @@
     padding-bottom: 16px;
     border-bottom: 2px solid var(--accent, #47a59d);
 }
-.o-site h3:not(.s-version-list *) {
+.o-site h3:not(.s-version-list *):not(.c-app-card__title) {
     margin-top: 40px; /* double Bootstrap h3 margin-top */
 }

--- a/designsafe/static/styles/app-page.css
+++ b/designsafe/static/styles/app-page.css
@@ -3,40 +3,30 @@
 
 /* To make width of page content line up with width of header. */
 /* TODO: Verify whether this is safe to put into `main.css` */
-/* FAQ: The `main` makes selector win against `main.css` at bottom of page */
-main.o-site__body > .container-fluid {
+.s-app-page > .container-fluid {
   margin: 0 50px;
 }
 
-/* SETTINGS */
-/* TODO: Consider making this a global setting */
-:root {
-    --accent: #47a59d;
+.s-app-page h1 {
+    color: var(--ds-accent-color, #47a59d);
 }
-
-/* ELEMENTS */
-/* FAQ: Each selector includes `.o-site` to be extra-specific,
-        because on DesignSafe website <head> is beneath <body>(?!) */
-.o-site h1 {
-    color: var(--accent, #47a59d);
-}
-.o-site h2 {
+.s-app-page h2 {
     font-size: 2.0rem;
     text-transform: none;
 
     margin-bottom: 30px;
 }
-.o-site h2:not(.s-version-list *) {
-    color: var(--accent, #47a59d);
+.s-app-page h2:not(.s-version-list *) {
+    color: var(--ds-accent-color, #47a59d);
 
     margin-top: 40px;
     padding-bottom: 16px;
-    border-bottom: 2px solid var(--accent, #47a59d);
+    border-bottom: 2px solid var(--ds-accent-color, #47a59d);
 }
-.o-site h3:not(.s-version-list *):not(.c-app-card__title) {
+.s-app-page h3:not(.s-version-list *):not(.c-app-card__title) {
     margin-top: 40px; /* double Bootstrap h3 margin-top */
 }
 
-p:where(.o-site__body *) {
+p:where(.s-app-page *) {
     line-height: 1.8;
 }

--- a/designsafe/static/styles/app-page.css
+++ b/designsafe/static/styles/app-page.css
@@ -30,3 +30,6 @@
     padding-bottom: 16px;
     border-bottom: 2px solid var(--accent, #47a59d);
 }
+.o-site h3:not(.s-version-list *) {
+    margin-top: 40px; /* double Bootstrap h3 margin-top */
+}

--- a/designsafe/static/styles/app-version-list.css
+++ b/designsafe/static/styles/app-version-list.css
@@ -12,8 +12,8 @@
     margin-block: 15px;
     display: grid;
     grid-template-areas:
-        "name button"
-        "description";
+        "name link"
+        "desc desc";
 }
 .s-version-list > *:not(:first-of-type) {
     border-top: 1px solid #333333;
@@ -23,11 +23,12 @@
     font-size: 1.6rem;
     font-weight: 500; /* e.g. "medium", Core-Styles `var(--medium)` */
 }
-.s-version-list > * > p:has(button) {
-    grid-template-name: "button";
+/* FAQ: CMS forces a button or link on its own line to be in a paragraph */
+.s-version-list > * > p:has(:is(a,button):only-child) {
+    grid-template-name: "link";
 }
 .s-version-list > * > p {
-    grid-template-name: "description";
+    grid-template-name: "desc";
 }
 /* TODO: Consider making this a global change */
 .s-version-list .btn-success {

--- a/designsafe/static/styles/app-version-list.css
+++ b/designsafe/static/styles/app-version-list.css
@@ -1,0 +1,35 @@
+.s-version-list {
+    background-color: #F4F4F4;
+    padding: 20px;
+}
+.s-version-list > h2 {
+    color: inherit;
+    margin-top: unset;
+    padding-bottom: unset;
+    border-bottom: unset;
+}
+.s-version-list > * {
+    margin-block: 15px;
+    display: grid;
+    grid-template-areas:
+        "name button"
+        "description";
+}
+.s-version-list > *:not(:first-of-type) {
+    border-top: 1px solid #333333;
+}
+.s-version-list > * > h3 {
+    grid-template-name: "name";
+    font-size: 1.6rem;
+    font-weight: 500; /* e.g. "medium", Core-Styles `var(--medium)` */
+}
+.s-version-list > * > p:has(button) {
+    grid-template-name: "button";
+}
+.s-version-list > * > p {
+    grid-template-name: "description";
+}
+/* TODO: Consider making this a global change */
+.s-version-list .btn-success {
+    background-color: var(--accent, #47a59d);
+}

--- a/designsafe/static/styles/app-version-list.css
+++ b/designsafe/static/styles/app-version-list.css
@@ -9,7 +9,7 @@
     border-bottom: unset;
 }
 .s-version-list > * {
-    margin-block: 15px;
+    padding-block: 15px;
     display: grid;
     grid-template-areas:
         "name link"
@@ -22,6 +22,7 @@
     grid-area: name;
     font-size: 1.6rem;
     font-weight: 500; /* e.g. "medium", Core-Styles `var(--medium)` */
+    margin-top: 0;
 }
 /* FAQ: CMS forces a button or link on its own line to be in a paragraph */
 .s-version-list > * > p:has(
@@ -29,6 +30,7 @@
     button:only-child
 ) {
     grid-area: link;
+    justify-self: end;
 }
 .s-version-list > * > p:not(:has(
     a:only-child,

--- a/designsafe/static/styles/app-version-list.css
+++ b/designsafe/static/styles/app-version-list.css
@@ -24,10 +24,10 @@
     font-weight: 500; /* e.g. "medium", Core-Styles `var(--medium)` */
 }
 /* FAQ: CMS forces a button or link on its own line to be in a paragraph */
-.s-version-list > * > p:has(:is(a,button):only-child) {
+.s-version-list > * > p:has(a:only-child,button:only-child) {
     grid-template-name: "link";
 }
-.s-version-list > * > p {
+.s-version-list > * > p:not(:has(a:only-child,button:only-child)) {
     grid-template-name: "desc";
 }
 /* TODO: Consider making this a global change */

--- a/designsafe/static/styles/app-version-list.css
+++ b/designsafe/static/styles/app-version-list.css
@@ -26,6 +26,10 @@
     font-size: 1.6rem;
     font-weight: 500; /* e.g. "medium", Core-Styles `var(--medium)` */
     margin-top: 0;
+
+    /* To center align text vertically (compared to button) */
+    display: grid;
+    align-content: center;
 }
 /* FAQ: CMS forces a button or link on its own line to be in a paragraph */
 .s-version-list > * > p:has(

--- a/designsafe/static/styles/app-version-list.css
+++ b/designsafe/static/styles/app-version-list.css
@@ -19,7 +19,7 @@
     border-top: 1px solid #333333;
 }
 .s-version-list > * > h3 {
-    grid-area: "name";
+    grid-area: name;
     font-size: 1.6rem;
     font-weight: 500; /* e.g. "medium", Core-Styles `var(--medium)` */
 }
@@ -28,11 +28,11 @@
     a:only-child,
     button:only-child
 ) {
-    grid-area: "link";
+    grid-area: link;
 }
 .s-version-list > * > p:not(:has(
     a:only-child,
     button:only-child
 )) {
-    grid-area: "desc";
+    grid-area: desc;
 }

--- a/designsafe/static/styles/app-version-list.css
+++ b/designsafe/static/styles/app-version-list.css
@@ -36,7 +36,3 @@
 )) {
     grid-area: "desc";
 }
-/* TODO: Consider making this a global change */
-.s-version-list .btn-success {
-    background-color: var(--accent, #47a59d);
-}

--- a/designsafe/static/styles/app-version-list.css
+++ b/designsafe/static/styles/app-version-list.css
@@ -8,12 +8,15 @@
     padding-bottom: unset;
     border-bottom: unset;
 }
-.s-version-list > * {
-    padding-block: 15px;
+.s-version-list > article {
+    padding-top: 30px;
     display: grid;
     grid-template-areas:
         "name link"
         "desc desc";
+}
+.s-version-list > article:not(:last-of-type) {
+    padding-bottom: 15px;
 }
 .s-version-list > *:not(:first-of-type) {
     border-top: 1px solid #333333;
@@ -37,4 +40,9 @@
     button:only-child
 )) {
     grid-area: desc;
+}
+
+/* Bootstrap */
+.s-version-list .btn {
+    padding-inline: 24px; /* double Bootstrap .btn padding */
 }

--- a/designsafe/static/styles/app-version-list.css
+++ b/designsafe/static/styles/app-version-list.css
@@ -19,16 +19,22 @@
     border-top: 1px solid #333333;
 }
 .s-version-list > * > h3 {
-    grid-template-name: "name";
+    grid-area: "name";
     font-size: 1.6rem;
     font-weight: 500; /* e.g. "medium", Core-Styles `var(--medium)` */
 }
 /* FAQ: CMS forces a button or link on its own line to be in a paragraph */
-.s-version-list > * > p:has(a:only-child,button:only-child) {
-    grid-template-name: "link";
+.s-version-list > * > p:has(
+    a:only-child,
+    button:only-child
+) {
+    grid-area: "link";
 }
-.s-version-list > * > p:not(:has(a:only-child,button:only-child)) {
-    grid-template-name: "desc";
+.s-version-list > * > p:not(:has(
+    a:only-child,
+    button:only-child
+)) {
+    grid-area: "desc";
 }
 /* TODO: Consider making this a global change */
 .s-version-list .btn-success {

--- a/designsafe/static/styles/main.css
+++ b/designsafe/static/styles/main.css
@@ -946,7 +946,7 @@ li .popover.right {
 }
 
 .o-site__body > .container-fluid {
-  margin: 0 30px;
+  margin: 0 50px;
 }
 
 .o-site__footer {

--- a/designsafe/static/styles/main.css
+++ b/designsafe/static/styles/main.css
@@ -943,6 +943,8 @@ li .popover.right {
   flex-grow: 1;
   flex-shrink: 0;
   flex-basis: auto;
+
+  line-height: 1.8;
 }
 
 .o-site__body > .container-fluid {

--- a/designsafe/static/styles/main.css
+++ b/designsafe/static/styles/main.css
@@ -943,8 +943,6 @@ li .popover.right {
   flex-grow: 1;
   flex-shrink: 0;
   flex-basis: auto;
-
-  line-height: 1.8;
 }
 
 .o-site__body > .container-fluid {

--- a/designsafe/static/styles/main.css
+++ b/designsafe/static/styles/main.css
@@ -946,7 +946,7 @@ li .popover.right {
 }
 
 .o-site__body > .container-fluid {
-  margin: 0 50px;
+  margin: 0 30px;
 }
 
 .o-site__footer {

--- a/designsafe/static/styles/main.css
+++ b/designsafe/static/styles/main.css
@@ -1,3 +1,7 @@
+:root {
+  --ds-accent-color: #47a59d;
+}
+
 body, html {
   background-color: #ffffff;
 }

--- a/designsafe/templates/base.j2
+++ b/designsafe/templates/base.j2
@@ -68,7 +68,7 @@
       <meta name="DC.type" content="dataset">
       {% endblock %}
   </head>
-  <body ng-app="designsafe.portal" class="o-site">
+  <body ng-app="designsafe.portal" class="o-site {% block page_class %}{% endblock page_class %}">
     {% cms_toolbar %}
     <div>
         {% include 'includes/header.html' %}

--- a/designsafe/templates/cms_page_for_app.html
+++ b/designsafe/templates/cms_page_for_app.html
@@ -1,0 +1,6 @@
+{% extends "cms_page.html" %}
+{% load cms_tags static %}
+{% block page_class %}s-app-page{% endblock page_class %}
+{% addtoblock "css" %}
+<link href="{% static 'styles/app-page.css' %}" rel="stylesheet" />
+{% endaddtoblock %}


### PR DESCRIPTION
## Overview: ##

Add stylesheet for app page.

> [!IMPORTANT]
> After deploy:
> 1. Update these pages to use new template "Main Site App Page":
>     - https://www.designsafe-ci.org/rw/tools-applications/tools-applications-new/
>     - https://www.designsafe-ci.org/rw/tools-applications/adcirc/
> 2. Merge `main` into `feat/Tapis-v3-redesign`.
> 3. Sync **prod** server pages to **next** server.
> 4. Update "Version List" and "Related Applications" to use plugin.
> 5. Edit "Version List" as necessary.

## PR Status: ##

* [x] Ready.

## Related Jira tickets: ##

* [DES-2725](https://tacc-main.atlassian.net/browse/DES-2725)
* refactored by #1199.

## Summary of Changes: ##

* **added** a stylesheet `app-page.css`
* **added** a stylesheet `app-version-list.css`

## Testing Steps: ##

1. Open https://www.designsafe-ci.org/rw/tools-applications/adcirc/.
2. Verify styles are loaded from `app-page.css`.
3. Verify page looks like [design](https://xd.adobe.com/view/bab9a62d-3f2a-45f8-be0f-5680c474d9c1-efea/screen/eaaed901-7a1c-43e7-9563-6d22b2fac6e3/specs/).

## UI Photos: ##

| wide | medium | narrow |
| -| - | - |
| ![des-2725 wide](https://github.com/DesignSafe-CI/portal/assets/62723358/8f6072ff-0194-427f-8dfc-45bf4ee98cdb) | ![des-2725 medium](https://github.com/DesignSafe-CI/portal/assets/62723358/992851f1-4755-4b9d-9f47-8fd03d17758e) | ![des-2725 narrow](https://github.com/DesignSafe-CI/portal/assets/62723358/d638ef1a-1849-4d6b-aead-882080f8196c)

## Notes: ##

> [!NOTE]
> This is not from Core-Styles, so I am willing to forgo the [BEMIT prefix](https://csswizardry.com/2015/08/bemit-taking-the-bem-naming-convention-a-step-further/) (`s-`). Just ask.