### PR TITLE
feat: DES-2806 cms breadcrumbs

### DIFF
--- a/designsafe/static/styles/_mixins/_link.scss
+++ b/designsafe/static/styles/_mixins/_link.scss
@@ -1,0 +1,6 @@
+@mixin link {
+  text-underline-offset: 0.2em;
+}
+@mixin link--active {
+  text-decoration-style: dotted;
+}

--- a/designsafe/static/styles/base.scss
+++ b/designsafe/static/styles/base.scss
@@ -1,3 +1,16 @@
+/* ELEMENTS */
+
+@import '_mixins/link';
+
+a {
+  @include link;
+}
+a:active {
+  @include link--active;
+}
+
+/* MODULES */
+
 .row-flex {
     display: flex;
     flex-direction: row;

--- a/designsafe/static/styles/bootstrap3.breadcrumb.css
+++ b/designsafe/static/styles/bootstrap3.breadcrumb.css
@@ -1,4 +1,4 @@
-@import url("https://cdn.jsdelivr.net/gh/TACC/Core-Styles@b3d1227/dist/components/bootstrap3.breadcrumb.css");
+@import url("https://cdn.jsdelivr.net/gh/TACC/Core-Styles@v2.27.0/dist/components/bootstrap3.breadcrumb.css");
 
 /* To negate `.navbar-ds` padding bottom */
 /* https://github.com/DesignSafe-CI/portal/blob/v7.0.0--tapis-v3-20240607/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css#L4769 */

--- a/designsafe/static/styles/bootstrap3.breadcrumb.css
+++ b/designsafe/static/styles/bootstrap3.breadcrumb.css
@@ -2,9 +2,12 @@
 
 /* To negate `.navbar-ds` padding bottom */
 /* https://github.com/DesignSafe-CI/portal/blob/v7.0.0--tapis-v3-20240607/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css#L4769 */
+/* NOTE: Use only after Workspace breadcrumbs are updated to match design */
+/*
 div:has(.navbar-ds) + main .breadcrumb {
   margin-top: -20px;
 }
+*/
 
 /* To "disable" ineffectual links */
 .breadcrumb a:not([href]) {
@@ -21,6 +24,9 @@ div:has(.navbar-ds) + main .breadcrumb {
 .breadcrumb {
   /* https://github.com/DesignSafe-CI/portal/blob/v7.0.0--tapis-v3-20240607/client/modules/workspace/src/AppsBreadcrumb/AppsBreadcrumb.module.css#L3 */
   font-size: 1.6rem;
+}
+.breadcrumb:where(.breadcrumb-major) {
+  padding-top: unset;
 }
 .breadcrumb:where(ol,ul),
 .breadcrumb:where(.breadcrumb-major) li:last-child {

--- a/designsafe/static/styles/bootstrap3.breadcrumb.css
+++ b/designsafe/static/styles/bootstrap3.breadcrumb.css
@@ -40,12 +40,12 @@ div:has(.navbar-ds) + main .breadcrumb {
   padding-top: unset;
 }
 .breadcrumb:where(ol,ul),
-.breadcrumb:where(.breadcrumb-major) li:last-child {
+.breadcrumb:where(.breadcrumb-major) .breadcrumb-item:last-child {
   font-weight: 400;
 }
-.breadcrumb li:last-child {
+.breadcrumb-item:last-child {
   color: var(--text-color-dark);
 }
-.breadcrumb li + li:last-child::before {
+.breadcrumb-item + .breadcrumb-item:last-child::before {
   color: var(--text-color);
 }

--- a/designsafe/static/styles/bootstrap3.breadcrumb.css
+++ b/designsafe/static/styles/bootstrap3.breadcrumb.css
@@ -19,6 +19,12 @@ div:has(.navbar-ds) + main .breadcrumb {
   color: unset;
 }
 
+/* To improve focus UI */
+.breadcrumb a:focus {
+  /* https://github.com/DesignSafe-CI/portal/blob/v7.0.0--tapis-v3-20240607/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css#L1134 */
+  outline-offset: 2px;
+}
+
 /* To match workspace breadcrumbs until they are updated to match design */
 /* NOTE: Workspace breadcrumbs use Ant not Bootstrap */
 .breadcrumb {

--- a/designsafe/static/styles/bootstrap3.breadcrumb.css
+++ b/designsafe/static/styles/bootstrap3.breadcrumb.css
@@ -1,4 +1,4 @@
-@import url("https://cdn.jsdelivr.net/gh/TACC/Core-Styles@09c4b4f/dist/components/bootstrap3.breadcrumb.css");
+@import url("https://cdn.jsdelivr.net/gh/TACC/Core-Styles@b3d1227/dist/components/bootstrap3.breadcrumb.css");
 
 /* To negate `.navbar-ds` padding bottom */
 /* https://github.com/DesignSafe-CI/portal/blob/v7.0.0--tapis-v3-20240607/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css#L4769 */

--- a/designsafe/static/styles/bootstrap3.breadcrumb.css
+++ b/designsafe/static/styles/bootstrap3.breadcrumb.css
@@ -28,6 +28,11 @@ div:has(.navbar-ds) + main .breadcrumb {
 /* To match workspace breadcrumbs until they are updated to match design */
 /* NOTE: Workspace breadcrumbs use Ant not Bootstrap */
 .breadcrumb {
+  --text-color: rgba(0, 0, 0, 0.45);
+  --text-color-dark: rgba(0, 0, 0, 0.88);
+
+  color: var(--text-color);
+
   /* https://github.com/DesignSafe-CI/portal/blob/v7.0.0--tapis-v3-20240607/client/modules/workspace/src/AppsBreadcrumb/AppsBreadcrumb.module.css#L3 */
   font-size: 1.6rem;
 }
@@ -37,4 +42,10 @@ div:has(.navbar-ds) + main .breadcrumb {
 .breadcrumb:where(ol,ul),
 .breadcrumb:where(.breadcrumb-major) li:last-child {
   font-weight: 400;
+}
+.breadcrumb li:last-child {
+  color: var(--text-color-dark);
+}
+.breadcrumb li + li:last-child::before {
+  color: var(--text-color);
 }

--- a/designsafe/static/styles/bootstrap3.breadcrumb.css
+++ b/designsafe/static/styles/bootstrap3.breadcrumb.css
@@ -1,0 +1,24 @@
+@import url("https://cdn.jsdelivr.net/gh/TACC/Core-Styles@feat/DES-2806-breadcrumbs-sans-class-s-prefix/dist/components/bootstrap3.breadcrumb.css");
+
+/* To negate `.navbar-ds` padding bottom */
+/* https://github.com/DesignSafe-CI/portal/blob/v7.0.0--tapis-v3-20240607/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css#L4769 */
+div:has(.navbar-ds) + main .breadcrumb {
+  margin-top: -20px;
+}
+
+/* To "disable" ineffectual links */
+.breadcrumb a:not([href]) {
+  /* https://github.com/TACC/Core-Styles/blob/v2.26.0/dist/elements/links.css */
+  pointer-events: none;
+
+  /* https://github.com/TACC/tup-ui/blob/v1.1.10/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/trumps/s-breadcrumbs.css */
+  opacity: 0.75;
+  color: unset;
+}
+
+/* To match workspace breadcrumb font-size */
+/* NOTE: Workspace breadcrumbs use Ant not Bootstrap */
+.breadcrumb {
+  /* https://github.com/DesignSafe-CI/portal/blob/v7.0.0--tapis-v3-20240607/client/modules/workspace/src/AppsBreadcrumb/AppsBreadcrumb.module.css#L3 */
+  font-size: 1.6rem;
+}

--- a/designsafe/static/styles/bootstrap3.breadcrumb.css
+++ b/designsafe/static/styles/bootstrap3.breadcrumb.css
@@ -1,4 +1,4 @@
-@import url("https://cdn.jsdelivr.net/gh/TACC/Core-Styles@feat/DES-2806-breadcrumbs-sans-class-s-prefix/dist/components/bootstrap3.breadcrumb.css");
+@import url("https://cdn.jsdelivr.net/gh/TACC/Core-Styles@09c4b4f/dist/components/bootstrap3.breadcrumb.css");
 
 /* To negate `.navbar-ds` padding bottom */
 /* https://github.com/DesignSafe-CI/portal/blob/v7.0.0--tapis-v3-20240607/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css#L4769 */
@@ -16,9 +16,13 @@ div:has(.navbar-ds) + main .breadcrumb {
   color: unset;
 }
 
-/* To match workspace breadcrumb font-size */
+/* To match workspace breadcrumbs until they are updated to match design */
 /* NOTE: Workspace breadcrumbs use Ant not Bootstrap */
 .breadcrumb {
   /* https://github.com/DesignSafe-CI/portal/blob/v7.0.0--tapis-v3-20240607/client/modules/workspace/src/AppsBreadcrumb/AppsBreadcrumb.module.css#L3 */
   font-size: 1.6rem;
+}
+.breadcrumb:where(ol,ul),
+.breadcrumb:where(.breadcrumb-major) li:last-child {
+  font-weight: 400;
 }

--- a/designsafe/static/styles/bootstrap3.breadcrumb.css
+++ b/designsafe/static/styles/bootstrap3.breadcrumb.css
@@ -40,12 +40,12 @@ div:has(.navbar-ds) + main .breadcrumb {
   padding-top: unset;
 }
 .breadcrumb:where(ol,ul),
-.breadcrumb:where(.breadcrumb-major) .breadcrumb-item:last-child {
+.breadcrumb:where(.breadcrumb-major) li:last-child {
   font-weight: 400;
 }
-.breadcrumb-item:last-child {
+.breadcrumb li:last-child {
   color: var(--text-color-dark);
 }
-.breadcrumb-item + .breadcrumb-item:last-child::before {
+.breadcrumb li + li:last-child::before {
   color: var(--text-color);
 }

--- a/designsafe/static/styles/main.css
+++ b/designsafe/static/styles/main.css
@@ -1,7 +1,4 @@
-:root {
-  --ds-accent-color: #47a59d;
-  --ds-active-color: #337AB7;
-}
+@import url("./variables.css");
 
 body, html {
   background-color: #ffffff;

--- a/designsafe/static/styles/variables.css
+++ b/designsafe/static/styles/variables.css
@@ -17,7 +17,7 @@
 
   /* Font */
   /* TODO: Add missing variables after determining values */
-  --global-font-size--x-small: 1.2rem;
+  --global-font-size--x-small: 1.4rem;
   --global-font-weight--medium: 500;
 
   /* Common */

--- a/designsafe/static/styles/variables.css
+++ b/designsafe/static/styles/variables.css
@@ -15,11 +15,6 @@
   --global-space--above-breadcrumbs: 35px;
   --global-space--under-breadcrumbs: 20px;
 
-  /* Font */
-  /* TODO: Add missing variables after determining values */
-  --global-font-size--x-small: 1.4rem;
-  --global-font-weight--medium: 500;
-
   /* Common */
   --global-color-background--app: var(--global-color-primary--xx-light);
 }

--- a/designsafe/static/styles/variables.css
+++ b/designsafe/static/styles/variables.css
@@ -1,0 +1,25 @@
+:root {
+  --ds-accent-color: #47a59d;
+  --ds-active-color: #337AB7;
+
+  /* Primary (Text, Layout) */
+  --global-color-primary--xx-light: #ffffff;
+  --global-color-primary--x-light: #f4f4f4;
+  --global-color-primary--light: #c6c6c6;
+  --global-color-primary--normal: #afafaf;
+  --global-color-primary--dark: #707070;
+  --global-color-primary--x-dark: #484848; /* ¹ */
+  --global-color-primary--xx-dark: #222222; /* ¹ */
+
+  /* Space */
+  --global-space--above-breadcrumbs: 35px;
+  --global-space--under-breadcrumbs: 20px;
+
+  /* Font */
+  /* TODO: Add missing variables after determining values */
+  --global-font-size--x-small: 1.2rem;
+  --global-font-weight--medium: 500;
+
+  /* Common */
+  --global-color-background--app: var(--global-color-primary--xx-light);
+}

--- a/designsafe/templates/cms_breadcrumbs.html
+++ b/designsafe/templates/cms_breadcrumbs.html
@@ -18,6 +18,10 @@
     opacity: 0.75;
     color: unset;
   }
+  .breadcrumb {
+    {# https://github.com/DesignSafe-CI/portal/blob/v7.0.0--tapis-v3-20240607/client/modules/workspace/src/AppsBreadcrumb/AppsBreadcrumb.module.css#L3 #}
+    font-size: 1.6rem;
+  }
 </style>
 {% endaddtoblock %}
 

--- a/designsafe/templates/cms_breadcrumbs.html
+++ b/designsafe/templates/cms_breadcrumbs.html
@@ -3,37 +3,32 @@
 
 {% addtoblock "css" %}
 <style id="cms_breadcrumbs">
-  @import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@v2.26.0/dist/trumps/s-breadcrumbs.css");
+  @import url("https://cdn.jsdelivr.net/gh/TACC/Core-Styles@feat/DES-2806-breadcrumbs-sans-class-s-prefix/dist/components/bootstrap3.breadcrumb.css");
 
   {# To negate `.navbar-ds` padding bottom #}
   {# https://github.com/DesignSafe-CI/portal/blob/8048436/designsafe/static/styles/main.css#L168 #}
-  div:has(.navbar-ds) + main > .s-breadcrumbs {
+  div:has(.navbar-ds) + main .breadcrumb {
     margin-top: -2.5em;
   }
-  {# https://github.com/TACC/Core-Styles/blob/v2.26.0/dist/elements/links.css #}
-  .s-breadcrumbs a:not([href]) {
+  .breadcrumb a:not([href]) {
+    {# https://github.com/TACC/Core-Styles/blob/v2.26.0/dist/elements/links.css #}
     pointer-events: none;
-  }
-  {# https://github.com/TACC/tup-ui/blob/v1.1.10/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/trumps/s-breadcrumbs.css #}
-  .s-breadcrumbs:is(nav) a:not([href]) {
+
+    {# https://github.com/TACC/tup-ui/blob/v1.1.10/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/trumps/s-breadcrumbs.css #}
     opacity: 0.75;
     color: unset;
   }
 </style>
 {% endaddtoblock %}
 
-<nav class="s-breadcrumbs  {{className}}" id="cms-breadcrumbs">
-
-  {# To support structured data, item* attributes are used #}
-  {# SEE: https://confluence.tacc.utexas.edu/x/5yMFDg #}
-  <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+<nav class="{{className}}" id="cms-breadcrumbs">
+  <ol class="breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">
 
     {# To include pages marked to not show in menu, attributes are added #}
     {# SEE: https://docs.django-cms.org/en/release-3.6.x/reference/navigation.html#show-breadcrumb #}
     {% show_breadcrumb 0 "menu/breadcrumb.html" 0 %}
 
   </ol>
-
 </nav>
 
 {# To disable 2nd-level breadcrumb #}

--- a/designsafe/templates/cms_breadcrumbs.html
+++ b/designsafe/templates/cms_breadcrumbs.html
@@ -6,9 +6,9 @@
   @import url("https://cdn.jsdelivr.net/gh/TACC/Core-Styles@feat/DES-2806-breadcrumbs-sans-class-s-prefix/dist/components/bootstrap3.breadcrumb.css");
 
   {# To negate `.navbar-ds` padding bottom #}
-  {# https://github.com/DesignSafe-CI/portal/blob/8048436/designsafe/static/styles/main.css#L168 #}
+  {# https://github.com/DesignSafe-CI/portal/blob/v7.0.0--tapis-v3-20240607/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css#L4769 #}
   div:has(.navbar-ds) + main .breadcrumb {
-    margin-top: -2.5em;
+    margin-top: -20px;
   }
   .breadcrumb a:not([href]) {
     {# https://github.com/TACC/Core-Styles/blob/v2.26.0/dist/elements/links.css #}

--- a/designsafe/templates/cms_breadcrumbs.html
+++ b/designsafe/templates/cms_breadcrumbs.html
@@ -1,7 +1,8 @@
 {# @var className #}
-{% load menu_tags %}
+{% load menu_tags sekizai_tags %}
 
-<style>
+{% addtoblock "css" %}
+<style id="cms_breadcrumbs">
   @import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@v2.26.0/dist/trumps/s-breadcrumbs.css");
 
   {# To negate `.navbar-ds` padding bottom #}
@@ -19,6 +20,8 @@
     color: unset;
   }
 </style>
+{% endaddtoblock %}
+
 <nav class="s-breadcrumbs  {{className}}" id="cms-breadcrumbs">
 
   {# To support structured data, item* attributes are used #}
@@ -32,9 +35,11 @@
   </ol>
 
 </nav>
+
+{# To disable 2nd-level breadcrumb #}
+{# NOTE: Not using `block`, so markup is loaded first #}
+{# NOTE: Not using `block` nor `type="module"`, so effect is quicker #}
 <script>
-  {# To disable 2nd-level breadcrumb #}
-  {# NOTE: Not using module, so effect is quicker (and code is minimal) #}
   {# FAQ: Attempts to do this server-side failed cuz useful props are blank #}
   {# https://docs.django-cms.org/en/release-3.11.x/reference/navigation.html#properties-of-navigation-nodes-in-templates #}
   document

--- a/designsafe/templates/cms_breadcrumbs.html
+++ b/designsafe/templates/cms_breadcrumbs.html
@@ -3,16 +3,20 @@
 
 <style>
   @import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@v2.26.0/dist/trumps/s-breadcrumbs.css");
-  @import url("https://cdn.jsdelivr.net/gh/TACC/tup-ui@v1.1.10/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/trumps/s-breadcrumbs.css");
 
   {# To negate `.navbar-ds` padding bottom #}
   {# https://github.com/DesignSafe-CI/portal/blob/8048436/designsafe/static/styles/main.css#L168 #}
   div:has(.navbar-ds) + main > .s-breadcrumbs {
     margin-top: -2.5em;
   }
-  {# https://cdn.jsdelivr.net/gh/TACC/core-styles@v2.26.0/dist/elements/links.css #}
+  {# https://github.com/TACC/Core-Styles/blob/v2.26.0/dist/elements/links.css #}
   .s-breadcrumbs a:not([href]) {
     pointer-events: none;
+  }
+  {# https://github.com/TACC/tup-ui/blob/v1.1.10/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/trumps/s-breadcrumbs.css #}
+  .s-breadcrumbs:is(nav) a:not([href]) {
+    opacity: 0.75;
+    color: unset;
   }
 </style>
 <nav class="s-breadcrumbs  {{className}}" id="cms-breadcrumbs">

--- a/designsafe/templates/cms_breadcrumbs.html
+++ b/designsafe/templates/cms_breadcrumbs.html
@@ -1,0 +1,35 @@
+{# @var className #}
+{% load menu_tags %}
+
+<style>
+  @import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@v2.26.0/dist/trumps/s-breadcrumbs.css");
+  @import url("https://cdn.jsdelivr.net/gh/TACC/tup-ui@v1.1.10/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/trumps/s-breadcrumbs.css");
+
+  {# https://cdn.jsdelivr.net/gh/TACC/core-styles@v2.26.0/dist/elements/links.css #}
+  .s-breadcrumbs a:not([href]) {
+    pointer-events: none;
+  }
+</style>
+<nav class="s-breadcrumbs  {{className}}" id="cms-breadcrumbs">
+
+  {# To support structured data, item* attributes are used #}
+  {# SEE: https://confluence.tacc.utexas.edu/x/5yMFDg #}
+  <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+
+    {# To include pages marked to not show in menu, attributes are added #}
+    {# SEE: https://docs.django-cms.org/en/release-3.6.x/reference/navigation.html#show-breadcrumb #}
+    {% show_breadcrumb 0 "menu/breadcrumb.html" 0 %}
+
+  </ol>
+
+</nav>
+<script>
+  {# To disable 2nd-level breadcrumb #}
+  {# NOTE: Not using module, so effect is quicker (and code is minimal) #}
+  {# FAQ: Attempts to do this server-side failed cuz useful props are blank #}
+  {# https://docs.django-cms.org/en/release-3.11.x/reference/navigation.html#properties-of-navigation-nodes-in-templates #}
+  document
+    .getElementById('cms-breadcrumbs')
+    .querySelector('li:nth-of-type(2) > a')
+    .removeAttribute('href');
+</script>

--- a/designsafe/templates/cms_breadcrumbs.html
+++ b/designsafe/templates/cms_breadcrumbs.html
@@ -1,28 +1,8 @@
 {# @var className #}
-{% load menu_tags sekizai_tags %}
+{% load static menu_tags sekizai_tags %}
 
 {% addtoblock "css" %}
-<style id="cms_breadcrumbs">
-  @import url("https://cdn.jsdelivr.net/gh/TACC/Core-Styles@feat/DES-2806-breadcrumbs-sans-class-s-prefix/dist/components/bootstrap3.breadcrumb.css");
-
-  {# To negate `.navbar-ds` padding bottom #}
-  {# https://github.com/DesignSafe-CI/portal/blob/v7.0.0--tapis-v3-20240607/designsafe/static/vendor/bootstrap-ds/css/bootstrap.css#L4769 #}
-  div:has(.navbar-ds) + main .breadcrumb {
-    margin-top: -20px;
-  }
-  .breadcrumb a:not([href]) {
-    {# https://github.com/TACC/Core-Styles/blob/v2.26.0/dist/elements/links.css #}
-    pointer-events: none;
-
-    {# https://github.com/TACC/tup-ui/blob/v1.1.10/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/trumps/s-breadcrumbs.css #}
-    opacity: 0.75;
-    color: unset;
-  }
-  .breadcrumb {
-    {# https://github.com/DesignSafe-CI/portal/blob/v7.0.0--tapis-v3-20240607/client/modules/workspace/src/AppsBreadcrumb/AppsBreadcrumb.module.css#L3 #}
-    font-size: 1.6rem;
-  }
-</style>
+<link href="{% static 'styles/bootstrap3.breadcrumb.css' %}" rel="stylesheet">
 {% endaddtoblock %}
 
 <nav class="{{className}}" id="cms-breadcrumbs">

--- a/designsafe/templates/cms_breadcrumbs.html
+++ b/designsafe/templates/cms_breadcrumbs.html
@@ -6,7 +6,7 @@
 {% endaddtoblock %}
 
 <nav class="{{className}}" id="cms-breadcrumbs">
-  <ol class="breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">
+  <ol class="breadcrumb breadcrumb-major" itemscope itemtype="https://schema.org/BreadcrumbList">
 
     {# To include pages marked to not show in menu, attributes are added #}
     {# SEE: https://docs.django-cms.org/en/release-3.6.x/reference/navigation.html#show-breadcrumb #}

--- a/designsafe/templates/cms_breadcrumbs.html
+++ b/designsafe/templates/cms_breadcrumbs.html
@@ -5,6 +5,11 @@
   @import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@v2.26.0/dist/trumps/s-breadcrumbs.css");
   @import url("https://cdn.jsdelivr.net/gh/TACC/tup-ui@v1.1.10/apps/tup-cms/src/taccsite_custom/tup_cms/static/tup_cms/css/for-tup-cms/trumps/s-breadcrumbs.css");
 
+  {# To negate `.navbar-ds` padding bottom #}
+  {# https://github.com/DesignSafe-CI/portal/blob/8048436/designsafe/static/styles/main.css#L168 #}
+  div:has(.navbar-ds) + main > .s-breadcrumbs {
+    margin-top: -2.5em;
+  }
   {# https://cdn.jsdelivr.net/gh/TACC/core-styles@v2.26.0/dist/elements/links.css #}
   .s-breadcrumbs a:not([href]) {
     pointer-events: none;

--- a/designsafe/templates/cms_page.html
+++ b/designsafe/templates/cms_page.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load cms_tags static sekizai_tags menu_tags %}
 {% block breadcrumb %}
-    {% include "cms_breadcrumbs.html" with className="container" %}
+    {% include "cms_breadcrumbs.html" with className="container-fluid" %}
 {% endblock %}
 {% block content %}{% placeholder "content" %}{% endblock content %}
 {% block footer %}{% include 'includes/footer.html' %}{% endblock footer %}

--- a/designsafe/templates/cms_page.html
+++ b/designsafe/templates/cms_page.html
@@ -1,7 +1,4 @@
 {% extends "base.html" %}
 {% load cms_tags static sekizai_tags menu_tags %}
-{% block breadcrumb %}
-    {% include "cms_breadcrumbs.html" with className="container-fluid" %}
-{% endblock %}
 {% block content %}{% placeholder "content" %}{% endblock content %}
 {% block footer %}{% include 'includes/footer.html' %}{% endblock footer %}

--- a/designsafe/templates/cms_page.html
+++ b/designsafe/templates/cms_page.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
 {% load cms_tags static sekizai_tags menu_tags %}
+{% block breadcrumb %}
+    {% include "cms_breadcrumbs.html" with className="container" %}
+{% endblock %}
 {% block content %}{% placeholder "content" %}{% endblock content %}
 {% block footer %}{% include 'includes/footer.html' %}{% endblock footer %}

--- a/designsafe/templates/cms_page_for_app.html
+++ b/designsafe/templates/cms_page_for_app.html
@@ -2,6 +2,9 @@
 {% load cms_tags static sekizai_tags %}
 {% block page_class %}s-app-page{% endblock page_class %}
 
+{% block breadcrumb %}
+    {% include "cms_breadcrumbs.html" with className="container-fluid" %}
+{% endblock %}
 {% block styles %}
     {% addtoblock "css" %}
     <link href="{% static 'styles/app-page.css' %}" rel="stylesheet" />

--- a/designsafe/templates/menu/breadcrumb.html
+++ b/designsafe/templates/menu/breadcrumb.html
@@ -1,10 +1,11 @@
 {# https://github.com/django-cms/django-cms/blob/release/3.11.x/menus/templates/menu/breadcrumb.html #}
 {% for ance in ancestors %}
 
-  {# To support structured data, item* attributes are used #}
-  {# https://confluence.tacc.utexas.edu/x/5yMFDg #}
   <li itemscope itemprop="itemListElement"
-      itemtype="https://schema.org/ListItem">
+      itemtype="https://schema.org/ListItem"
+      {% if not forloop.last %}
+      class="active"
+      {% endif %}>
   {% if not forloop.last %}
 
     <a href="{{ ance.get_absolute_url }}" itemprop="item">

--- a/designsafe/templates/menu/breadcrumb.html
+++ b/designsafe/templates/menu/breadcrumb.html
@@ -1,0 +1,23 @@
+{# https://github.com/django-cms/django-cms/blob/release/3.11.x/menus/templates/menu/breadcrumb.html #}
+{% for ance in ancestors %}
+
+  {# To support structured data, item* attributes are used #}
+  {# https://confluence.tacc.utexas.edu/x/5yMFDg #}
+  <li itemscope itemprop="itemListElement"
+      itemtype="https://schema.org/ListItem">
+  {% if not forloop.last %}
+
+    <a href="{{ ance.get_absolute_url }}" itemprop="item">
+      <span itemprop="name">{{ ance.get_menu_title }}</span>
+    </a>
+
+  {% else %}
+
+    <span itemprop="name">{{ ance.get_menu_title }}</span>
+
+  {% endif %}
+
+    <meta itemprop="position" content="{{ forloop.counter }}" />
+  </li>
+
+{% endfor %}

--- a/designsafe/templates/menu/breadcrumb.html
+++ b/designsafe/templates/menu/breadcrumb.html
@@ -3,7 +3,9 @@
 
   <li itemscope itemprop="itemListElement"
       itemtype="https://schema.org/ListItem"
-      class="breadcrumb-item{% if forloop.last %} active{% endif %}">
+      {% if not forloop.last %}
+      class="active"
+      {% endif %}>
   {% if not forloop.last %}
 
     <a href="{{ ance.get_absolute_url }}" itemprop="item">

--- a/designsafe/templates/menu/breadcrumb.html
+++ b/designsafe/templates/menu/breadcrumb.html
@@ -3,9 +3,7 @@
 
   <li itemscope itemprop="itemListElement"
       itemtype="https://schema.org/ListItem"
-      {% if not forloop.last %}
-      class="active"
-      {% endif %}>
+      class="breadcrumb-item{% if forloop.last %} active{% endif %}">
   {% if not forloop.last %}
 
     <a href="{{ ance.get_absolute_url }}" itemprop="item">


### PR DESCRIPTION
## Overview

Add TACC-style breadcrumbs to CMS.

## Status

- [x] Do **not** add new breadcrumb CSS pattern.
    <sup>(because there are already too many)</sup>
- [ ] Re-evaluate [global hyperlink styles](https://github.com/DesignSafe-CI/portal/pull/1268#discussion_r1624702564).
    <sup>If merge, then I do this in #1269.</sup>
- [x] update [DES-2809](https://tacc-main.atlassian.net/browse/DES-2809) to require matching design
- [x] match Portal styles (for now, until DES-2809)

## Related

* [DES-2806](https://tacc-main.atlassian.net/browse/DES-2806)
* required by https://github.com/DesignSafe-CI/portal/pull/1269
* requires https://github.com/TACC/Core-Styles/pull/346

## Changes

- **added** link state mixin & styles
- **moved** CSS variables
- **added** CSS variables
- **added** CMS breadcrumbs template
- **changed** DjangoCMS breadcrumb template
- **added** ID to App Category Listing heading

## Testing

### Basic Implementation

1. Have a CMS page that is heavily nested.
    - See "**Testing**" > "**for DesignSafe App Redesign**" for suggestion.
3. Set template to "Main Site Page" (or non-Main templates).
4. Verify no breadcrumbs.
5. Set template to "Main Site App Page".
6. Review breadcrumbs:
    - Compare to [design](https://xd.adobe.com/view/bab9a62d-3f2a-45f8-be0f-5680c474d9c1-efea/screen/bc798ccd-87fb-4a71-a01f-b9aceb3c914c/specs/).
      <sub>Text is darker than design, because Designer agreed to use existing body color (darker than design).</sub>
    - Compare to [TACC](https://tacc.utexas.edu/education/educators/presentations/).
      <sub>The second item _should_ **not** be a link **and** _should_ be lighter text.</sub>
7. Verify second-level breadcrumb is not a link.
    <sub>(Because all second-level nav links redirect.)</sub>
8. Verify only change is narrow container.

### for DesignSafe App Redesign

9. Have an App Category model "Simulation".
10. Have a CMS page "Tools & Applications".
11. On that page, have a CMS plugin "App Category Listing"; choose "Simulation".
12. Verify listing heading has `id="simulation"` attribute.
13. Have a child CMS page "Simulation".
    - In "Advanced Settings" set "Redirect" to `/the/path-to/tools-appplications/#simulation`.
14. Put a child page under "Simulation" page (e.g. from Step 1).
15. Load child page.
16. Verify breadcrumb link "Simulation" loads "Tools & Applications" with anchor `#simulation`.

> [!NOTE]
> Page will not scroll to section unless the page has enough content to scroll.

## UI

### Basic Implementation

| CMS | Workspace<br><sup>(unchanged)</sup> |
| - | - |
| <img width="880" alt="cms" src="https://github.com/DesignSafe-CI/portal/assets/62723358/533be53f-0089-425d-848d-eaf54bc5bdaf"> | <img width="880" alt="portal" src="https://github.com/DesignSafe-CI/portal/assets/62723358/65c7dda8-d774-4d04-8647-10a8da5f649e"> |

https://github.com/DesignSafe-CI/portal/assets/62723358/f7df3c6b-a27a-441d-a995-83824c7a421e

| Main Site Page | Main Site App Page | EF Site Page | Footerless Page |
| - | - | - | - |
| <img width="1200" alt="main site page" src="https://github.com/DesignSafe-CI/portal/assets/62723358/4f332396-9216-44d8-a02c-04badcbdc8bf"> | <img width="1200" alt="main site app page" src="https://github.com/DesignSafe-CI/portal/assets/62723358/a8582add-88a0-4bb7-acd5-def80bf0268c"> | <img width="1200" alt="ef site page" src="https://github.com/DesignSafe-CI/portal/assets/62723358/5682a856-ae95-45a8-9aed-088fd20b8d20"> | <img width="1200" alt="footerless page" src="https://github.com/DesignSafe-CI/portal/assets/62723358/2f572f6b-0315-4e22-a97b-4d1e9a888d58"> |

<details><summary>Notes</summary>

Only doing this for the new App pages, to reduce regression test scope. Easy to do for Main Site Pages, but oughta test well [the spacing](https://github.com/DesignSafe-CI/portal/blob/0c8377b/designsafe/templates/cms_breadcrumbs.html#L8-L12).

</details>

### for DesignSafe App Redesign

| blank App page in Category page |
| - |
| <img width="795" alt="apps redesign" src="https://github.com/DesignSafe-CI/portal/assets/62723358/db5cc978-25ed-46ad-a25f-fe46f0d4f31c"> |

https://github.com/DesignSafe-CI/portal/assets/62723358/9cf296a5-af6e-46cc-bc25-bb1eaed51920