### PR TITLE
DES-2805: App overview breadcrumb

### DIFF
--- a/client/modules/_hooks/src/workspace/useAppsListing.ts
+++ b/client/modules/_hooks/src/workspace/useAppsListing.ts
@@ -4,6 +4,7 @@ import apiClient from '../apiClient';
 export type TPortalApp = {
   app_id: string;
   app_type: string;
+  bundle_href: string;
   bundle_id: number;
   bundle_label: string;
   html?: string;

--- a/client/modules/workspace/src/AppsBreadcrumb/AppsBreadcrumb.tsx
+++ b/client/modules/workspace/src/AppsBreadcrumb/AppsBreadcrumb.tsx
@@ -2,7 +2,12 @@ import React, { ReactNode } from 'react';
 import { Breadcrumb, Button } from 'antd';
 import { Link, useLocation } from 'react-router-dom';
 import styles from './AppsBreadcrumb.module.css';
-import { useGetApps, TAppResponse } from '@client/hooks';
+import {
+  useGetApps,
+  TAppResponse,
+  useAppsListing,
+  TAppCategories,
+} from '@client/hooks';
 import { useGetAppParams } from '../utils';
 
 function getPathRoutes(path: string = '') {
@@ -19,6 +24,13 @@ function getPathRoutes(path: string = '') {
 export const AppsBreadcrumb: React.FC = () => {
   const { pathname } = useLocation();
   const { appId, appVersion } = useGetAppParams();
+  const {
+    data: { categories },
+  } = useAppsListing() as { data: TAppCategories };
+  const currentAppFromCategories = categories
+    .map((cat) => cat.apps)
+    .flat()
+    .find((app) => app.app_id === appId && app.version === (appVersion || ''));
 
   const breadcrumbItems = [
     { title: 'Home', path: window.location.origin },
@@ -28,6 +40,13 @@ export const AppsBreadcrumb: React.FC = () => {
       href: '/use-designsafe/tools-applications/',
     },
   ];
+
+  if (currentAppFromCategories?.bundle_href) {
+    breadcrumbItems.push({
+      title: `${currentAppFromCategories.bundle_label} Overview`,
+      href: currentAppFromCategories.bundle_href,
+    });
+  }
 
   return (
     <Breadcrumb

--- a/designsafe/apps/workspace/api/views.py
+++ b/designsafe/apps/workspace/api/views.py
@@ -375,6 +375,7 @@ class AppsTrayView(AuthenticatedApiView):
         reduced_values = [
             "app_id",
             "app_type",
+            "bundle_href",
             "bundle_id",
             "bundle_label",
             "html",


### PR DESCRIPTION
## Overview: ##

Include app overview link in breadcrumbs

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2805](https://tacc-main.atlassian.net/browse/DES-2805)

## Testing Steps: ##
1. Load an app that exists in your App Entries model
2. Confirm the overview link appears in breadcrumbs
3. Load an app that does not exist in your App Entries model
4. Confirm overview link does not appear, but app still loads

## UI Photos:
<img width="769" alt="Screenshot 2024-06-03 at 12 55 38 PM" src="https://github.com/DesignSafe-CI/portal/assets/20326896/273a36b9-87a8-47fd-a1d5-b337b590fd8b">

