### PR TITLE
fix: des-2738 do not show empty releated apps list

### DIFF
--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/related_apps_plugin.html
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/related_apps_plugin.html
@@ -1,6 +1,10 @@
+{% if listing|length > 0 %}
 <h2>Related Applications</h2>
 <section class="o-app-grid">
     {% for app in listing %}
     {% include "designsafe/apps/workspace/app_card.html" with app=app %}
     {% endfor %}
 </section>
+{% else %}
+<!-- No related apps -->
+{% endif %}


### PR DESCRIPTION
## Overview: ##

Do not show list if "Related Applications" listing is empty.

## PR Status: ##

* [X] Ready.
* Work in Progress.
* Hold.

## Related Jira tickets: ##

* [DES-2738](https://tacc-main.atlassian.net/browse/DES-2738)

## Summary of Changes: ##

- **added** if/then around app listing render

## Testing Steps: ##

1. Create/Have an app with no related apps.
2. Create/Have an app with some related apps.
3. Add "Related Apps" listing onto page for each.
4. Verify the former renders **not** title nor list.
5. Verify the latter **does** render title and list.

## UI Photos:

| no related apps | has related apps |
| - | - |
| <img width="1440" alt="DES-2738 no related apps" src="https://github.com/DesignSafe-CI/portal/assets/62723358/14377f72-0914-4dc1-9995-43a9844ae38c"> | <img width="1440" alt="DES-2738 has related app" src="https://github.com/DesignSafe-CI/portal/assets/62723358/c96e0d2a-3ad7-4c51-a14c-9c13f4ccf38a"> |