### PR TITLE
Bug/DES-2786: Use key to make sure app instance is created on navigation

### DIFF
--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -181,6 +181,7 @@ export const AppsSubmissionForm: React.FC = () => {
     configuration: getConfigurationStep(configuration.fields),
     outputs: getOutputsStep(outputs.fields),
   });
+  const [current, setCurrent] = useState('inputs');
 
   useEffect(() => {
     reset(initialValues);
@@ -190,9 +191,8 @@ export const AppsSubmissionForm: React.FC = () => {
       configuration: getConfigurationStep(configuration.fields),
       outputs: getOutputsStep(outputs.fields),
     });
+    setCurrent('inputs');
   }, [initialValues]);
-
-  const [current, setCurrent] = useState('inputs');
 
   const [fields, setFields] = useState<{
     [dynamic: string]: {

--- a/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
+++ b/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
@@ -246,7 +246,6 @@ const FormSchema = (
     },
     configuration: {
       defaults: {
-        execSystemId: undefined,
         execSystemLogicalQueue: '',
         maxMinutes: 0,
         nodeCount: 0,

--- a/client/src/workspace/layouts/AppsViewLayout.tsx
+++ b/client/src/workspace/layouts/AppsViewLayout.tsx
@@ -7,9 +7,10 @@ import { useAppsListing } from '@client/hooks';
 import parse from 'html-react-parser';
 
 export const AppsViewLayout: React.FC = () => {
-  const { appId } = useGetAppParams();
+  const { appId, appVersion } = useGetAppParams();
   const { data } = useAppsListing();
   const htmlApp = data?.htmlDefinitions[appId];
+  const key = `${appId}-${appVersion}`;
   return (
     <>
       {htmlApp ? (
@@ -25,7 +26,7 @@ export const AppsViewLayout: React.FC = () => {
           }
         >
           {/* <AppFormProvider> */}
-          <AppsSubmissionForm />
+          <AppsSubmissionForm key={key} />
           {/* </AppFormProvider> */}
         </Suspense>
       )}


### PR DESCRIPTION
## Overview: ##
Use key to make new instance of component on navigation.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2786](https://tacc-main.atlassian.net/browse/DES-2786)
* [DES-2782](https://tacc-main.atlassian.net/browse/DES-2782)

## Summary of Changes: ##
1. Add key property to App Form
2. set initial step state in additional to re-initialization of steps.
3. Remove unnecessary execSystemId initialization

## Testing Steps: ##
1. Go to OpenFoam. Click Continue
2. Go to MPM, it has default file set, click continue - Should not see any error
3. Go back to OpenFoam, it should be in first step.
4. More testing steps in  [DES-2786](https://tacc-main.atlassian.net/browse/DES-2786)

## UI Photos:

## Notes: ##
