### PR TITLE
feat: DES-2725 app page styles - via template

### DIFF
--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -309,6 +309,7 @@ CMS_TEMPLATES = (
     ('cms_homepage.html', 'Homepage Navigation'),
     ('ef_cms_page.html', 'EF Site Page'),
     ('cms_page.html', 'Main Site Page'),
+    ('cms_page_for_app.html', 'Main Site App Page'),
     ('cms_page_no_footer.html', 'Footerless Page'),
 )
 CMSPLUGIN_CASCADE = {

--- a/designsafe/static/styles/app-card.css
+++ b/designsafe/static/styles/app-card.css
@@ -1,7 +1,7 @@
 /* STRUCTURE */
 
 /* To load most structure from Core-Styles */
-@import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@v2.25.3/dist/components/c-app-card.css");
+@import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@cbc98bb/dist/components/c-app-card.css");
 
 
 

--- a/designsafe/static/styles/app-page.css
+++ b/designsafe/static/styles/app-page.css
@@ -3,7 +3,7 @@
 
 /* To make width of page content line up with width of header. */
 /* TODO: Verify whether this is safe to put into `main.css` */
-.s-app-page .o-site__body > .container-fluid {
+.s-app-page > .container-fluid {
   margin: 0 50px;
 }
 

--- a/designsafe/static/styles/app-page.css
+++ b/designsafe/static/styles/app-page.css
@@ -1,33 +1,20 @@
 @import url("./app-card.css");
 @import url("./app-version-list.css");
 
-
-
-/* SETTINGS */
-/* TODO: Consider making this a global setting */
-:root {
-    --accent: #47a59d;
+.s-app-page h1 {
+    color: var(--ds-accent-color, #47a59d);
 }
-
-
-
-/* ELEMENTS */
-/* FAQ: Each selector is prefixed with an extra-specific selector,
-        because on DesignSafe website <head> is beneath <body>(?!) */
-.o-site h1 {
-    color: var(--accent, #47a59d);
-}
-.o-site h2 {
+.s-app-page h2 {
     font-size: 2.0rem;
     font-weight: 500; /* e.g. "medium", Core-Styles `var(--medium)` */
     text-transform: none;
 
     margin-bottom: 30px;
 }
-.o-site h2:not(.s-version-list *) {
-    color: var(--accent, #47a59d);
+.s-app-page h2:not(.s-version-list *) {
+    color: var(--ds-accent-color, #47a59d);
 
     margin-top: 40px;
     padding-bottom: 16px;
-    border-bottom: 2px solid var(--accent, #47a59d);
+    border-bottom: 2px solid var(--ds-accent-color, #47a59d);
 }

--- a/designsafe/static/styles/main.css
+++ b/designsafe/static/styles/main.css
@@ -1,3 +1,7 @@
+:root {
+  --ds-accent-color: #47a59d;
+}
+
 body, html {
   background-color: #ffffff;
 }

--- a/designsafe/templates/base.j2
+++ b/designsafe/templates/base.j2
@@ -68,7 +68,7 @@
       <meta name="DC.type" content="dataset">
       {% endblock %}
   </head>
-  <body ng-app="designsafe.portal" class="o-site {% block page_type_class %}{% endblock page_type_class %}">
+  <body ng-app="designsafe.portal" class="o-site {% block page_class %}{% endblock page_class %}">
     {% cms_toolbar %}
     <div>
         {% include 'includes/header.html' %}

--- a/designsafe/templates/base.j2
+++ b/designsafe/templates/base.j2
@@ -68,7 +68,7 @@
       <meta name="DC.type" content="dataset">
       {% endblock %}
   </head>
-  <body ng-app="designsafe.portal" class="o-site">
+  <body ng-app="designsafe.portal" class="o-site {% block page_type_class %}{% endblock page_type_class %}">
     {% cms_toolbar %}
     <div>
         {% include 'includes/header.html' %}

--- a/designsafe/templates/cms_page_for_app.html
+++ b/designsafe/templates/cms_page_for_app.html
@@ -1,0 +1,6 @@
+{% extends "cms_page.html" %}
+{% load cms_tags static %}
+{% block page_type_class %}s-app-page{% endblock page_type_class %}
+{% addtoblock "css" %}
+<link href="{% static 'styles/app-page.css' %}" rel="stylesheet" />
+{% endaddtoblock %}

--- a/designsafe/templates/cms_page_for_app.html
+++ b/designsafe/templates/cms_page_for_app.html
@@ -1,6 +1,6 @@
 {% extends "cms_page.html" %}
 {% load cms_tags static %}
-{% block page_type_class %}s-app-page{% endblock page_type_class %}
+{% block page_class %}s-app-page{% endblock page_class %}
 {% addtoblock "css" %}
 <link href="{% static 'styles/app-page.css' %}" rel="stylesheet" />
 {% endaddtoblock %}


### PR DESCRIPTION
## Overview: ##

Perform #1198 with a Page Template.

## PR Status: ##

* [x] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2725](https://tacc-main.atlassian.net/browse/DES-2725)
* refactors #1198

## Summary of Changes: ##

Atop #1198:
- **added** new CMS page template
- **changed** app page styles to require class
- **added** first global CSS variable (`--ds-accent-color`)
- **added** custom class feature to `<body>`

## Testing Steps: ##
1. Open https://www.designsafe-ci.org/rw/tools-applications/adcirc/.
2. Change page template to "Main Site App Page".
3. Remove snippet from page.
4. Verify page still looks like it does in #1198.

## UI Photos:

> [!WARNING]
> I do not know how to test DesignSafe changes.

Should look just like #1198.

## Notes: ##

This is an alternative to #1198, that introduces new features to DesignSafe. Using #1198 alone is acceptable.