### PR TITLE
Bugs: App Form step and summary rendering fixes

### DIFF
--- a/client/modules/_hooks/src/workspace/usePostJobs.ts
+++ b/client/modules/_hooks/src/workspace/usePostJobs.ts
@@ -13,10 +13,10 @@ export type TParameterSetSubmit = {
 
 export type TConfigurationValues = {
   execSystemId?: string;
-  execSystemLogicalQueue: string;
+  execSystemLogicalQueue?: string;
   maxMinutes: number;
-  nodeCount: number;
-  coresPerNode: number;
+  nodeCount?: number;
+  coresPerNode?: number;
   allocation?: string;
 };
 

--- a/client/modules/workspace/src/AppsSubmissionDetails/AppsSubmissionDetails.tsx
+++ b/client/modules/workspace/src/AppsSubmissionDetails/AppsSubmissionDetails.tsx
@@ -123,8 +123,13 @@ export const AppsSubmissionDetails: React.FC<{
   };
 
   const getItems = (values: FieldValues) => {
-    const items: DescriptionsProps['items'] = Object.entries(values).map(
-      ([key, value], index) => ({
+    // Filter out empty items. Example: app with no inputs
+    const items: DescriptionsProps['items'] = Object.entries(values)
+      .filter(
+        ([_, value]) =>
+          typeof value !== 'object' || Object.keys(value).length > 0
+      )
+      .map(([key, value], index) => ({
         key: key,
         label: (
           <Flex
@@ -154,8 +159,7 @@ export const AppsSubmissionDetails: React.FC<{
           border: '0',
           backgroundColor: 'inherit',
         },
-      })
-    );
+      }));
     return items;
   };
 

--- a/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
+++ b/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
@@ -170,6 +170,22 @@ export const getConfigurationFields = (
         execSystems[0].batchLogicalQueues
       ).map((q) => ({ value: q, label: q })),
     };
+    configurationFields['allocation'] = {
+      description:
+        'Select the project allocation you would like to use with this job submission.',
+      label: 'Allocation',
+      name: 'configuration.allocation',
+      key: 'configuration.allocation',
+      required: true,
+      type: 'select',
+      options: [
+        { label: '', hidden: true, disabled: true },
+        ...allocations.sort().map((projectId) => ({
+          value: projectId,
+          label: projectId,
+        })),
+      ],
+    };
   }
 
   configurationFields['maxMinutes'] = {
@@ -206,22 +222,6 @@ export const getConfigurationFields = (
     };
   }
 
-  configurationFields['allocation'] = {
-    description:
-      'Select the project allocation you would like to use with this job submission.',
-    label: 'Allocation',
-    name: 'configuration.allocation',
-    key: 'configuration.allocation',
-    required: true,
-    type: 'select',
-    options: [
-      { label: '', hidden: true, disabled: true },
-      ...allocations.sort().map((projectId) => ({
-        value: projectId,
-        label: projectId,
-      })),
-    ],
-  };
   return configurationFields;
 };
 
@@ -246,11 +246,7 @@ const FormSchema = (
     },
     configuration: {
       defaults: {
-        execSystemLogicalQueue: '',
         maxMinutes: 0,
-        nodeCount: 0,
-        coresPerNode: 0,
-        allocation: undefined,
       },
       fields: {},
       schema: {},

--- a/client/modules/workspace/src/AppsWizard/Steps.tsx
+++ b/client/modules/workspace/src/AppsWizard/Steps.tsx
@@ -1,9 +1,10 @@
 import { FormField } from './FormField';
 import { TField } from '../AppsWizard/AppsFormSchema';
 
+export const stepKeys = ['inputs', 'parameters', 'configuration', 'outputs'];
+
 export const getInputsStep = (fields: { [dynamic: string]: TField }) => ({
   title: 'Inputs',
-  nextPage: 'parameters',
   content: (
     <>
       {Object.values(fields).map((field) => {
@@ -18,8 +19,6 @@ export const getParametersStep = (fields: {
   [dynamic: string]: { [dynamic: string]: TField };
 }) => ({
   title: 'Parameters',
-  prevPage: 'inputs',
-  nextPage: 'configuration',
   content: (
     <>
       {Object.values(fields).map((parameterValue) => {
@@ -41,8 +40,6 @@ const configurationFieldOrder = [
 
 export const getConfigurationStep = (fields: { [key: string]: TField }) => ({
   title: 'Configuration',
-  prevPage: 'parameters',
-  nextPage: 'outputs',
   content: (
     <>
       {configurationFieldOrder.map((key) => {
@@ -59,7 +56,6 @@ export const getConfigurationStep = (fields: { [key: string]: TField }) => ({
 const outputFieldOrder = ['name', 'archiveSystemId', 'archiveSystemDir'];
 export const getOutputsStep = (fields: { [key: string]: TField }) => ({
   title: 'Outputs',
-  prevPage: 'configuration',
   content: (
     <>
       {outputFieldOrder.map((key) => {


### PR DESCRIPTION
## Overview: ##
Various app form bugs related to steps, summary panel and express app usage.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2781](https://tacc-main.atlassian.net/browse/DES-2781)
* [DES-2787](https://tacc-main.atlassian.net/browse/DES-2787)
* [DES-2788](https://tacc-main.atlassian.net/browse/DES-2788)

## Summary of Changes: ##
1. Shows steps that are available. U
2. Adjust step back and continue according to availability
3. Do not show node and core counts in summary/details if they are not visible in form. Summary panel has edit button, which might give a false indication that the fields are editable
4. Do not show allocation if it is not applicable.
5. Make node, core counts as optional in job post.
6. Summary panel should not show main category if they are empty.


## Testing Steps: ##
These different apps, test the variations:

1. All steps are available: https://designsafe.dev/rw/workspace/mpm?appVersion=1.1.0
2. Next step for inputs is configuration: https://designsafe.dev/rw/workspace/paraview?appVersion=5.10.0
3. No inputs or configuration: https://designsafe.dev/rw/workspace/qgis?appVersion=3.30
4. No inputs or configuration. And no allocation, core or node count: https://designsafe.dev/rw/workspace/qgis_express?appVersion=3.36

## UI Photos:
no Input or parameter sets:
![Screenshot 2024-05-21 at 3 06 08 PM](https://github.com/DesignSafe-CI/portal/assets/2568355/e8fc1a4a-901e-4766-bb2a-44e72e23b94f)

no parameter set, but has input:
![Screenshot 2024-05-21 at 3 32 28 PM](https://github.com/DesignSafe-CI/portal/assets/2568355/12672e8e-9a34-4860-b258-607b40658706)

express app:
![Screenshot 2024-05-21 at 3 05 48 PM](https://github.com/DesignSafe-CI/portal/assets/2568355/a7157fa6-cdc2-4766-87a9-23684b540488)

## Notes: ##
I found OpenSees Express app that is impacted by validations. I'm working on that bug [DES-2789](https://tacc-main.atlassian.net/browse/DES-2789). Note zod string validation needs to be adjusted to hit this bug, which will also be part of the fix. So, not truly blocking at this moment.