### PR TITLE
task/DES-2767: fix file metadata route path issue

### DIFF
--- a/designsafe/apps/api/filemeta/models.py
+++ b/designsafe/apps/api/filemeta/models.py
@@ -5,6 +5,16 @@ from django.db.models import Q
 from django.utils import timezone
 
 
+def _get_normalized_path(path) -> str:
+    """ Return a file path that begins with /"
+
+    For example, "file.jpg" becomes "/file.jpg"
+    """
+    if not path.startswith('/'):
+        path = '/' + path
+    return path
+
+
 class FileMetaModel(models.Model):
     """Model for File Meta"""
 
@@ -41,7 +51,8 @@ class FileMetaModel(models.Model):
         - tuple (instance, created): The FileMetaModel instance and a boolean indicating if it was created (True) or updated (False).
         """
         system = value.get("system")
-        path = value.get("path")
+        path = _get_normalized_path(value.get("path"))
+        value["path"] = path
 
         # Use a transaction to ensure atomicity
         with transaction.atomic():
@@ -64,4 +75,5 @@ class FileMetaModel(models.Model):
         Raises:
             - DoesNotExist: if file metadata entry not found
         """
+        path = _get_normalized_path(path)
         return cls.objects.get(value__system=system, value__path=path)

--- a/designsafe/apps/api/filemeta/tests.py
+++ b/designsafe/apps/api/filemeta/tests.py
@@ -191,3 +191,28 @@ def test_create_file_metadata_missing_system_or_path(
         content_type="application/json",
     )
     assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_create_using_path_without_starting_slashes_issue_DES_2767 (
+    filemeta_value_mock,
+):
+    # testing that "file.txt" and "/file.txt" are referring to the same
+    # file and that "file.txt" is normalized to "/file.txt"
+    filemeta_value_mock["path"] = "file.txt"
+
+    file_meta, created = FileMetaModel.create_or_update_file_meta(filemeta_value_mock)
+    assert created
+    assert file_meta.value["path"] == "/file.txt"
+
+
+@pytest.mark.django_db
+def test_get_using_path_with_or_without_starting_slashes_issue_DES_2767(
+    filemeta_value_mock,
+):
+    filemeta_value_mock["path"] = "file.txt"
+    FileMetaModel.create_or_update_file_meta(filemeta_value_mock)
+
+    system = filemeta_value_mock["system"]
+    FileMetaModel.get_by_path_and_system(system, "file.txt")
+    FileMetaModel.get_by_path_and_system(system, "/file.txt")

--- a/designsafe/apps/api/filemeta/tests.py
+++ b/designsafe/apps/api/filemeta/tests.py
@@ -179,8 +179,6 @@ def test_create_file_meta_update_existing_entry(
 def test_create_file_metadata_missing_system_or_path(
     client,
     authenticated_user,
-    filemeta_db_mock,
-    filemeta_value_mock,
     mock_access_success,
 ):
     value_missing_system_path = {"foo": "bar"}


### PR DESCRIPTION
## Overview: ##

Fix file metadata route path issue so that all `path`'s are normalized to start with `/`.  See example problem in [DES-2767](https://tacc-main.atlassian.net/browse/DES-2767)

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2767](https://tacc-main.atlassian.net/browse/DES-2767)

## Testing Steps: ##
1. Run unit tests
2. Find a top-level file in a project system
3. See if you can create metadata on file and see that has `/` at the start of path:
```
% curl --insecure -X POST -H "X-Tapis-Token: $JWT" -H "Content-Type: application/json" -d '{"system": "project-4983294419299528210-242ac118-0001-012", "path": "image.jpg", "otherKey": "value", "anotherKey": "anotherValue"}'  https://designsafe.dev/api/filemeta/
{"result": "OK"}%
% curl --insecure -H "X-Tapis-Token: $JWT"   https://designsafe.dev/api/filemeta/project-4983294419299528210-242ac118-0001-012/image.jpg
{"value": {"path": "/image.jpg", "system": "project-4983294419299528210-242ac118-0001-012", "otherKey": "value", "anotherKey": "anotherValue"}, "lastUpdated": "2024-05-09T19:29:36.488Z", "name": "designsafe.file"}%

```
