### PR TITLE
fix: DES-2735 app page template crash

### DIFF
--- a/designsafe/templates/cms_page_for_app.html
+++ b/designsafe/templates/cms_page_for_app.html
@@ -1,5 +1,5 @@
 {% extends "cms_page.html" %}
-{% load cms_tags static %}
+{% load cms_tags static sekizai_tags %}
 {% block page_class %}s-app-page{% endblock page_class %}
 {% addtoblock "css" %}
 <link href="{% static 'styles/app-page.css' %}" rel="stylesheet" />


### PR DESCRIPTION
## Overview: ##

Fix "Main Site App Page" template causing page error. (The `addtoblock` tag requires `sekizai_tags`.)

## PR Status: ##

* [X] Ready.

## Related: ##

* [DES-2735](https://tacc-main.atlassian.net/browse/DES-2735)
* fixes https://github.com/DesignSafe-CI/portal/pull/1199

## Summary of Changes: ##

- **added** load of missing tags for template

## Testing Steps: ##
1. Open a page.
2. Change page template to “Main Site App Page”.
3. Page `<body>` is given a class `s-app-page`.

## UI Photos: ##

<img width="900" alt="DES-2735" src="https://github.com/DesignSafe-CI/portal/assets/62723358/2e83b168-a066-46a5-8c58-620481c2831a">