### PR TITLE
fix: DES-2766 app with 1 variant needs diff list

### DIFF
--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin.html
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin.html
@@ -1,3 +1,11 @@
+{% if listing|length == 1 %}
+<section class="s-app-version-list">
+    <h2>Already know everything?</h2>
+    {% for variant in listing %}
+    <a class="btn btn-success" href="{{variant.href}}">Get Started</a>
+    {% endfor %}
+</section>
+{% else %}
 <section class="s-app-version-list">
     <h2>Select a Version</h2>
     {% for variant in listing %}
@@ -8,3 +16,4 @@
     </article>
     {% endfor %}
 </section>
+{% endif %}

--- a/designsafe/static/styles/app-version-list.css
+++ b/designsafe/static/styles/app-version-list.css
@@ -7,6 +7,7 @@
 }
 .s-app-version-list:not(:has(article)) {
     text-align: center;
+    padding: 60px;
 }
 
 /* List Title */

--- a/designsafe/static/styles/app-version-list.css
+++ b/designsafe/static/styles/app-version-list.css
@@ -5,6 +5,9 @@
     background-color: #F4F4F4;
     padding: 20px;
 }
+.s-app-version-list:not(:has(article)) {
+    text-align: center;
+}
 
 /* List Title */
 .s-app-version-list > h2 {


### PR DESCRIPTION
## Overview: ##

Make the "App Version Selection" look different if only one variant exists.

## PR Status: ##

* [X] Ready.
* Work in Progress.
* Hold.

## Related Jira tickets: ##

* [DES-2766](https://tacc-main.atlassian.net/browse/DES-2766)

## Summary of Changes: ##

- **added** different version list markup if only 1 variant
- **added** styles for `s-version-list` sans `<article>`s

## Testing Steps: ##
1. Open page that has "App Version Selection" plugin instance.
2. Ensure the app selected is one that only has one variant.
3. Verify UI is:
    > Already know everything?
    > [[ Get Started ]](https://example.com/)

## UI Photos: ##

| before | after | in situ |
| - | - | - |
| ![before](https://github.com/DesignSafe-CI/portal/assets/62723358/a932a724-094c-43b3-8a2d-37c1a89bee50) | ![after](https://github.com/DesignSafe-CI/portal/assets/62723358/c4af4eb6-be3a-4a69-99cb-83e73eb2b359) | ![in situ](https://github.com/DesignSafe-CI/portal/assets/62723358/47ec349a-5a72-42b0-94f1-a1a1e5580a2a) |