### PR TITLE
fix: des-2735 app page not loading app page css

### DIFF
--- a/designsafe/templates/cms_page_for_app.html
+++ b/designsafe/templates/cms_page_for_app.html
@@ -1,6 +1,9 @@
 {% extends "cms_page.html" %}
 {% load cms_tags static sekizai_tags %}
 {% block page_class %}s-app-page{% endblock page_class %}
-{% addtoblock "css" %}
-<link href="{% static 'styles/app-page.css' %}" rel="stylesheet" />
-{% endaddtoblock %}
+
+{% block styles %}
+    {% addtoblock "css" %}
+    <link href="{% static 'styles/app-page.css' %}" rel="stylesheet" />
+    {% endaddtoblock %}
+{% endblock %}


### PR DESCRIPTION
## Overview: ##

App Page template was not loading app page styles (because `addtoblock` must be used within a `block`).

## PR Status: ##

* [X] Ready.
* Work in Progress.
* Hold.

## Related Jira tickets: ##

* [DES-2735](https://tacc-main.atlassian.net/browse/DES-2735)

## Summary of Changes: ##

- **added** `block` around `addtoblock` that loads stylesheet

## Testing Steps: ##

1. Create/Open a page.
2. Change page template to “Main Site App Page”.
3. Page `<head>` loads stylesheet `app-page.css`.

## UI Photos: ##

<img width="535" alt="des-2735" src="https://github.com/DesignSafe-CI/portal/assets/62723358/8b99c6ee-c0a5-4974-85c8-00d7434059ed">