### PR TITLE
task/DES-2674 - Versioned Publications aren't being indexed by Google

### DIFF
--- a/designsafe/sitemaps.py
+++ b/designsafe/sitemaps.py
@@ -182,7 +182,9 @@ class ProjectSitemap(sitemaps.Sitemap):
                     'system' : 'designsafe.storage.published',
                     'revision' : 'v' + str(proj['revision']) if 'revision' in proj else ''
                 }
-                projPath.append('{root}public/{system}/{project}{revision}'.format(**subpath))
+                # making sure that only the most recent revision is included in the sitemap
+                if not any(subpath['project'] in s for s in projPath): 
+                    projPath.append('{root}public/{system}/{project}{revision}'.format(**subpath))
             if len(projects['listing']) < 200:
                 break
             count += 200

--- a/designsafe/sitemaps.py
+++ b/designsafe/sitemaps.py
@@ -179,9 +179,10 @@ class ProjectSitemap(sitemaps.Sitemap):
                 subpath = {
                     'root' : reverse('designsafe_data:data_depot'),
                     'project' : proj['project']['value']['projectId'],
-                    'system' : 'designsafe.storage.published'
+                    'system' : 'designsafe.storage.published',
+                    'revision' : 'v' + str(proj['revision']) if 'revision' in proj else ''
                 }
-                projPath.append('{root}public/{system}/{project}'.format(**subpath))
+                projPath.append('{root}public/{system}/{project}{revision}'.format(**subpath))
             if len(projects['listing']) < 200:
                 break
             count += 200


### PR DESCRIPTION
## Overview: ##
Publications that have been versioned aren’t being indexed, due to the way we present metadata and build the URLs. We add v2 , v3, vX to a URL that has been versioned, but the canonical URL that is on the page doesn't include that versioning.  This change now includes only the latest revisions of versioned publications.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2674](https://tacc-main.atlassian.net/browse/DES-2674)

## Summary of Changes: ##
Now includes revision number in sitemap for publications that have been versioned, and only includes the latest revision.

## Testing Steps: ##
1. While on VPN, go to https://designsafe.dev/sitemap.xml
2. Check to make sure that there are some URLs included that end in `v2`, `v3`,`v4`, etc.
3. Make sure that none of these also have other versions included.

## UI Photos:

## Notes: ##
