### PR TITLE
Bugs/DES-2789 Only validate current step on continue

### DIFF
--- a/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
+++ b/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
@@ -318,7 +318,11 @@ const FormSchema = (
           );
         } else {
           field.type = 'text';
-          parameterSetSchema[field.label] = z.string();
+          // Need to do this for non empty strings. Zod does not handle
+          // string with 0 length even with required property.
+          parameterSetSchema[field.label] = z
+            .string()
+            .refine((data) => data.trim() !== '');
         }
 
         if (!field.required) {

--- a/client/modules/workspace/src/AppsWizard/AppsWizard.tsx
+++ b/client/modules/workspace/src/AppsWizard/AppsWizard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Layout, Flex } from 'antd';
-import { useFormContext, SubmitHandler, FieldValues } from 'react-hook-form';
+import { SubmitHandler, FieldValues } from 'react-hook-form';
 import { SecondaryButton } from '@client/common-components';
 
 // import styles from './AppsWizard.module.css';
@@ -59,8 +59,6 @@ export const AppsWizard: React.FC<{
   handlePreviousStep: SubmitHandler<FieldValues>;
   handleNextStep: SubmitHandler<FieldValues>;
 }> = ({ step, handlePreviousStep, handleNextStep }) => {
-  const { handleSubmit } = useFormContext();
-
   const contentStyle = {
     lineHeight: '260px',
     textAlign: 'center' as const,
@@ -93,9 +91,7 @@ export const AppsWizard: React.FC<{
                   margin: '0 8px',
                 }}
                 disabled={!step.prevPage}
-                onClick={handleSubmit(handlePreviousStep, (data) => {
-                  console.log('error prev data', data);
-                })}
+                onClick={handlePreviousStep}
               >
                 Back
               </SecondaryButton>
@@ -105,9 +101,7 @@ export const AppsWizard: React.FC<{
                 }}
                 htmlType="submit"
                 disabled={!step.nextPage}
-                onClick={handleSubmit(handleNextStep, (data) => {
-                  console.log('error next data', data);
-                })}
+                onClick={handleNextStep}
               >
                 Continue
               </SecondaryButton>


### PR DESCRIPTION
## Overview: ##
Only validate current step on continue. Previous behavior was that it validated all the fields in the form.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2789](https://tacc-main.atlassian.net/browse/DES-2789)

## Summary of Changes: ##
* Remove association of prev and next button onclick to form submit handler. This causes validation of the entire form to trigger. 
    * An alternative approach is to write custom zod resolver, but that complicates things for the final submit button. This seemed to be a simpler solution.
* Use methods#trigger to trigger validation on the fields in the current step.
* z.string() does not check for strings with length 0 in zod (when compared with Yup). Adjust the validation.


## Testing Steps: ##
1. Go to app: https://designsafe.dev/rw/workspace/opensees-express?appVersion=3.6.0
2. Hit continue and it should allow the user to continue to next steps. Previous behavior was to block there and the console log showed error message.

![Screenshot 2024-05-24 at 12 25 57 PM](https://github.com/DesignSafe-CI/portal/assets/2568355/f923bba3-f5e3-4b5d-a5eb-c39ea0e04c59)


## UI Photos:

## Notes: ##
