### PR TITLE
Bug DES-2830: Handle zod optional fields for undefined or empty values

### DIFF
--- a/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
+++ b/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
@@ -32,8 +32,6 @@ export type TParameterSetDefaults = {
   [dynamic: string]: TDynamicString;
 };
 export type TFileInputsDefaults = TDynamicString;
-//export type TConfigurationDefaults = TDynamicString;
-//export type TOutputsDefaults = TDynamicString;
 
 export type TFieldOptions = {
   label: string;
@@ -96,6 +94,12 @@ export type TAppFormSchema = {
     schema: { [dynamic: string]: ZodType };
   };
 };
+
+// See https://github.com/colinhacks/zod/issues/310 for Zod issue
+const emptyStringToUndefined = z.literal('').transform(() => undefined);
+function asOptionalField<T extends z.ZodTypeAny>(schema: T) {
+  return schema.optional().or(emptyStringToUndefined);
+}
 
 // Configuration Schema is pulled out of the default Schema
 // building logic because configuration can change based on queue
@@ -326,8 +330,9 @@ const FormSchema = (
         }
 
         if (!field.required) {
-          parameterSetSchema[field.label] =
-            parameterSetSchema[field.label].optional();
+          parameterSetSchema[field.label] = asOptionalField(
+            parameterSetSchema[field.label]
+          );
         }
         if (param.notes?.validator?.regex && param.notes?.validator?.message) {
           try {
@@ -386,8 +391,9 @@ const FormSchema = (
     );
 
     if (!field.required) {
-      appFields.fileInputs.schema[input.name] =
-        appFields.fileInputs.schema[input.name].optional();
+      appFields.fileInputs.schema[input.name] = asOptionalField(
+        appFields.fileInputs.schema[input.name]
+      );
     }
 
     appFields.fileInputs.fields[input.name] = field;


### PR DESCRIPTION
## Overview: ##
Zod does not automatically handle [undefined or empty values](https://github.com/colinhacks/zod/issues/310) in optional fields like Yup. Handle that specifically.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2830](https://tacc-main.atlassian.net/browse/DES-2830)

## Summary of Changes: ##

## Testing Steps: ##
Test below and contrast behavior with next:

1. Go to https://designsafe.dev/rw/workspace/paraview?version=5.10.0. Para view definition does not require input directory as required. 
      * check if job submit button is enabled
      * click continue and no error should be shown
      * submit job
2. Enter junk value in input file for para view and it should show validation error. Submit is disabled. Continue is halting progress.
3. Submit paraview with valid file path in input.


## UI Photos:
<img width="1129" alt="Screenshot 2024-06-03 at 10 39 34 AM" src="https://github.com/DesignSafe-CI/portal/assets/2568355/93902d79-9f3f-4e27-a81a-dae8a587c5b7">

## Notes: ##
