### PR TITLE
task/DES-2758, DES-2747: Tapis v3 Job Notifications

### DIFF
--- a/client/modules/_hooks/src/workspace/usePostJobs.ts
+++ b/client/modules/_hooks/src/workspace/usePostJobs.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import apiClient from '../apiClient';
+import apiClient, { type TApiError } from '../apiClient';
 import { TJobArgSpecs, TJobKeyValuePair, TAppFileInput } from './types';
 
 type TJobPostOperations = 'resubmitJob' | 'cancelJob' | 'submitJob';
@@ -52,6 +52,7 @@ export function usePostJobs() {
     mutationFn: (body: TJobBody) => {
       return postJobs(body);
     },
+    onError: (err: TApiError) => err,
   });
 }
 

--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -534,7 +534,12 @@ export const AppsSubmissionForm: React.FC = () => {
           )}
           {submitError && (
             <Alert
-              message={<>Error: {submitError?.message}</>}
+              message={
+                <>
+                  Job Submit Error:{' '}
+                  {submitError.response?.data.message || submitError.message}
+                </>
+              }
               type="warning"
               closable
               showIcon

--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -369,6 +369,7 @@ export const AppsSubmissionForm: React.FC = () => {
   const {
     mutate: submitJob,
     isPending,
+    isSuccess,
     data: submitResult,
     error: submitError,
   } = usePostJobs();
@@ -380,6 +381,8 @@ export const AppsSubmissionForm: React.FC = () => {
   useEffect(() => {
     if (submitResult?.execSys) {
       setPushKeysSystem(submitResult.execSys);
+    } else if (isSuccess) {
+      reset(initialValues);
     }
   }, [submitResult]);
 

--- a/client/modules/workspace/src/Toast/Notifications.module.css
+++ b/client/modules/workspace/src/Toast/Notifications.module.css
@@ -1,0 +1,4 @@
+.toast-is-error {
+  color: #eb6e6e;
+  font-weight: 1000;
+}

--- a/client/modules/workspace/src/Toast/Notifications.module.css
+++ b/client/modules/workspace/src/Toast/Notifications.module.css
@@ -1,4 +1,3 @@
 .toast-is-error {
   color: #eb6e6e;
-  font-weight: 1000;
 }

--- a/client/modules/workspace/src/Toast/Toast.tsx
+++ b/client/modules/workspace/src/Toast/Toast.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import useWebSocket from 'react-use-websocket';
 import { notification } from 'antd';
 import { Icon } from '@client/common-components';
@@ -6,33 +6,26 @@ import { type TJobStatusNotification, getToastMessage } from '../utils';
 import styles from './Notifications.module.css';
 
 const Notifications = () => {
-  const [messageHistory, setMessageHistory] = useState<MessageEvent<any>[]>([]);
-
   const { lastMessage } = useWebSocket(
     `wss://${window.location.host}/ws/websockets/`
   );
 
-  const [api, contextHolder] = notification.useNotification();
+  const [api, contextHolder] = notification.useNotification({ maxCount: 1 });
 
   const openNotification = (notification: TJobStatusNotification) => {
     api.open({
-      message: ['interactive_session_ready', 'job'].includes(
-        notification.event_type
-      )
-        ? 'Job Status Update'
-        : notification.event_type,
-      description: getToastMessage(notification),
+      message: getToastMessage(notification),
       placement: 'bottomLeft',
       icon: <Icon className={`ds-icon-Job-Status`} label="Job-Status" />,
       className: `${
-        notification.status === 'ERROR' && styles['toast-is-error']
+        notification.extra.status === 'FAILED' && styles['toast-is-error']
       }`,
+      closeIcon: false,
     });
   };
 
   useEffect(() => {
     if (lastMessage !== null) {
-      setMessageHistory((prev) => prev.concat(lastMessage));
       openNotification(JSON.parse(lastMessage.data));
     }
   }, [lastMessage]);

--- a/client/modules/workspace/src/Toast/Toast.tsx
+++ b/client/modules/workspace/src/Toast/Toast.tsx
@@ -1,0 +1,43 @@
+import React, { useState, useEffect } from 'react';
+import useWebSocket from 'react-use-websocket';
+import { notification } from 'antd';
+import { Icon } from '@client/common-components';
+import { type TJobStatusNotification, getToastMessage } from '../utils';
+import styles from './Notifications.module.css';
+
+const Notifications = () => {
+  const [messageHistory, setMessageHistory] = useState<MessageEvent<any>[]>([]);
+
+  const { lastMessage } = useWebSocket(
+    `wss://${window.location.host}/ws/websockets/`
+  );
+
+  const [api, contextHolder] = notification.useNotification();
+
+  const openNotification = (notification: TJobStatusNotification) => {
+    api.open({
+      message: ['interactive_session_ready', 'job'].includes(
+        notification.event_type
+      )
+        ? 'Job Status Update'
+        : notification.event_type,
+      description: getToastMessage(notification),
+      placement: 'bottomLeft',
+      icon: <Icon className={`ds-icon-Job-Status`} label="Job-Status" />,
+      className: `${
+        notification.status === 'ERROR' && styles['toast-is-error']
+      }`,
+    });
+  };
+
+  useEffect(() => {
+    if (lastMessage !== null) {
+      setMessageHistory((prev) => prev.concat(lastMessage));
+      openNotification(JSON.parse(lastMessage.data));
+    }
+  }, [lastMessage]);
+
+  return <>{contextHolder}</>;
+};
+
+export default Notifications;

--- a/client/modules/workspace/src/Toast/index.tsx
+++ b/client/modules/workspace/src/Toast/index.tsx
@@ -1,0 +1,1 @@
+export { default as Toast } from './Toast';

--- a/client/modules/workspace/src/index.ts
+++ b/client/modules/workspace/src/index.ts
@@ -5,5 +5,6 @@ export * from './JobsDetailModal/JobsDetailModal';
 export * from './JobStatusNav/JobStatusNav';
 export * from './AppsBreadcrumb/AppsBreadcrumb';
 export * from './SystemsPushKeysModal/SystemsPushKeysModal';
+export * from './Toast';
 export * from './utils';
 export * from './constants';

--- a/client/modules/workspace/src/utils/index.ts
+++ b/client/modules/workspace/src/utils/index.ts
@@ -1,3 +1,5 @@
 export * from './jobs';
 export * from './systems';
 export * from './apps';
+export * from './truncateMiddle';
+export * from './notifications';

--- a/client/modules/workspace/src/utils/jobs.ts
+++ b/client/modules/workspace/src/utils/jobs.ts
@@ -1,6 +1,6 @@
 import { STATUS_TEXT_MAP } from '../constants';
 
-export function getStatusText({ status }: { status: string }) {
+export function getStatusText(status: string) {
   if (status in STATUS_TEXT_MAP) {
     return STATUS_TEXT_MAP[status];
   }

--- a/client/modules/workspace/src/utils/notifications.ts
+++ b/client/modules/workspace/src/utils/notifications.ts
@@ -48,9 +48,9 @@ export const getToastMessage = ({
 }: TJobStatusNotification) => {
   switch (eventType) {
     case 'job':
-      return `${truncateMiddle(extra.name, 20)} ${toastMap(extra.status)}`;
+      return `${truncateMiddle(extra.name, 25)} ${toastMap(extra.status)}`;
     case 'interactive_session_ready':
-      return `${truncateMiddle(extra.name, 20)} ${
+      return `${truncateMiddle(extra.name, 25)} ${
         message ? message.toLowerCase() : 'session ready to view.'
       }`;
     default:

--- a/client/modules/workspace/src/utils/notifications.ts
+++ b/client/modules/workspace/src/utils/notifications.ts
@@ -1,0 +1,59 @@
+import { truncateMiddle, getStatusText } from '../utils';
+
+export type TJobStatusNotification = {
+  event_type: string;
+  datetime: string;
+  status: string;
+  operation: string;
+  message: string;
+  extra: {
+    name: string;
+    owner: string;
+    status: string;
+    uuid: string;
+  };
+  pk: number;
+  action_link: string;
+  user: string;
+  read: boolean;
+  deleted: boolean;
+};
+
+/*
+ * Post-process mapped status message to get a toast message translation.
+ */
+const toastMap = (status: string) => {
+  const mappedStatus = getStatusText(status);
+  switch (mappedStatus) {
+    case 'Running':
+      return 'is now running';
+    case 'Failure' || 'Stopped':
+      return status.toLowerCase();
+    case 'Finished':
+      return 'finished successfully';
+    case 'Unknown':
+      return 'is in an unknown state';
+    default:
+      return `is ${mappedStatus.toLowerCase()}`;
+  }
+};
+
+/*
+ * Returns a human readable message from a job update event.
+ */
+export const getToastMessage = ({
+  extra,
+  event_type: eventType,
+  message,
+}: TJobStatusNotification) => {
+  switch (eventType) {
+    case 'job':
+      return `${truncateMiddle(extra.name, 20)} ${toastMap(extra.status)}`;
+    case 'interactive_session_ready':
+      return `${truncateMiddle(extra.name, 20)} ${
+        message ? message.toLowerCase() : 'session ready to view.'
+      }`;
+    default:
+      return message;
+  }
+};

--- a/client/modules/workspace/src/utils/truncateMiddle.ts
+++ b/client/modules/workspace/src/utils/truncateMiddle.ts
@@ -1,0 +1,29 @@
+/**
+ * Truncates a string with ellipses in the middle.
+ *
+ * @param {string} s - A string param
+ * @param {number} maxLen - Maximum length of resulting string, including ellipses
+ * @return {string} Truncated string
+ *
+ * @example
+ * // returns "this...ing"
+ * truncateMiddle('this is a long string', 10)
+ */
+export function truncateMiddle(s: string, maxLen: number) {
+  if (!s) {
+    return '';
+  }
+  if (maxLen < 5) {
+    throw new Error(
+      'Cannot middle truncate string with a maximum length less than 5.'
+    );
+  }
+  if (s.length > maxLen) {
+    // starting index of ellipses
+    const start = Math.max(1, Math.floor(maxLen / 2) - 1);
+    // ending index of ellipses
+    const end = -Math.max(1, Math.ceil(maxLen / 2) - 2);
+    return `${s.substring(0, start)}...${s.slice(end)}`;
+  }
+  return s;
+}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,6 +20,7 @@
         "react-hook-form": "^7.51.3",
         "react-hook-form-antd": "^1.1.0",
         "react-router-dom": "^6.21.1",
+        "react-use-websocket": "^4.8.1",
         "tslib": "^2.3.0",
         "zod": "^3.23.4"
       },
@@ -7269,9 +7270,9 @@
       "dev": true
     },
     "node_modules/ejs": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
-      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dev": true,
       "dependencies": {
         "jake": "^10.8.5"
@@ -11955,6 +11956,15 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-use-websocket": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/react-use-websocket/-/react-use-websocket-4.8.1.tgz",
+      "integrity": "sha512-FTXuG5O+LFozmu1BRfrzl7UIQngECvGJmL7BHsK4TYXuVt+mCizVA8lT0hGSIF0Z0TedF7bOo1nRzOUdginhDw==",
+      "peerDependencies": {
+        "react": ">= 18.0.0",
+        "react-dom": ">= 18.0.0"
       }
     },
     "node_modules/readable-stream": {

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "react-hook-form": "^7.51.3",
     "react-hook-form-antd": "^1.1.0",
     "react-router-dom": "^6.21.1",
+    "react-use-websocket": "^4.8.1",
     "tslib": "^2.3.0",
     "zod": "^3.23.4"
   },

--- a/client/src/workspace/layouts/WorkspaceBaseLayout.tsx
+++ b/client/src/workspace/layouts/WorkspaceBaseLayout.tsx
@@ -6,6 +6,7 @@ import {
   JobStatusNav,
   useGetAppParams,
   AppsBreadcrumb,
+  Toast,
 } from '@client/workspace';
 import { useAppsListing, usePrefetchGetSystems } from '@client/hooks';
 import { Spinner } from '@client/common-components';
@@ -33,28 +34,31 @@ const WorkspaceRoot: React.FC = () => {
   };
 
   return (
-    <Flex
-      vertical
-      style={{
-        margin: '-20px 50px 0 50px',
-      }}
-    >
-      <Header style={headerStyle}>
-        <AppsBreadcrumb />
-      </Header>
-      <Layout
-        hasSider
+    <>
+      <Flex
+        vertical
         style={{
-          gap: '20px',
+          margin: '-20px 50px 0 50px',
         }}
       >
-        <Sider width={200} theme="light" breakpoint="md" collapsedWidth={0}>
-          <JobStatusNav />
-          <AppsSideNav categories={data.categories} />
-        </Sider>
-        <Outlet />
-      </Layout>
-    </Flex>
+        <Header style={headerStyle}>
+          <AppsBreadcrumb />
+        </Header>
+        <Layout
+          hasSider
+          style={{
+            gap: '20px',
+          }}
+        >
+          <Sider width={200} theme="light" breakpoint="md" collapsedWidth={0}>
+            <JobStatusNav />
+            <AppsSideNav categories={data.categories} />
+          </Sider>
+          <Outlet />
+        </Layout>
+      </Flex>
+      <Toast />
+    </>
   );
 };
 

--- a/designsafe/apps/api/views.py
+++ b/designsafe/apps/api/views.py
@@ -1,19 +1,21 @@
 from django.views.decorators.csrf import csrf_exempt
-from django.http.response import HttpResponse, HttpResponseForbidden, JsonResponse
 from django.views.generic import View
-from django.http import JsonResponse
+from django.http import JsonResponse, HttpResponse, Http404
+from django.core.exceptions import PermissionDenied
 from django.utils.decorators import method_decorator
-from requests.exceptions import ConnectionError, HTTPError
+from requests.exceptions import HTTPError
 from .exceptions import ApiException
 import logging
 from logging import getLevelName
 import json
 from designsafe.apps.api.decorators import tapis_jwt_login
+from tapipy.errors import BaseTapyException
 
 logger = logging.getLogger(__name__)
 
 
 class BaseApiView(View):
+    """Base api view to centralize error logging."""
 
     def dispatch(self, request, *args, **kwargs):
         """
@@ -24,35 +26,77 @@ class BaseApiView(View):
         logger output.
         """
         try:
-            return super(BaseApiView, self).dispatch(request, *args, **kwargs)
+            return super().dispatch(request, *args, **kwargs)
+        except (PermissionDenied, Http404) as e:
+            # log information but re-raise exception to let django handle response
+            logger.error(e, exc_info=True)
+            raise e
         except ApiException as e:
             status = e.response.status_code
             message = e.response.reason
             extra = e.extra
-            logger.error('{}'.format(message), exc_info=True, extra=extra)
-        except (ConnectionError, HTTPError) as e:
-            if e.response:
-                status = e.response.status_code
-                message = e.response.reason
-                if status not in [403, 404]:
-                    logger.error('%s: %s', message, e.response.text,
-                                 exc_info=True,
-                                 extra={'username': request.user.username,
-                                        'sessionId': request.session.session_key})
-                else:
-                    logger.warning('%s: %s', message, e.response.text,
-                                   exc_info=True,
-                                   extra={'username': request.user.username,
-                                          'sessionId': request.session.session_key})
+            if status != 404:
+                logger.error(
+                    "%s: %s", message, e.response.text, exc_info=True, extra=extra
+                )
             else:
-                logger.error('%s', e, exc_info=True)
+                logger.info("Error %s", message, exc_info=True, extra=extra)
+            return JsonResponse({"message": message}, status=400)
+        except (ConnectionError, HTTPError, BaseTapyException) as e:
+            # status code and json content from ConnectionError/HTTPError exceptions
+            # are used in the returned response. Note: the handling of these two exceptions
+            # is significant as client-side code make use of these status codes (e.g. error
+            # responses from tapis are used to determine a tapis storage systems does not exist)
+            status = 500
+            if e.response is not None:
+                status = e.response.status_code
+                try:
+                    content = e.response.json()
+                    message = content.get("message", "Unknown Error")
+                except ValueError:
+                    message = "Unknown Error"
+                if status in [404, 403]:
+                    logger.warning(
+                        "%s: %s",
+                        message,
+                        e.response.text,
+                        exc_info=True,
+                        extra={
+                            "username": request.user.username,
+                            "session_key": request.session.session_key,
+                        },
+                    )
+                else:
+                    logger.error(
+                        "%s: %s",
+                        message,
+                        e.response.text,
+                        exc_info=True,
+                        extra={
+                            "username": request.user.username,
+                            "session_key": request.session.session_key,
+                        },
+                    )
+            else:
+                logger.error(
+                    e,
+                    exc_info=True,
+                    extra={
+                        "username": request.user.username,
+                        "session_key": request.session.session_key,
+                    },
+                )
                 message = str(e)
-                status = 500
-
-        return JsonResponse({'message': message}, status=status)
+            return JsonResponse({"message": message}, status=status)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error(e, exc_info=True)
+            return JsonResponse({"message": "Something went wrong here..."}, status=500)
 
 
 class AuthenticatedApiView(BaseApiView):
+    """
+    Extends BaseApiView to require authenticated requests
+    """
 
     def dispatch(self, request, *args, **kwargs):
         """Returns 401 if user is not authenticated."""
@@ -71,7 +115,9 @@ class AuthenticatedAllowJwtApiView(AuthenticatedApiView):
     @method_decorator(tapis_jwt_login)
     def dispatch(self, request, *args, **kwargs):
         """Returns 401 if user is not authenticated like AuthenticatedApiView but allows JWT access."""
-        return super(AuthenticatedAllowJwtApiView, self).dispatch(request, *args, **kwargs)
+        return super(AuthenticatedAllowJwtApiView, self).dispatch(
+            request, *args, **kwargs
+        )
 
 
 class LoggerApi(BaseApiView):
@@ -93,13 +139,19 @@ class LoggerApi(BaseApiView):
         Returns: HTTP 202
 
         """
-        log_json = request.body.decode('utf-8')
+        log_json = request.body.decode("utf-8")
         log_data = json.loads(log_json)
-        level = getLevelName(log_data.pop('level', 'INFO'))
-        name = log_data.pop('name');
+        level = getLevelName(log_data.pop("level", "INFO"))
+        name = log_data.pop("name")
 
-        logger.log(level, '%s: %s', name, json.dumps(log_data), extra={
-            'user': request.user.username,
-            'referer': request.META.get('HTTP_REFERER')
-        })
-        return HttpResponse('OK', status=202)
+        logger.log(
+            level,
+            "%s: %s",
+            name,
+            json.dumps(log_data),
+            extra={
+                "user": request.user.username,
+                "referer": request.META.get("HTTP_REFERER"),
+            },
+        )
+        return HttpResponse("OK", status=202)

--- a/designsafe/apps/api/views.py
+++ b/designsafe/apps/api/views.py
@@ -32,7 +32,7 @@ class BaseApiView(View):
             logger.error(e, exc_info=True)
             raise e
         except ApiException as e:
-            status = e.response.status_code
+            status = e.response.status_code or 400
             message = e.response.reason
             extra = e.extra
             if status != 404:
@@ -41,7 +41,7 @@ class BaseApiView(View):
                 )
             else:
                 logger.info("Error %s", message, exc_info=True, extra=extra)
-            return JsonResponse({"message": message}, status=400)
+            return JsonResponse({"message": message}, status=status)
         except (ConnectionError, HTTPError, BaseTapyException) as e:
             # status code and json content from ConnectionError/HTTPError exceptions
             # are used in the returned response. Note: the handling of these two exceptions

--- a/designsafe/apps/webhooks/views.py
+++ b/designsafe/apps/webhooks/views.py
@@ -105,6 +105,7 @@ class JobsWebhookView(BaseApiView):
             event_data = {
                 Notification.EVENT_TYPE: "job",
                 Notification.STATUS: Notification.INFO,
+                Notification.MESSAGE: f"Job '{job_name}' updated to {job_status}",
                 Notification.USER: username,
                 Notification.EXTRA: {
                     "name": job_name,
@@ -172,6 +173,7 @@ class InteractiveWebhookView(BaseApiView):
             Notification.EVENT_TYPE: event_type,
             Notification.STATUS: Notification.INFO,
             Notification.USER: job_owner,
+            Notification.MESSAGE: 'Ready to view.',
             Notification.ACTION_LINK: address,
         }
 

--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/index.j2
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/index.j2
@@ -32,7 +32,6 @@
          ng-init="panel.collapsed = true"></div>
   </div>
 </div>
-{% endif %}
 
 {% addtoblock "css" %}
 <link href="{% static 'scripts/workspace/styles/workspace.css' %}" rel="stylesheet">
@@ -52,6 +51,7 @@
 <script src="{% static 'scripts/workspace/directives/asf-agave-file-picker.js' %}"></script>
 <script src="<%= htmlWebpackPlugin.files.js %>"></script>
 {% endaddtoblock %}
+{% endif %}
 
 {% addtoblock "react_assets" %}
 {% if debug and react_flag %}

--- a/designsafe/static/scripts/ng-designsafe/providers/notifications-provider.js
+++ b/designsafe/static/scripts/ng-designsafe/providers/notifications-provider.js
@@ -148,16 +148,16 @@ function NotificationService(
         });
 
         const toastViewLink = renderLink(msg);
-        // if (typeof toastViewLink !== 'undefined') {
-        //     toast.action('View');
-        //     $mdToast.show(toast).then(function(response) {
-        //         if (response == 'ok') {
-        //             window.location.href = toastViewLink;
-        //         }
-        //     });
-        // } else {
-        //     $mdToast.show(toast);
-        // }
+        if (typeof toastViewLink !== 'undefined') {
+            toast.action('View');
+            $mdToast.show(toast).then(function(response) {
+                if (response == 'ok') {
+                    window.location.href = toastViewLink;
+                }
+            });
+        } else {
+            $mdToast.show(toast);
+        }
     }
 
     return {

--- a/designsafe/static/scripts/ng-designsafe/providers/notifications-provider.js
+++ b/designsafe/static/scripts/ng-designsafe/providers/notifications-provider.js
@@ -25,7 +25,6 @@ function NotificationService(
      * @return {string} url
      */
     function renderLink(msg) {
-        console.log('rendering link?')
         const eventType = msg.event_type.toLowerCase();
         let url = '';
         if (typeof processors[eventType] !== 'undefined' &&
@@ -120,6 +119,10 @@ function NotificationService(
      * @param {Object} msg
      */
     function processToastr(e, msg) {
+        if (e.event_type !== 'data_depot') {
+            return;
+        }
+
         try {
             // msg.extra = JSON.parse(msg.extra);
             msg.extra = (typeof msg.extra === 'string') ? JSON.parse(msg.extra) : msg.extra;

--- a/designsafe/static/scripts/ng-designsafe/providers/notifications-provider.js
+++ b/designsafe/static/scripts/ng-designsafe/providers/notifications-provider.js
@@ -148,16 +148,16 @@ function NotificationService(
         });
 
         const toastViewLink = renderLink(msg);
-        if (typeof toastViewLink !== 'undefined') {
-            toast.action('View');
-            $mdToast.show(toast).then(function(response) {
-                if (response == 'ok') {
-                    window.location.href = toastViewLink;
-                }
-            });
-        } else {
-            $mdToast.show(toast);
-        }
+        // if (typeof toastViewLink !== 'undefined') {
+        //     toast.action('View');
+        //     $mdToast.show(toast).then(function(response) {
+        //         if (response == 'ok') {
+        //             window.location.href = toastViewLink;
+        //         }
+        //     });
+        // } else {
+        //     $mdToast.show(toast);
+        // }
     }
 
     return {


### PR DESCRIPTION
## Overview: ##

- Display toast notifications for v3 job status updates
- Disable v2 angular toast notifications

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2758](https://tacc-main.atlassian.net/browse/DES-2758)
* [DES-2747](https://tacc-main.atlassian.net/browse/DES-2747)

## Testing Steps: ##
1. Submit a job
2. Confirm toasts show in bottom left corner

## UI Photos:
![Screenshot 2024-05-20 at 2 19 29 PM](https://github.com/DesignSafe-CI/portal/assets/20326896/bffbedcb-2869-4959-8c81-243bfa631636)
![Screenshot 2024-05-20 at 2 19 19 PM](https://github.com/DesignSafe-CI/portal/assets/20326896/f3d0c62a-7812-4aeb-8ea5-697c3bd23662)



## Notes: ##
TODO items for future:
- [x] Fix bug where on job status change, focus redirects to where the notification context is instantiated
- [ ] Style notification toast popups
- [ ] Hook job status updates via websocket events into updating the job listing and job detail modal