### PR TITLE
Use wsgi instead of asgi for local django container

### DIFF
--- a/conf/docker/docker-compose-dev.all.debug.yml
+++ b/conf/docker/docker-compose-dev.all.debug.yml
@@ -91,7 +91,7 @@ services:
     dns:
       - 8.8.8.8
       - 8.8.4.4
-    command: python manage.py runserver 0.0.0.0:8000
+    command: python manage.py runserver --noasgi 0.0.0.0:8000
     container_name: des_django
     hostname: des_django
 

--- a/designsafe/urls.py
+++ b/designsafe/urls.py
@@ -25,6 +25,7 @@ Examples:
 from django.conf import settings
 from django.urls import include, re_path as url
 from django.conf.urls.static import static
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.contrib import admin
 from django.views.generic import RedirectView, TemplateView
 from django.urls import reverse, path
@@ -171,4 +172,8 @@ urlpatterns = [
     url(r'^', include('cms.urls')),
 ]
 if settings.DEBUG:
-    urlpatterns + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    # https://docs.djangoproject.com/en/4.2/howto/static-files/#serving-files-uploaded-by-a-user-during-development
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+    # https://docs.djangoproject.com/en/4.2/ref/contrib/staticfiles/#static-file-development-view
+    urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
## Overview: ##

- Sets the `--noasgi` flag on the daphne `runserver` command to bypass the asgi server in favor of the wsgi server for the `django` container.
https://github.com/django/daphne/blob/63790936d1f5728ff358ff9c5d519454c36f4e33/daphne/management/commands/runserver.py#L47

- Adds `staticfiles_urlpatterns()` to `urlpatterns` if `DEBUG` is `True`, to allow wsgi to serve staticfile assets locally without the need to `collectstatic` every time.

Note: This was implemented to resolve an issue we're seeing in local dev with the asgi `des_django` server crashing intermittently, e.g.:
```
des_django         | Application instance <Task pending name='Task-28' coro=<ASGIStaticFilesHandler.__call__() running at /opt/pysetup/.venv/lib/python3.11/site-packages/django/contrib/staticfiles/handlers.py:101> wait_for=<Future pending cb=[shield.<locals>._outer_done_callback() at /usr/local/lib/python3.11/asyncio/tasks.py:898, Task.task_wakeup()]>> for connection <WebRequest at 0xffff6e13cd90 method=GET uri=/api/workspace/tray/ clientproto=HTTP/1.0> took too long to shut down and was killed.
```

## PR Status: ##

* [X] Ready.

## Testing Steps: ##
1. `make stop` then `make start`
2. Load up https://designsafe.dev/data/browser and do a hard refresh.
3. Confirm static assets load correctly
4. Change something related to static assets on the backend, like a template, and confirm you can see changes without needing to collectstatic again
