### PR TITLE
Bug DES-2762: Job Name field does not get initialValue 

### DIFF
--- a/client/modules/workspace/src/AppsWizard/Steps.tsx
+++ b/client/modules/workspace/src/AppsWizard/Steps.tsx
@@ -102,6 +102,7 @@ export const getOutputsStep = (app) => ({
   content: (
     <>
       <FormField
+        key="name"
         label="Job Name"
         description="A recognizable name for this job."
         name="outputs.name"


### PR DESCRIPTION
## Overview: ##
"Job Name" field has value of "execSystemLogicalQueue" or if the order of field in the step, it takes value from another

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2762](https://tacc-main.atlassian.net/browse/DES-2762)

## Summary of Changes: ##
Ant FormItem does some optimization to reuse elements (see [here](https://github.com/ant-design/ant-design/blob/73adedbfaba2f736a2c2a63f21d8cb557e1bf24f/components/form/FormItem/index.tsx#L76) and [here](https://github.com/ant-design/ant-design/blob/73adedbfaba2f736a2c2a63f21d8cb557e1bf24f/components/form/FormItem/index.tsx#L57)).

The current App Form uses wizard, and content replacement, which I'm assuming falls into Ant's checks to optimize rendering. This PR does not find exact bug location/fix in Ant yet. On trying various layout mechanism, checking state, control and component inspection, I see the issue is with Ant - it picks initialValue from another similar element from previous rendered state. Note, it also will pick dirty Value, just any current value of matching element. There were bugs in this same FormItem in the past.

Adding key property to form name, which will fail checks in AntD and properly renders the name field.

## Testing Steps: ##
1. https://designsafe.dev/rw/workspace/openfoam#!/
2. Work through the wizard screens and check if the initial Values are 


![Screenshot 2024-05-07 at 6 34 47 PM](https://github.com/DesignSafe-CI/portal/assets/2568355/fa68c45d-892d-4030-a47c-033112e76012)
![Screenshot 2024-05-07 at 6 34 55 PM](https://github.com/DesignSafe-CI/portal/assets/2568355/2252ee9f-5ce1-46b3-a900-c564dfe64f5f)

## UI Photos:

## Notes: ##
