### PR TITLE
fix: DES-2765 app variant without label could use app entry/bundle label

### DIFF
--- a/designsafe/apps/workspace/cms_plugins.py
+++ b/designsafe/apps/workspace/cms_plugins.py
@@ -100,6 +100,9 @@ class AppVariants(CMSPluginBase):
         context = super().render(context, instance, placeholder)
         app_variants = instance.app.appvariant_set.filter(enabled=True)
         context["listing"] = app_variants
+        context["app"] = {
+            "label": instance.app.label
+        }
 
         return context
 

--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin.html
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin.html
@@ -2,7 +2,7 @@
     <h2>Select a Version</h2>
     {% for variant in listing %}
     <article>
-        <h3>{{variant.label}}</h3>
+        <h3>{{variant.label|default_if_none:app.label}}</h3>
         <a class="btn btn-success" href="{{variant.href}}">Get Started</a>
         <p>{{variant.description}}</p>
     </article>

--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin.html
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin.html
@@ -2,7 +2,7 @@
     <h2>Select a Version</h2>
     {% for variant in listing %}
     <article>
-        <h3>{{variant.label|default_if_none:app.label}}</h3>
+        <h3>{{variant.label|default:app.label}}</h3>
         <a class="btn btn-success" href="{{variant.href}}">Get Started</a>
         <p>{{variant.description}}</p>
     </article>


### PR DESCRIPTION
## Overview: ##

If an app variant does not have a label, it could use the app entry/bundle label.

_This would make "The display name of this app in the Apps Tray. If not defined, uses `notes.label` from app definition." true for someone who misinterprets "Apps Tray" as "Tools & Applications" page grid._

## PR Status: ##

* [x] Ready.
* Work in Progress.
* Hold.

## Related Jira tickets: ##

* [DES-2765](https://tacc-main.atlassian.net/browse/DES-2765)

## Summary of Changes: ##

- **added** `'app'` with `label` to template context for `AppVariants`
- **changed** `app_variant_plugin.html` to use `app.label` as fallback.

## Testing Steps: ##
1. Create/Open a page with an "App Version Selection" instance.
2. Set the plugin instance to an App Entry/Bundle with a variant that has **no** label.
3. Verify the label rendered for the variant is the app's label.

| has App Entry/Bundle label | no Variant label |
| - | - |
| ![has app label](https://github.com/DesignSafe-CI/portal/assets/62723358/879b1ca6-a637-4d1a-b1e5-8231e7361d13) | ![no variant label](https://github.com/DesignSafe-CI/portal/assets/62723358/b12dcfce-273f-490e-8b43-5250db1c0222) |

## UI Photos: ##

| before | after |
| - | - |
| ![no label shown](https://github.com/DesignSafe-CI/portal/assets/62723358/92b9c319-5f24-45c0-9d28-4251bddf48dc) | ![use app label](https://github.com/DesignSafe-CI/portal/assets/62723358/83afddfa-906b-43e4-af60-97d864fc1719) |

## Notes: ##

> [!IMPORTANT]
> This is a proposal. Maybe I misunderstand apps.