### PR TITLE
task/DES-2763: Allow JWT-authed requests for filemeta routes

### DIFF
--- a/designsafe/apps/api/filemeta/tests.py
+++ b/designsafe/apps/api/filemeta/tests.py
@@ -86,6 +86,23 @@ def test_get_file_meta(
 
 
 @pytest.mark.django_db
+def test_get_file_meta_using_jwt(
+    regular_user_using_jwt, client, filemeta_db_mock, mock_access_success
+):
+    system_id, path, file_meta = filemeta_db_mock
+    response = client.get(f"/api/filemeta/{system_id}/{path}")
+    assert response.status_code == 200
+
+    assert response.json() == {
+        "value": file_meta.value,
+        "name": "designsafe.file",
+        "lastUpdated": file_meta.last_updated.isoformat(
+            timespec="milliseconds"
+        ).replace("+00:00", "Z"),
+    }
+
+
+@pytest.mark.django_db
 def test_create_file_meta_no_access(
     client, authenticated_user, filemeta_value_mock, mock_access_failure
 ):
@@ -110,6 +127,21 @@ def test_create_file_meta_unauthenticated(client, filemeta_value_mock):
 @pytest.mark.django_db
 def test_create_file_meta(
     client, authenticated_user, filemeta_value_mock, mock_access_success
+):
+    response = client.post(
+        "/api/filemeta/",
+        data=json.dumps(filemeta_value_mock),
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+
+    file_meta = FileMetaModel.objects.first()
+    assert file_meta.value == filemeta_value_mock
+
+
+@pytest.mark.django_db
+def test_create_file_meta_using_jwt(
+    client, regular_user_using_jwt, filemeta_value_mock, mock_access_success
 ):
     response = client.post(
         "/api/filemeta/",

--- a/designsafe/apps/api/filemeta/views.py
+++ b/designsafe/apps/api/filemeta/views.py
@@ -5,7 +5,7 @@ from django.http import JsonResponse, HttpRequest
 from designsafe.apps.api.datafiles.operations.tapis_operations import listing
 from designsafe.apps.api.exceptions import ApiException
 from designsafe.apps.api.filemeta.models import FileMetaModel
-from designsafe.apps.api.views import AuthenticatedApiView
+from designsafe.apps.api.views import AuthenticatedAllowJwtApiView
 
 
 logger = logging.getLogger(__name__)
@@ -36,8 +36,7 @@ def check_access(request, system_id: str, path: str, check_for_writable_access=F
         raise ApiException("User forbidden to access metadata", status=403) from exc
 
 
-# TODO_V3 update to allow JWT access DES-2706: https://github.com/DesignSafe-CI/portal/pull/1192
-class FileMetaView(AuthenticatedApiView):
+class FileMetaView(AuthenticatedAllowJwtApiView):
     """View for creating and getting file metadata"""
 
     def get(self, request: HttpRequest, system_id: str, path: str):
@@ -64,8 +63,7 @@ class FileMetaView(AuthenticatedApiView):
         return JsonResponse(result, safe=False)
 
 
-# TODO_V3 update to allow JWT access DES-2706: https://github.com/DesignSafe-CI/portal/pull/1192
-class CreateFileMetaView(AuthenticatedApiView):
+class CreateFileMetaView(AuthenticatedAllowJwtApiView):
     """View for creating (and updating) file metadata"""
 
     def post(self, request: HttpRequest):

--- a/designsafe/conftest.py
+++ b/designsafe/conftest.py
@@ -3,6 +3,7 @@
 import pytest
 import os
 import json
+from unittest.mock import patch
 from django.conf import settings
 from designsafe.apps.auth.models import TapisOAuthToken
 
@@ -35,6 +36,19 @@ def regular_user(django_user_model, mock_tapis_client):
     )
 
     yield user
+
+
+@pytest.fixture
+def regular_user_using_jwt(regular_user, client):
+    """Fixture for regular user who is using jwt for authenticated requests"""
+    with patch('designsafe.apps.api.decorators.Tapis') as mock_tapis:
+        # Mock the Tapis's validate_token method within the tapis_jwt_login decorator
+        mock_validate_token = mock_tapis.return_value.validate_token
+        mock_validate_token.return_value = {"tapis/username": regular_user.username}
+
+        client.defaults['HTTP_X_TAPIS_TOKEN'] = 'fake_token_string'
+
+        yield client
 
 
 @pytest.fixture


### PR DESCRIPTION
## Overview: ##

Allow JWT-authed requests for filemeta routes as follow on to https://github.com/DesignSafe-CI/portal/pull/1194

## PR Status: ##

* [X] Ready.


## Related Jira tickets: ##

* [DES-2763](https://tacc-main.atlassian.net/browse/DES-2763)

## Summary of Changes: ##

## Testing Steps: ##
1. See unit tests
2. Or manually test (find an existing file in a project)
3. curl --insecure -X POST -H "X-Tapis-Token: $JWT"  -H "Content-Type: application/json"  -d '{"system": "project-1234", "path": "/test/path.txt", "otherKey": "value", "anotherKey": "anotherValue"}' https://designsafe.dev/api/filemeta/
4. curl -H "X-Tapis-Token: $JWT"   https://designsafeci-next.tacc.utexas.edu/api/filemeta/project-1234/test/path.txt

