### PR TITLE
feat: Tapis v3 Redesign - fix: des-2730 adjust app page styles

### DIFF
--- a/designsafe/static/styles/app-card.css
+++ b/designsafe/static/styles/app-card.css
@@ -14,7 +14,7 @@
 
 /* Title */
 .c-app-card__title {
-    margin-top: 0.5em;
+    margin-top: 1em;
     margin-bottom: 0;
 }
 .c-app-card__title > .icon::before {
@@ -23,7 +23,7 @@
 
 /* Description */
 .c-app-card__desc {
-    padding-inline: 1rem;
+    padding-inline: 1.5rem;
     margin-block: 1.5rem;
 }
 

--- a/designsafe/static/styles/app-card.css
+++ b/designsafe/static/styles/app-card.css
@@ -89,3 +89,7 @@ a.c-app-card:active {
 .c-app-card__flags > *:has(strong) {
     background-color: #ECE4BF;
 }
+
+.c-app-card__repo {
+    font-style: italic;
+}

--- a/designsafe/static/styles/app-page.css
+++ b/designsafe/static/styles/app-page.css
@@ -11,7 +11,8 @@
     color: var(--ds-accent-color, #47a59d);
 }
 .s-app-page h2 {
-    font-size: 2.0rem;
+    font-size: 2.5rem;
+    font-weight: 500; /* e.g. "medium" */
     text-transform: none;
 
     margin-bottom: 30px;
@@ -24,6 +25,7 @@
     border-bottom: 2px solid var(--ds-accent-color, #47a59d);
 }
 .s-app-page h3:not(.s-version-list *):not(.c-app-card__title) {
+    font-size: 1.8rem;
     margin-top: 40px; /* double Bootstrap h3 margin-top */
 }
 

--- a/designsafe/static/styles/app-version-list.css
+++ b/designsafe/static/styles/app-version-list.css
@@ -1,27 +1,38 @@
+/* FAQ: Relies on markup, so CMS can replicate the design */
+
+/* Container */
 .s-version-list {
     background-color: #F4F4F4;
     padding: 20px;
 }
+
+/* List Title */
 .s-version-list > h2 {
     color: inherit;
     margin-top: unset;
     padding-bottom: unset;
     border-bottom: unset;
 }
+
+/* Version Content Layout */
 .s-version-list > article {
     display: grid;
     grid-template-areas:
         "name link"
         "desc desc";
 }
+
+/* Space & Lines Between Versions */
 .s-version-list > article:not(:last-of-type) {
     padding-bottom: 15px;
 }
-.s-version-list > *:not(:first-of-type) {
+.s-version-list > article:not(:first-of-type) {
     padding-top: 30px;
     border-top: 1px solid #333333;
 }
-.s-version-list > * > h3 {
+
+/* Version Label */
+.s-version-list > article > h3 {
     grid-area: name;
     font-size: 1.6rem;
     font-weight: 500; /* e.g. "medium", Core-Styles `var(--medium)` */
@@ -31,18 +42,19 @@
     display: grid;
     align-content: center;
 }
+
+/* Version Link */
+.s-version-list > article > a,
+/* To support manual content via CMS */
 /* FAQ: CMS forces a button or link on its own line to be in a paragraph */
-.s-version-list > * > p:has(
-    a:only-child,
-    button:only-child
-) {
+.s-version-list > * > p:has(a:only-child) {
     grid-area: link;
     justify-self: end;
 }
-.s-version-list > * > p:not(:has(
-    a:only-child,
-    button:only-child
-)) {
+.s-version-list > * > p:not(:has(a:only-child)),
+/* To support manual content via CMS */
+/* FAQ: CMS forces a button or link on its own line to be in a paragraph */
+.s-version-list > * > p:not(:has(a:only-child)) {
     grid-area: desc;
 }
 

--- a/designsafe/static/styles/app-version-list.css
+++ b/designsafe/static/styles/app-version-list.css
@@ -9,7 +9,6 @@
     border-bottom: unset;
 }
 .s-version-list > article {
-    padding-top: 30px;
     display: grid;
     grid-template-areas:
         "name link"
@@ -19,6 +18,7 @@
     padding-bottom: 15px;
 }
 .s-version-list > *:not(:first-of-type) {
+    padding-top: 30px;
     border-top: 1px solid #333333;
 }
 .s-version-list > * > h3 {

--- a/designsafe/templates/base.j2
+++ b/designsafe/templates/base.j2
@@ -35,7 +35,6 @@
       <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css %>">
       <link href="{% static 'vendor/angular-material/angular-material.css' %}" rel="stylesheet">
       <link href="{% static 'styles/ng-designsafe.css' %}" rel="stylesheet">
-      <link href="{% static 'styles/app-card.css' %}" rel="stylesheet" type="text/css">
       {% block styles %}{% endblock %}
       {% render_block "css" %}
       {% render_block "react_assets" %}


### PR DESCRIPTION
## Overview: ##

Adjust styles of app-page content.

## PR Status: ##

> [!IMPORTANT]
> Recreated off of `main` branch via https://github.com/DesignSafe-CI/portal/pull/1206.

## Related: ##

* [DES-2730](https://tacc-main.atlassian.net/browse/DES-2730)
* pairs with https://github.com/DesignSafe-CI/portal/pull/1204

## Summary of Changes: ##

See [commit summaries](https://github.com/DesignSafe-CI/portal/pull/1203/commits).

## Testing Steps: ##

If deployed:

1. Open test pages:
    - https://www.designsafe-ci.org/rw/tools-applications/tools-applications-new/
    - https://www.designsafe-ci.org/rw/tools-applications/adcirc/
2. Verify the match reference pages:
    - https://www.designsafe-ci.org/rw/tools-applications/tools-applications-new-backup/
    - https://www.designsafe-ci.org/rw/tools-applications/adcirc-backup/

## UI Photos: ##

Skipped. See pages after deploy.