### PR TITLE
fix: app card design bugs DES-2741 through DES-2745

### DIFF
--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_card.html
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_card.html
@@ -3,11 +3,15 @@
 
     <p class="c-app-card__desc">{{app.description}}</p>
 
+    {% if app.tags|length > 0 %}
     <ul class="c-app-card__types">
         {% for tag in app.tags %}
         <li>{{tag}}</li>
         {% endfor %}
     </ul>
+    {% else %}
+    <!-- No tags -->
+    {% endif %}
 
     <ul class="c-app-card__flags">
         {% if app.is_popular %}

--- a/designsafe/static/styles/DesignSafe-Icons.css
+++ b/designsafe/static/styles/DesignSafe-Icons.css
@@ -1,125 +1,30 @@
-@font-face {
-    font-family: 'DesignSafe-Icons';
-    src: url('/static/fonts/DesignSafe-Icons.eot?nvbv6c');
-    src: url('/static/fonts/DesignSafe-Icons.eot?nvbv6c#iefix') format('embedded-opentype'),
-        url('/static/fonts/DesignSafe-Icons.ttf?nvbv6c') format('truetype'),
-        url('/static/fonts/DesignSafe-Icons.woff2') format('woff2'),
-        url('/static/fonts/DesignSafe-Icons.woff?nvbv6c') format('woff'),
-        url('/static/fonts/DesignSafe-Icons.svg?nvbv6c#DesignSafe-Icons') format('svg');
-    font-weight: normal;
-    font-style: normal;
-    font-display: block;
-}
+@import url('./DesignSafe-Icons.font.css');
 
-[class^='ds-icon-'],
-[class*=' ds-icon-'] {
-    /* use !important to prevent issues with browser extensions that change fonts */
-    font-family: 'DesignSafe-Icons' !important;
-    speak: never;
-    font-style: normal;
-    font-weight: normal;
-    font-variant: normal;
-    text-transform: none;
-    line-height: 1;
+/* TODO: Consider isolating and importing main.css & main-ef.css .ds-icon's */
 
-    /* Better Font Rendering =========== */
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+/* To globally adjust sizes of specific font icons */
+.ds-icon-All-Hazards::before,
+.ds-icon-Earth::before,
+.ds-icon-Water::before,
+.ds-icon-Wind::before,
+.ds-icon-OpenSees::before {
+    display: block;
 }
-
-.ds-icon-Contract:before {
-    content: '\e91d';
+.ds-icon-All-Hazards::before,
+.ds-icon-Earth::before,
+.ds-icon-Water::before,
+.ds-icon-Wind::before {
+    font-size: 1.2em;
+    /* To restore alignment after font-size changes it */
+    margin-top: -0.15em; /* FAQ: -0.2em did not re-align it perfectly */
 }
-.ds-icon-Expand:before {
-    content: '\e923';
+.ds-icon-OpenSees::before {
+    font-size: 1.5em;
+    /* To restore alignment after font-size changes it */
+    margin-top: -0.3em; /* FAQ: -0.2em did not re-align it perfectly */
 }
-.ds-icon-Job-Status:before {
-    content: '\e929';
-}
-.ds-icon-All-Hazards:before {
-    content: '\e908';
-}
-.ds-icon-New-Tab:before {
-    content: '\ea7e';
-}
-.ds-icon-NGL-without-text:before {
-    content: '\e903';
-}
-.ds-icon-Potree:before {
-    content: '\e906';
-}
-.ds-icon-Generic-Vis:before {
-    content: '\e907';
-}
-.ds-icon-HVSR:before {
-    content: '\e90d';
-}
-.ds-icon-MPM:before {
-    content: '\e90e';
-}
-.ds-icon-Generic-App:before {
-    content: '\e960';
-}
-.ds-icon-GiD:before {
-    content: '\e90f';
-}
-.ds-icon-Earth:before {
-    content: '\e910';
-}
-.ds-icon-Water:before {
-    content: '\e912';
-}
-.ds-icon-Wind:before {
-    content: '\e915';
-}
-.ds-icon-rWHALE:before {
-    content: '\e905';
-}
-.ds-icon-Extract:before {
-    content: '\e959';
-}
-.ds-icon-Hazmapper:before {
-    content: '\e904';
-}
-.ds-icon-Compress:before {
-    content: '\e958';
-}
-.ds-icon-STKO:before {
-    content: '\e91c';
-}
-.ds-icon-OpenFOAM:before {
-    content: '\e900';
-}
-.ds-icon-Blender:before {
-    content: '\e901';
-}
-.ds-icon-MATLAB:before {
-    content: '\e902';
-}
-.ds-icon-Paraview:before {
-    content: '\e911';
-}
-.ds-icon-Jupyter:before {
-    content: '\e913';
-}
-.ds-icon-QGIS:before {
-    content: '\e914';
-}
-.ds-icon-OpenSees:before {
-    content: '\e916';
-}
-.ds-icon-LS-DYNA:before {
-    content: '\e917';
-}
-.ds-icon-Dakota:before {
-    content: '\e918';
-}
-.ds-icon-Clawpack:before {
-    content: '\e919';
-}
-.ds-icon-Ansys:before {
-    content: '\e91a';
-}
-.ds-icon-SWBatch:before {
-    content: '\e91b';
+.ds-icon-All-Hazards::before,
+.ds-icon-OpenSees::before {
+    /* To move icon down */
+    translate: 0 0.25em;
 }

--- a/designsafe/static/styles/DesignSafe-Icons.font.css
+++ b/designsafe/static/styles/DesignSafe-Icons.font.css
@@ -1,0 +1,125 @@
+@font-face {
+    font-family: 'DesignSafe-Icons';
+    src: url('/static/fonts/DesignSafe-Icons.eot?nvbv6c');
+    src: url('/static/fonts/DesignSafe-Icons.eot?nvbv6c#iefix') format('embedded-opentype'),
+        url('/static/fonts/DesignSafe-Icons.ttf?nvbv6c') format('truetype'),
+        url('/static/fonts/DesignSafe-Icons.woff2') format('woff2'),
+        url('/static/fonts/DesignSafe-Icons.woff?nvbv6c') format('woff'),
+        url('/static/fonts/DesignSafe-Icons.svg?nvbv6c#DesignSafe-Icons') format('svg');
+    font-weight: normal;
+    font-style: normal;
+    font-display: block;
+}
+
+[class^='ds-icon-'],
+[class*=' ds-icon-'] {
+    /* use !important to prevent issues with browser extensions that change fonts */
+    font-family: 'DesignSafe-Icons' !important;
+    speak: never;
+    font-style: normal;
+    font-weight: normal;
+    font-variant: normal;
+    text-transform: none;
+    line-height: 1;
+
+    /* Better Font Rendering =========== */
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+.ds-icon-Contract:before {
+    content: '\e91d';
+}
+.ds-icon-Expand:before {
+    content: '\e923';
+}
+.ds-icon-Job-Status:before {
+    content: '\e929';
+}
+.ds-icon-All-Hazards:before {
+    content: '\e908';
+}
+.ds-icon-New-Tab:before {
+    content: '\ea7e';
+}
+.ds-icon-NGL-without-text:before {
+    content: '\e903';
+}
+.ds-icon-Potree:before {
+    content: '\e906';
+}
+.ds-icon-Generic-Vis:before {
+    content: '\e907';
+}
+.ds-icon-HVSR:before {
+    content: '\e90d';
+}
+.ds-icon-MPM:before {
+    content: '\e90e';
+}
+.ds-icon-Generic-App:before {
+    content: '\e960';
+}
+.ds-icon-GiD:before {
+    content: '\e90f';
+}
+.ds-icon-Earth:before {
+    content: '\e910';
+}
+.ds-icon-Water:before {
+    content: '\e912';
+}
+.ds-icon-Wind:before {
+    content: '\e915';
+}
+.ds-icon-rWHALE:before {
+    content: '\e905';
+}
+.ds-icon-Extract:before {
+    content: '\e959';
+}
+.ds-icon-Hazmapper:before {
+    content: '\e904';
+}
+.ds-icon-Compress:before {
+    content: '\e958';
+}
+.ds-icon-STKO:before {
+    content: '\e91c';
+}
+.ds-icon-OpenFOAM:before {
+    content: '\e900';
+}
+.ds-icon-Blender:before {
+    content: '\e901';
+}
+.ds-icon-MATLAB:before {
+    content: '\e902';
+}
+.ds-icon-Paraview:before {
+    content: '\e911';
+}
+.ds-icon-Jupyter:before {
+    content: '\e913';
+}
+.ds-icon-QGIS:before {
+    content: '\e914';
+}
+.ds-icon-OpenSees:before {
+    content: '\e916';
+}
+.ds-icon-LS-DYNA:before {
+    content: '\e917';
+}
+.ds-icon-Dakota:before {
+    content: '\e918';
+}
+.ds-icon-Clawpack:before {
+    content: '\e919';
+}
+.ds-icon-Ansys:before {
+    content: '\e91a';
+}
+.ds-icon-SWBatch:before {
+    content: '\e91b';
+}

--- a/designsafe/static/styles/app-card.css
+++ b/designsafe/static/styles/app-card.css
@@ -7,11 +7,15 @@
 
 /* Title */
 .c-app-card__title {
-    margin-top: 1em;
-    margin-bottom: 0;
+    margin-block: 1em 0;
+    padding-inline: 1rem;
 }
-.c-app-card__title > .icon::before {
-    font-size: unset; /* to undo 5vw from ng-designsafe.css */
+.c-app-card__title > .ds-icon {
+    width: unset; /* overwrite .ds-icon from main.css */
+    height: unset; /* overwrite .ds-icon from main.css */
+}
+.c-app-card__title > .ds-icon::before {
+    margin-right: 0.25em;
 }
 
 /* Description */

--- a/designsafe/static/styles/app-card.css
+++ b/designsafe/static/styles/app-card.css
@@ -57,12 +57,22 @@
     box-shadow: 3px 2px 2px #00000029;
 }
 .c-app-card:hover {
-    outline: 2px solid #0000FF;
+    outline: 2px solid var(--ds-active-color);
     outline-offset: calc( var(--border-width) * -1 );
     box-shadow: none;
 }
+.c-app-card:hover,
+.c-app-card:focus {
+    color: inherit;
+    text-decoration: none;
+}
 a.c-app-card:active {
     outline-width: 1px;
+}
+
+/* Title */
+.c-app-card:hover .c-app-card__title {
+    color: var(--ds-active-color);
 }
 
 /* Description */

--- a/designsafe/static/styles/app-card.css
+++ b/designsafe/static/styles/app-card.css
@@ -13,9 +13,10 @@
 .c-app-card__title > .ds-icon {
     width: unset; /* overwrite .ds-icon from main.css */
     height: unset; /* overwrite .ds-icon from main.css */
-}
-.c-app-card__title > .ds-icon::before {
-    margin-right: 0.25em;
+
+    /* To add space between icon and text */
+    /* FAQ: Using `rem` cuz some icons are globally resized via `em` */
+    margin-right: 0.5rem;
 }
 
 /* Description */

--- a/designsafe/static/styles/app-page.css
+++ b/designsafe/static/styles/app-page.css
@@ -2,9 +2,10 @@
 @import url("./app-grid.css");
 @import url("./app-version-list.css");
 
-/* To make width of page content line up with width of header. */
-/* TODO: Verify whether this is safe to put into `main.css` */
-.s-app-page > .container-fluid {
+/* To make width of page content line up with width of header */
+.s-app-page > .container-fluid /* FAQ: To support Style wrapper (as fallback) */,
+.s-app-page main > .container-fluid {
+  /* HELP: Is this safe to replace the .container-fluid margin in main.css? */
   margin: 0 50px;
 }
 

--- a/designsafe/static/styles/main.css
+++ b/designsafe/static/styles/main.css
@@ -1,5 +1,6 @@
 :root {
   --ds-accent-color: #47a59d;
+  --ds-active-color: #337AB7;
 }
 
 body, html {


### PR DESCRIPTION
## Overview: ##

Fix final (I hope) UI bugs on Tools & Apps page.

## PR Status: ##

* [X] Ready.
* Work in Progress.
* Hold.

## Related Jira tickets & Summary of Changes: ##

- #1221
    * [DES-2743](https://tacc-main.atlassian.net/browse/DES-2741): CMS: No List for Tag-less Apps
    * [DES-2743](https://tacc-main.atlassian.net/browse/DES-2742): CMS: Update CSS Since Icon Class Rename
    * [DES-2743](https://tacc-main.atlassian.net/browse/DES-2743): CMS: Container Too Wide
- #1224
    * [DES-2744](https://tacc-main.atlassian.net/browse/DES-2744): CMS: UI When Hovering Over Card
- #1225
    * [DES-2745](https://tacc-main.atlassian.net/browse/DES-2745): CMS: Resize Specific Icons Globally

## Testing Steps: ##

1. Verify a card with no list does not show an empty gray stripe in the middle of the card.
2. Verify icon is:
    - slightly bigger than title
    - [aligns with the baseline](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align) of the title text
    - has about a space character of width between it and title text
3. Verify container aligns left and right with logo/nav header content.
4. Verify hover and focus UI changes box border and title (and icon) color to an exiting accessible color.
5. Verify these icons are sized similar to other icons:

    | icon to resize | icon to reference |
    | - | - |
    | OpenSees | ParaView |
    | All Hazards (e.g. PBE, quoFEM) | _no guidance_ |
    | Earth, Wind, Water | other triangles e.g. OpenFoam, Ansys |

## UI Photos:

| 1. (DES-2471) & 2. (DES-2472) | 3. (DES-2473) |
| - | - |
| ![DES-2471 DES-2472](https://github.com/DesignSafe-CI/portal/assets/62723358/189c0ea2-45b4-4d4e-bb99-e98c54579221) | ![DES-2473](https://github.com/DesignSafe-CI/portal/assets/62723358/d2401b82-f1e5-49d7-b626-2a21eeb0e9b8) |

https://github.com/DesignSafe-CI/portal/assets/62723358/58b1bd37-f228-4d05-9598-2a8c2caef99c

| Before 4. (DES-2745) | After 4. (DES-2745) |
| - | - |
| <img width="1440" alt="before" src="https://github.com/DesignSafe-CI/portal/assets/62723358/86d7f616-36a2-4ba2-abed-eb747d9f16f2"> | <img width="1440" alt="after" src="https://github.com/DesignSafe-CI/portal/assets/62723358/f98e48cf-9220-4505-a018-9431d7fee06c"> |