### PR TITLE
Task/DES-2749: Dynamically update nodes and cores validation when queue changes

### DIFF
--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -11,11 +11,8 @@ import {
   useGetSystems,
   useAuthenticatedUser,
   TTapisSystem,
-  TTapisSystemQueue,
   TUser,
   TAppFileInput,
-  TConfigurationValues,
-  TOutputValues,
   TJobSubmit,
   TParameterSetSubmit,
   TJobBody,
@@ -26,8 +23,10 @@ import { default as AppIcon } from './AppIcon';
 import {
   default as FormSchema,
   TField,
-  TFileInputsDefaults,
-  TParameterSetDefaults,
+  TFormValues,
+  TAppFieldSchema,
+  getConfigurationSchema,
+  getConfigurationFields,
 } from '../AppsWizard/AppsFormSchema';
 import {
   getInputsStep,
@@ -40,30 +39,17 @@ import {
   // AppFormProvider,
   // useAppFormState,
   // getSystemName,
-  getQueueMaxMinutes,
-  getAppQueueValues,
   getExecSystemFromId,
   getQueueValueForExecSystem,
-  getNodeCountValidation,
-  getCoresPerNodeValidation,
-  getMaxMinutesValidation,
-  getAllocationValidation,
-  getExecSystemLogicalQueueValidation,
   isAppTypeBATCH,
   isTargetPathField,
   getInputFieldFromTargetPathField,
   isTargetPathEmpty,
   getExecSystemsFromApp,
   useGetAppParams,
+  updateValuesForQueue,
 } from '../utils';
 // import styles from './layout.module.css';
-
-type FormValues = {
-  inputs: TFileInputsDefaults;
-  parameters: TParameterSetDefaults;
-  configuration: TConfigurationValues;
-  outputs: TOutputValues;
-};
 
 export const AppsSubmissionForm: React.FC = () => {
   const { data: app } = useGetAppsSuspense(useGetAppParams());
@@ -102,50 +88,22 @@ export const AppsSubmissionForm: React.FC = () => {
     executionSystems as TTapisSystem[]
   );
 
-  const defaultExecSystem = getExecSystemFromId(
-    execSystems,
-    definition.jobAttributes.execSystemId
-  ) as TTapisSystem;
-
-  const { fileInputs, parameterSet } = FormSchema(definition);
+  const { fileInputs, parameterSet, configuration, outputs } = FormSchema(
+    definition,
+    executionSystems,
+    allocations,
+    portalAlloc,
+    defaultStorageSystem,
+    username
+  );
 
   // TODOv3: dynamic exec system and queues
-  const initialValues: FormValues = useMemo(
+  const initialValues: TFormValues = useMemo(
     () => ({
       inputs: fileInputs.defaults,
       parameters: parameterSet.defaults,
-      configuration: {
-        // execSystemId: defaultExecSystem?.id,
-        execSystemLogicalQueue: isAppTypeBATCH(definition)
-          ? definition.jobAttributes.execSystemLogicalQueue
-          : // (
-            //     app.execSystems.batchLogicalQueues.find(
-            //       (q) =>
-            //         q.name ===
-            //         (app.definition.jobAttributes.execSystemLogicalQueue ||
-            //           app.execSystems.batchDefaultLogicalQueue)
-            //     ) || app.execSystems.batchLogicalQueues[0]
-            //   ).name
-            '',
-        maxMinutes: definition.jobAttributes.maxMinutes,
-        nodeCount: definition.jobAttributes.nodeCount,
-        coresPerNode: definition.jobAttributes.coresPerNode,
-        allocation: isAppTypeBATCH(definition)
-          ? allocations.includes(portalAlloc)
-            ? portalAlloc
-            : allocations.length === 1
-            ? allocations[0]
-            : ''
-          : '',
-      },
-      outputs: {
-        name: `${definition.id}-${definition.version}_${
-          new Date().toISOString().split('.')[0]
-        }`,
-        archiveSystemId:
-          defaultStorageSystem?.id || definition.jobAttributes.archiveSystemId,
-        archiveSystemDir: `${username}/tapis-jobs-archive/\${JobCreateDate}/\${JobName}-\${JobUUID}`,
-      },
+      configuration: configuration.defaults,
+      outputs: outputs.defaults,
     }),
     [definition]
   );
@@ -181,32 +139,12 @@ export const AppsSubmissionForm: React.FC = () => {
 
   // const currentExecSystem = getExecSystemFromId(app, state.execSystemId);
 
-  const queue = getQueueValueForExecSystem({
-    definition,
-    exec_sys: defaultExecSystem,
-    queue_name: definition.jobAttributes.execSystemLogicalQueue,
-  }) as TTapisSystemQueue;
-
-  const schema = {
-    // TODOv3 handle fileInputArrays https://jira.tacc.utexas.edu/browse/WP-81
+  const [schema, setSchema] = useState<TAppFieldSchema>({
     inputs: z.object(fileInputs.schema),
     parameters: z.object(parameterSet.schema),
-    configuration: z.object({
-      execSystemLogicalQueue: getExecSystemLogicalQueueValidation(
-        definition,
-        defaultExecSystem
-      ),
-      maxMinutes: getMaxMinutesValidation(definition, queue),
-      coresPerNode: getCoresPerNodeValidation(definition, queue),
-      nodeCount: getNodeCountValidation(definition, queue),
-      allocation: getAllocationValidation(definition, allocations),
-    }),
-    outputs: z.object({
-      name: z.string().max(80),
-      archiveSystemId: z.string().optional(),
-      archiveSystemDir: z.string().optional(),
-    }),
-  };
+    configuration: z.object(configuration.schema),
+    outputs: z.object(outputs.schema),
+  });
 
   const { Header, Content } = Layout;
   const headerStyle = {
@@ -233,7 +171,7 @@ export const AppsSubmissionForm: React.FC = () => {
     resolver: zodResolver(z.object(schema)),
     mode: 'onChange',
   });
-  const { handleSubmit, reset } = methods;
+  const { handleSubmit, reset, setValue, getValues, watch } = methods;
 
   useEffect(() => {
     reset(initialValues);
@@ -241,104 +179,64 @@ export const AppsSubmissionForm: React.FC = () => {
 
   const [current, setCurrent] = useState('inputs');
 
-  const fields: {
+  const [fields, setFields] = useState<{
     [dynamic: string]: {
       [dynamic: string]: TField | { [dynamic: string]: TField };
     };
-  } = {
+  }>({
     inputs: fileInputs.fields,
     parameters: parameterSet.fields,
-    configuration: {
-      execSystemLogicalQueue: {
-        description: 'Select the queue this job will execute on.',
-        label: 'Queue',
-        name: 'configuration.execSystemLogicalQueue',
-        key: 'configuration.execSystemLogicalQueue',
-        required: true,
-        type: 'select',
-        options: getAppQueueValues(
-          definition,
-          execSystems[0].batchLogicalQueues
-        ).map((q) => ({ value: q, label: q })),
-      },
-      maxMinutes: {
-        description: `The maximum number of minutes you expect this job to run for. Maximum possible is ${getQueueMaxMinutes(
-          definition,
-          defaultExecSystem,
-          queue.name
-        )} minutes. After this amount of time your job will end. Shorter run times result in shorter queue wait times.`,
-        label: 'Maximum Job Runtime (minutes)',
-        name: 'configuration.maxMinutes',
-        key: 'configuration.maxMinutes',
-        required: true,
-        type: 'number',
-      },
-      coresPerNode: {
-        description:
-          'Number of processors (cores) per node for the job. e.g. a selection of 16 processors per node along with 4 nodes will result in 16 processors on 4 nodes, with 64 processors total.',
-        label: 'Cores Per Node',
-        name: 'configuration.coresPerNode',
-        key: 'configuration.coresPerNode',
-        required: true,
-        type: 'number',
-      },
-      nodeCount: {
-        description: 'Number of requested process nodes for the job.',
-        label: 'Node Count',
-        name: 'configuration.nodeCount',
-        key: 'configuration.nodeCount',
-        required: true,
-        type: 'number',
-      },
-      allocation: {
-        description:
-          'Select the project allocation you would like to use with this job submission.',
-        label: 'Allocation',
-        name: 'configuration.allocation',
-        key: 'configuration.allocation',
-        required: true,
-        type: 'select',
-        options: [
-          { label: '', hidden: true, disabled: true },
-          ...allocations.sort().map((projectId) => ({
-            value: projectId,
-            label: projectId,
-          })),
-        ],
-      },
-    },
-    outputs: {
-      name: {
-        description: 'A recognizable name for this job.',
-        label: 'Job Name',
-        name: 'outputs.name',
-        key: 'outputs.name',
-        required: true,
-        type: 'text',
-      },
-      archiveSystemId: {
-        description:
-          'System into which output files are archived after application execution.',
-        label: 'Archive System',
-        name: 'outputs.archiveSystemId',
-        key: 'outputs.archiveSystemId',
-        required: false,
-        type: 'text',
-        placeholder:
-          defaultStorageSystem.id || definition.jobAttributes.archiveSystemId,
-      },
-      archiveSystemDir: {
-        description:
-          'Directory into which output files are archived after application execution.',
-        label: 'Archive Directory',
-        name: 'outputs.archiveSystemDir',
-        key: 'outputs.archiveSystemDir',
-        required: false,
-        type: 'text',
-        placeholder: `${username}/tapis-jobs-archive/\${JobCreateDate}/\${JobName}-\${JobUUID}`,
-      },
-    },
-  };
+    configuration: configuration.fields,
+    outputs: outputs.fields,
+  });
+
+  // Queue dependency handler.
+  const queueValue = watch('configuration.execSystemLogicalQueue');
+  React.useEffect(() => {
+    if (queueValue) {
+      const execSystem = getExecSystemFromId(
+        execSystems,
+        definition.jobAttributes.execSystemId
+      );
+      if (!execSystem) return;
+      updateValuesForQueue(
+        execSystems,
+        definition.jobAttributes.execSystemId,
+        getValues(),
+        setValue
+      );
+      const queue = getQueueValueForExecSystem({
+        exec_sys: execSystem,
+        queue_name: queueValue as string,
+      });
+      if (!queue) return;
+
+      // Only configuration is dependent on queue values
+      const updatedSchema = getConfigurationSchema(
+        definition,
+        allocations,
+        execSystem,
+        queue
+      );
+
+      setSchema((prevSchema) => ({
+        ...prevSchema,
+        configuration: z.object(updatedSchema),
+      }));
+
+      const updatedFields = getConfigurationFields(
+        definition,
+        allocations,
+        [execSystem],
+        queue
+      );
+
+      setFields((prevFields) => ({
+        ...prevFields,
+        configuration: updatedFields,
+      }));
+    }
+  }, [queueValue, setValue]);
 
   interface TStep {
     [dynamic: string]: {
@@ -349,12 +247,29 @@ export const AppsSubmissionForm: React.FC = () => {
     };
   }
 
-  const steps: TStep = {
+  // Make step part of state to allow steps
+  // to handle field changes
+  const [steps, setSteps] = useState<TStep>({
     inputs: getInputsStep(fileInputs.fields),
     parameters: getParametersStep(parameterSet.fields),
-    configuration: getConfigurationStep(definition, execSystems, allocations),
-    outputs: getOutputsStep(definition, defaultStorageSystem.id, username),
-  };
+    configuration: getConfigurationStep(configuration.fields),
+    outputs: getOutputsStep(outputs.fields),
+  });
+
+  // Note: currently configuration is the only
+  // step that needs. This can be more generic
+  // in future if the fields shape is same between
+  // Step and Submission Detail View (mostly related to env vars)
+  useEffect(() => {
+    const updatedSteps: TStep = {
+      ...steps,
+      configuration: getConfigurationStep(
+        fields.configuration as { [key: string]: TField }
+      ),
+    };
+
+    setSteps(updatedSteps);
+  }, [fields]);
 
   const handleNextStep = useCallback(() => {
     // setState({ ...state, ...data });
@@ -383,7 +298,7 @@ export const AppsSubmissionForm: React.FC = () => {
     }
   }, [submitResult]);
 
-  const submitJobCallback = (submitData: FormValues) => {
+  const submitJobCallback = (submitData: TFormValues) => {
     const jobData: Omit<TJobBody, 'job'> & { job: TJobSubmit } = {
       operation: 'submitJob' as const,
       licenseType: license.type,

--- a/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
+++ b/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
@@ -1,7 +1,29 @@
-import { z, ZodType } from 'zod';
-import { TTapisApp, TJobKeyValuePair, TJobArgSpec } from '@client/hooks';
+import { z, ZodType, ZodObject, ZodRawShape } from 'zod';
+import {
+  TTapisApp,
+  TJobKeyValuePair,
+  TJobArgSpec,
+  TConfigurationValues,
+  TOutputValues,
+  TTapisSystem,
+  TTapisSystemQueue,
+} from '@client/hooks';
 
-import { checkAndSetDefaultTargetPath, getTargetPathFieldName } from '../utils';
+import {
+  checkAndSetDefaultTargetPath,
+  getTargetPathFieldName,
+  getNodeCountValidation,
+  getCoresPerNodeValidation,
+  getMaxMinutesValidation,
+  getAllocationValidation,
+  getExecSystemsFromApp,
+  getExecSystemFromId,
+  getAppQueueValues,
+  getQueueValueForExecSystem,
+  getQueueMaxMinutes,
+  isAppTypeBATCH,
+  getExecSystemLogicalQueueValidation,
+} from '../utils';
 
 export type TDynamicString = { [dynamic: string]: string | number };
 export type TDynamicField = { [dynamic: string]: TField };
@@ -9,12 +31,21 @@ export type TParameterSetDefaults = {
   [dynamic: string]: TDynamicString;
 };
 export type TFileInputsDefaults = TDynamicString;
+//export type TConfigurationDefaults = TDynamicString;
+//export type TOutputsDefaults = TDynamicString;
 
 export type TFieldOptions = {
   label: string;
   value?: string;
   hidden?: boolean;
   disabled?: boolean;
+};
+
+export type TFormValues = {
+  inputs: TFileInputsDefaults;
+  parameters: TParameterSetDefaults;
+  configuration: TConfigurationValues;
+  outputs: TOutputValues;
 };
 
 export type TField = {
@@ -29,6 +60,13 @@ export type TField = {
   tapisFile?: boolean;
   placeholder?: string;
   readOnly?: boolean;
+};
+
+export type TAppFieldSchema = {
+  inputs: ZodObject<ZodRawShape>;
+  parameters: ZodObject<ZodRawShape>;
+  configuration: ZodObject<ZodRawShape>;
+  outputs: ZodObject<ZodRawShape>;
 };
 
 export type TAppFormSchema = {
@@ -46,9 +84,154 @@ export type TAppFormSchema = {
       [dynamic: string]: ZodType;
     };
   };
+  configuration: {
+    defaults: TConfigurationValues;
+    fields: TDynamicField;
+    schema: { [dynamic: string]: ZodType };
+  };
+  outputs: {
+    defaults: TOutputValues;
+    fields: TDynamicField;
+    schema: { [dynamic: string]: ZodType };
+  };
 };
 
-const FormSchema = (definition: TTapisApp) => {
+// Configuration Schema is pulled out of the default Schema
+// building logic because configuration can change based on queue
+// or exec system changes.
+export const getConfigurationSchema = (
+  definition: TTapisApp,
+  allocations: string[],
+  execSystem: TTapisSystem,
+  queue: TTapisSystemQueue
+) => {
+  const configurationSchema: { [dynamic: string]: ZodType } = {};
+
+  if (definition.jobType === 'BATCH') {
+    configurationSchema['execSystemLogicalQueue'] =
+      getExecSystemLogicalQueueValidation(definition, execSystem);
+    configurationSchema['allocation'] = getAllocationValidation(
+      definition,
+      allocations
+    );
+  }
+
+  configurationSchema['maxMinutes'] = getMaxMinutesValidation(
+    definition,
+    queue
+  );
+  if (!definition.notes.hideNodeCountAndCoresPerNode) {
+    configurationSchema['nodeCount'] = getNodeCountValidation(
+      definition,
+      queue
+    );
+
+    configurationSchema['coresPerNode'] = getCoresPerNodeValidation(
+      definition,
+      queue
+    );
+  }
+  return configurationSchema;
+};
+
+// Pulling configuration fields out of the main schema building
+// to allow for rebuilding of fields based on values changes.
+// Example: description has max minutes value, which is dependent
+// on queue.
+export const getConfigurationFields = (
+  definition: TTapisApp,
+  allocations: string[],
+  executionSystems: TTapisSystem[],
+  queue: TTapisSystemQueue
+) => {
+  const configurationFields: TDynamicField = {};
+
+  const execSystems = getExecSystemsFromApp(
+    definition,
+    executionSystems as TTapisSystem[]
+  );
+
+  const defaultExecSystem = getExecSystemFromId(
+    execSystems,
+    definition.jobAttributes.execSystemId
+  ) as TTapisSystem;
+
+  if (definition.jobType === 'BATCH') {
+    configurationFields['execSystemLogicalQueue'] = {
+      description: 'Select the queue this job will execute on.',
+      label: 'Queue',
+      name: 'configuration.execSystemLogicalQueue',
+      key: 'configuration.execSystemLogicalQueue',
+      required: true,
+      type: 'select',
+      options: getAppQueueValues(
+        definition,
+        execSystems[0].batchLogicalQueues
+      ).map((q) => ({ value: q, label: q })),
+    };
+  }
+
+  configurationFields['maxMinutes'] = {
+    description: `The maximum number of minutes you expect this job to run for. Maximum possible is ${getQueueMaxMinutes(
+      definition,
+      defaultExecSystem,
+      queue.name
+    )} minutes. After this amount of time your job will end. Shorter run times result in shorter queue wait times.`,
+    label: 'Maximum Job Runtime (minutes)',
+    name: 'configuration.maxMinutes',
+    key: 'configuration.maxMinutes',
+    required: true,
+    type: 'number',
+  };
+
+  if (!definition.notes.hideNodeCountAndCoresPerNode) {
+    configurationFields['nodeCount'] = {
+      description: 'Number of requested process nodes for the job.',
+      label: 'Node Count',
+      name: 'configuration.nodeCount',
+      key: 'configuration.nodeCount',
+      required: true,
+      type: 'number',
+    };
+
+    configurationFields['coresPerNode'] = {
+      description:
+        'Number of processors (cores) per node for the job. e.g. a selection of 16 processors per node along with 4 nodes will result in 16 processors on 4 nodes, with 64 processors total.',
+      label: 'Cores Per Node',
+      name: 'configuration.coresPerNode',
+      key: 'configuration.coresPerNode',
+      required: true,
+      type: 'number',
+    };
+  }
+
+  configurationFields['allocation'] = {
+    description:
+      'Select the project allocation you would like to use with this job submission.',
+    label: 'Allocation',
+    name: 'configuration.allocation',
+    key: 'configuration.allocation',
+    required: true,
+    type: 'select',
+    options: [
+      { label: '', hidden: true, disabled: true },
+      ...allocations.sort().map((projectId) => ({
+        value: projectId,
+        label: projectId,
+      })),
+    ],
+  };
+  return configurationFields;
+};
+
+const FormSchema = (
+  definition: TTapisApp,
+  executionSystems: [TTapisSystem],
+  allocations: string[],
+  portalAlloc: string,
+  defaultStorageSystem: TTapisSystem,
+  username: string
+) => {
   const appFields: TAppFormSchema = {
     fileInputs: {
       defaults: {},
@@ -57,6 +240,27 @@ const FormSchema = (definition: TTapisApp) => {
     },
     parameterSet: {
       defaults: {},
+      fields: {},
+      schema: {},
+    },
+    configuration: {
+      defaults: {
+        execSystemId: undefined,
+        execSystemLogicalQueue: '',
+        maxMinutes: 0,
+        nodeCount: 0,
+        coresPerNode: 0,
+        allocation: undefined,
+      },
+      fields: {},
+      schema: {},
+    },
+    outputs: {
+      defaults: {
+        name: '',
+        archiveSystemId: '',
+        archiveSystemDir: '',
+      },
       fields: {},
       schema: {},
     },
@@ -222,6 +426,107 @@ const FormSchema = (definition: TTapisApp) => {
     appFields.fileInputs.defaults[targetPathName] =
       checkAndSetDefaultTargetPath(input.targetPath) as string;
   });
+
+  // Configuration
+  const execSystems = getExecSystemsFromApp(
+    definition,
+    executionSystems as TTapisSystem[]
+  );
+
+  const defaultExecSystem = getExecSystemFromId(
+    execSystems,
+    definition.jobAttributes.execSystemId
+  ) as TTapisSystem;
+
+  const queue = getQueueValueForExecSystem({
+    definition,
+    exec_sys: defaultExecSystem,
+    queue_name: definition.jobAttributes.execSystemLogicalQueue,
+  }) as TTapisSystemQueue;
+
+  if (definition.jobType === 'BATCH') {
+    appFields.configuration.defaults['execSystemLogicalQueue'] = isAppTypeBATCH(
+      definition
+    )
+      ? definition.jobAttributes.execSystemLogicalQueue
+      : '';
+
+    appFields.configuration.defaults['allocation'] = isAppTypeBATCH(definition)
+      ? allocations.includes(portalAlloc)
+        ? portalAlloc
+        : allocations.length === 1
+        ? allocations[0]
+        : ''
+      : '';
+  }
+
+  appFields.configuration.defaults['maxMinutes'] =
+    definition.jobAttributes.maxMinutes;
+
+  if (!definition.notes.hideNodeCountAndCoresPerNode) {
+    appFields.configuration.defaults['nodeCount'] =
+      definition.jobAttributes.nodeCount;
+
+    appFields.configuration.defaults['coresPerNode'] =
+      definition.jobAttributes.coresPerNode;
+  }
+
+  appFields.configuration.schema = getConfigurationSchema(
+    definition,
+    allocations,
+    defaultExecSystem,
+    queue
+  );
+  appFields.configuration.fields = getConfigurationFields(
+    definition,
+    allocations,
+    execSystems,
+    queue
+  );
+
+  // Outputs
+  appFields.outputs.schema['name'] = z.string().max(80);
+  appFields.outputs.defaults['name'] = `${definition.id}-${
+    definition.version
+  }_${new Date().toISOString().split('.')[0]}`;
+  appFields.outputs.fields['name'] = {
+    description: 'A recognizable name for this job.',
+    label: 'Job Name',
+    name: 'outputs.name',
+    key: 'outputs.name',
+    required: true,
+    type: 'text',
+  };
+  appFields.outputs.schema['archiveSystemId'] = z.string().optional();
+  appFields.outputs.defaults['archiveSystemId'] =
+    defaultStorageSystem?.id || definition.jobAttributes.archiveSystemId;
+  appFields.outputs.fields['archiveSystemId'] = {
+    description:
+      'System into which output files are archived after application execution.',
+    label: 'Archive System',
+    name: 'outputs.archiveSystemId',
+    key: 'outputs.archiveSystemId',
+    required: false,
+    type: 'text',
+    placeholder:
+      defaultStorageSystem.id || definition.jobAttributes.archiveSystemId,
+  };
+
+  appFields.outputs.schema['archiveSystemDir'] = z.string().optional();
+  appFields.outputs.defaults[
+    'archiveSystemDir'
+  ] = `${username}/tapis-jobs-archive/\${JobCreateDate}/\${JobName}-\${JobUUID}`;
+  appFields.outputs.fields['archiveSystemDir'] = {
+    description:
+      'Directory into which output files are archived after application execution.',
+    label: 'Archive Directory',
+    name: 'outputs.archiveSystemDir',
+    key: 'outputs.archiveSystemDir',
+    required: false,
+    type: 'text',
+    placeholder: `${username}/tapis-jobs-archive/\${JobCreateDate}/\${JobName}-\${JobUUID}`,
+  };
+
   return appFields;
 };
 

--- a/client/modules/workspace/src/AppsWizard/Steps.tsx
+++ b/client/modules/workspace/src/AppsWizard/Steps.tsx
@@ -1,5 +1,3 @@
-import { TTapisApp, TTapisSystem } from '@client/hooks';
-import { getAppQueueValues } from '../utils';
 import { FormField } from './FormField';
 import { TField } from '../AppsWizard/AppsFormSchema';
 
@@ -33,114 +31,44 @@ export const getParametersStep = (fields: {
   ),
 });
 
-export const getConfigurationStep = (
-  definition: TTapisApp,
-  execSystems: TTapisSystem[],
-  allocations: string[]
-) => ({
+const configurationFieldOrder = [
+  'execSystemLogicalQueue',
+  'maxMinutes',
+  'nodeCount',
+  'coresPerNode',
+  'allocation',
+];
+
+export const getConfigurationStep = (fields: { [key: string]: TField }) => ({
   title: 'Configuration',
   prevPage: 'parameters',
   nextPage: 'outputs',
   content: (
     <>
-      {definition.jobType === 'BATCH' && (
-        <FormField
-          label="Queue"
-          name="configuration.execSystemLogicalQueue"
-          description="Select the queue this job will execute on."
-          type="select"
-          required
-          // TODOv3: Dynamic system queues
-          options={getAppQueueValues(
-            definition,
-            execSystems[0].batchLogicalQueues
-          ).map((q) => ({ value: q, label: q }))}
-        />
-      )}
-      <FormField
-        label="Maximum Job Runtime (minutes)"
-        // description={`The maximum number of minutes you expect this job to run for. Maximum possible is ${getQueueMaxMinutes(
-        //   app,
-        //   state.execSys,
-        //   state.execSystemLogicalQueue
-        // )} minutes. After this amount of time your job will end. Shorter run times result in shorter queue wait times.`}
-        name="configuration.maxMinutes"
-        type="number"
-        required
-      />
-      {!definition.notes.hideNodeCountAndCoresPerNode ? (
-        <>
-          <FormField
-            label="Cores Per Node"
-            description="Number of processors (cores) per node for the job. e.g. a selection of 16 processors per node along with 4 nodes will result in 16 processors on 4 nodes, with 64 processors total."
-            name="configuration.coresPerNode"
-            type="number"
-          />
-          <FormField
-            label="Node Count"
-            description="Number of requested process nodes for the job."
-            name="configuration.nodeCount"
-            type="number"
-          />
-        </>
-      ) : null}
-      {definition.jobType === 'BATCH' && (
-        <FormField
-          label="Allocation"
-          name="configuration.allocation"
-          description="Select the project allocation you would like to use with this job submission."
-          type="select"
-          required
-          options={[
-            { label: '', hidden: true, disabled: true },
-            ...allocations.sort().map((projectId) => ({
-              value: projectId,
-              label: projectId,
-            })),
-          ]}
-        />
-      )}
+      {configurationFieldOrder.map((key) => {
+        const field = fields[key];
+        if (!field) {
+          return null;
+        }
+        return <FormField {...field} />;
+      })}
     </>
   ),
 });
 
-export const getOutputsStep = (
-  definition: TTapisApp,
-  defaultStorageSystemId: string,
-  username: string
-) => ({
+const outputFieldOrder = ['name', 'archiveSystemId', 'archiveSystemDir'];
+export const getOutputsStep = (fields: { [key: string]: TField }) => ({
   title: 'Outputs',
   prevPage: 'configuration',
   content: (
     <>
-      <FormField
-        key="name"
-        label="Job Name"
-        description="A recognizable name for this job."
-        name="outputs.name"
-        type="text"
-        required
-      />
-      {!definition.notes.isInteractive && (
-        <>
-          <FormField
-            label="Archive System"
-            description="System into which output files are archived after application execution."
-            name="outputs.archiveSystemId"
-            type="text"
-            placeholder={
-              defaultStorageSystemId || definition.jobAttributes.archiveSystemId
-            }
-          />
-          <FormField
-            label="Archive Directory"
-            description="Directory into which output files are archived after application execution."
-            name="outputs.archiveSystemDir"
-            type="text"
-            placeholder={`${username}/tapis-jobs-archive/\${JobCreateDate}/\${JobName}-\${JobUUID}`}
-          />
-        </>
-      )}
+      {outputFieldOrder.map((key) => {
+        const field = fields[key];
+        if (!field) {
+          return null;
+        }
+        return <FormField {...field} />;
+      })}
     </>
   ),
 });

--- a/client/modules/workspace/src/utils/apps.ts
+++ b/client/modules/workspace/src/utils/apps.ts
@@ -6,8 +6,9 @@ import {
   TTapisApp,
   TAppResponse,
   TTapisSystemQueue,
-  TConfigurationValues,
 } from '@client/hooks';
+import { TFormValues } from '../AppsWizard/AppsFormSchema';
+import { UseFormSetValue } from 'react-hook-form';
 
 export const TARGET_PATH_FIELD_PREFIX = '_TargetPath_';
 export const DEFAULT_JOB_MAX_MINUTES = 60 * 24;
@@ -187,47 +188,44 @@ export const getCoresPerNodeValidation = (
  */
 export const updateValuesForQueue = (
   execSystems: TTapisSystem[],
-  values: TConfigurationValues
+  execSystemId: string,
+  values: TFormValues,
+  setValue: UseFormSetValue<TFormValues>
 ) => {
-  const exec_sys = getExecSystemFromId(
-    execSystems,
-    values.execSystemId as string
-  );
+  const exec_sys = getExecSystemFromId(execSystems, execSystemId);
   if (!exec_sys) {
-    return values;
+    return;
   }
-  const updatedValues = { ...values };
+
   const queue = getQueueValueForExecSystem({
     exec_sys,
-    queue_name: values.execSystemLogicalQueue,
+    queue_name: values.configuration.execSystemLogicalQueue as string,
   });
-  if (!queue) return values;
+  if (!queue) return;
 
-  if (values.nodeCount < queue.minNodeCount) {
-    updatedValues.nodeCount = queue.minNodeCount;
+  if ((values.configuration.nodeCount as number) < queue.minNodeCount) {
+    setValue('configuration.nodeCount', queue.minNodeCount);
   }
-  if (values.nodeCount > queue.maxNodeCount) {
-    updatedValues.nodeCount = queue.maxNodeCount;
+  if ((values.configuration.nodeCount as number) > queue.maxNodeCount) {
+    setValue('configuration.nodeCount', queue.maxNodeCount);
   }
 
-  if (values.coresPerNode < queue.minCoresPerNode) {
-    updatedValues.coresPerNode = queue.minCoresPerNode;
+  if ((values.configuration.coresPerNode as number) < queue.minCoresPerNode) {
+    setValue('configuration.coresPerNode', queue.minCoresPerNode);
   }
   if (
     queue.maxCoresPerNode !== -1 /* e.g. Frontera rtx/rtx-dev queue */ &&
-    values.coresPerNode > queue.maxCoresPerNode
+    (values.configuration.coresPerNode as number) > queue.maxCoresPerNode
   ) {
-    updatedValues.coresPerNode = queue.maxCoresPerNode;
+    setValue('configuration.coresPerNode', queue.maxCoresPerNode);
   }
 
-  if (values.maxMinutes < queue.minMinutes) {
-    updatedValues.maxMinutes = queue.minMinutes;
+  if ((values.configuration.maxMinutes as number) < queue.minMinutes) {
+    setValue('configuration.maxMinutes', queue.minMinutes);
   }
-  if (values.maxMinutes > queue.maxMinutes) {
-    updatedValues.maxMinutes = queue.maxMinutes;
+  if ((values.configuration.maxMinutes as number) > queue.maxMinutes) {
+    setValue('configuration.maxMinutes', queue.maxMinutes);
   }
-
-  return updatedValues;
 };
 
 /**


### PR DESCRIPTION
## Overview: ##
This PR handles updates to queue value changes specifically.

## PR Status: ##

* [ ] Ready.
* [x] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2749](https://tacc-main.atlassian.net/browse/DES-2749)

## Summary of Changes: ##

* Steps: make configuration and outputs part of the fields, schema and defaults structure that Files and ParameterSets are using. 
    * Because object.entries does not guarantee order, a field ordering is created in Steps for configuration and outputs.
* AppSchema:
    * Includes all categories now.
    * Configuration schema and fields is allowed to be re-created based on queue value changes.
* App submission form:
    * Add states for schema, fields, steps. Schema state is needed to handle dynamic validation. Fields and Steps have description with field specific info.
    * Add watch for queue value.
    * Handle queue value changes.
    
## Testing Steps: ##
1. Go to https://designsafe.dev/rw/workspace/openfoam#!/
2. Go to configuration step and update the queue value. 
3. Watch for node count, core count in both form and description panel on the right. Also, see the description of max minutes has a dynamic value.

A recording which shows how this works: 
(Note demo shows 513 being set as node count. 513 in minimum node count for frontera):

https://github.com/DesignSafe-CI/portal/assets/2568355/8a74cd16-d24a-4a9e-9197-7a326309acc5


## UI Photos:

## Notes: ##: 
*  Right now, value changes are handled via watch. State managegment is used where necessary. Most of this could be more cleaner with Context Provider handling schema, fields. I haven't done enough to make that work. Will keep looking into that. Meanwhile, this PR works with state management.
