### PR TITLE
Task/DES-2629 Use portal names to build system list in select modal

### DIFF
--- a/client/modules/_hooks/src/systems/types.ts
+++ b/client/modules/_hooks/src/systems/types.ts
@@ -61,6 +61,7 @@ export type TTapisSystem = {
     label?: string;
     keyservice?: boolean;
     isMyData?: boolean;
+    portalNames: string[];
   };
   importRefId?: string;
   uuid: string;

--- a/client/modules/workspace/src/SelectModal/SelectModal.tsx
+++ b/client/modules/workspace/src/SelectModal/SelectModal.tsx
@@ -21,6 +21,7 @@ type TModalChildren = (props: {
 }) => React.ReactElement;
 
 const api = 'tapis';
+const portalName = 'DesignSafe';
 const HeaderTitle: React.FC<{
   api: string;
   system: string;
@@ -109,15 +110,20 @@ export const SelectModal: React.FC<{
   const {
     data: { storageSystems, defaultStorageSystem },
   } = useGetSystems();
-  // only pick up enabled systems with label
+  // only pick up enabled systems in this portal
   const includedSystems = storageSystems.filter(
-    (s) => s.enabled && s.notes?.label
+    (s) => s.enabled && s.notes?.portalNames?.includes(portalName)
   );
 
-  const systemOptions = includedSystems.map((system) => ({
-    label: system.notes.label,
-    value: system.id,
-  }));
+  // Sort - so mydata is shown first.
+  const systemOptions = includedSystems
+    .sort((a, b) => {
+      return (a.notes?.isMyData ? 0 : 1) - (b.notes?.isMyData ? 0 : 1);
+    })
+    .map((system) => ({
+      label: system.notes.label,
+      value: system.id,
+    }));
   systemOptions.push({ label: 'My Projects', value: 'myprojects' });
 
   const defaultParams = useMemo(


### PR DESCRIPTION
## Overview: ##
Use portal names to build system list in select modal
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2629](https://tacc-main.atlassian.net/browse/DES-2629)

## Summary of Changes: ##
1. System definition has notes section indicating portals applicable. Use that info.
2. Sort the list by private then public (I think other places in portal have similar listing order).

## Testing Steps: ##
 
![Screenshot 2024-05-23 at 3 11 42 PM](https://github.com/DesignSafe-CI/portal/assets/2568355/65abf355-8654-4042-8dd3-78149275ea3a)

## UI Photos:

## Notes: ##
