### PR TITLE
Bug DES-2876: Select Modal bug fixes

### DIFF
--- a/client/modules/_common_components/src/datafiles/DatafilesBreadcrumb/DatafilesBreadcrumb.tsx
+++ b/client/modules/_common_components/src/datafiles/DatafilesBreadcrumb/DatafilesBreadcrumb.tsx
@@ -64,6 +64,7 @@ export const BaseFileListingBreadcrumb: React.FC<
     path: string;
     systemRootAlias?: string;
     initialBreadcrumbs?: { title: string; path: string }[];
+    systemLabel?: string;
   } & BreadcrumbProps
 > = ({
   api,
@@ -71,10 +72,12 @@ export const BaseFileListingBreadcrumb: React.FC<
   path,
   systemRootAlias,
   initialBreadcrumbs = [],
+  systemLabel,
   ...props
 }) => {
   const { user } = useAuthenticatedUser();
-  const rootAlias = systemRootAlias || getSystemRootDisplayName(api, system);
+  const rootAlias =
+    systemRootAlias || getSystemRootDisplayName(api, system, systemLabel);
   const systemRoot = isUserHomeSystem(system) ? '/' + user?.username : '';
   return (
     <DatafilesBreadcrumb

--- a/client/modules/_hooks/src/datafiles/usePathDisplayName.ts
+++ b/client/modules/_hooks/src/datafiles/usePathDisplayName.ts
@@ -1,7 +1,11 @@
 import { useCallback } from 'react';
 import { useAuthenticatedUser } from '../useAuthenticatedUser';
 
-export function getSystemRootDisplayName(api: string, system: string): string {
+export function getSystemRootDisplayName(
+  api: string,
+  system: string,
+  label: string = 'Data Files'
+): string {
   if (api === 'googledrive') return 'Google Drive';
   if (api === 'box') return 'Box';
   if (api === 'dropbox') return 'Dropbox';
@@ -10,7 +14,7 @@ export function getSystemRootDisplayName(api: string, system: string): string {
       'designsafe.storage.default': 'My Data',
       'designsafe.storage.frontera.work': 'My Data (Work)',
       'designsafe.storage.community': 'Community Data',
-    }[system] ?? 'Data Files'
+    }[system] ?? label
   );
 }
 
@@ -18,11 +22,12 @@ function _getPathDisplayName(
   api: string,
   system: string,
   path: string,
+  label: string,
   username?: string
 ) {
   const usernamePath = encodeURIComponent('/' + username);
 
-  if (!path) return getSystemRootDisplayName(api, system);
+  if (!path) return getSystemRootDisplayName(api, system, label);
   if (api === 'googledrive' && !path) return 'Google Drive';
   if (api === 'dropbox' && !path) return 'Dropbox';
   if (api === 'box' && !path) return 'Box';
@@ -41,8 +46,8 @@ export function usePathDisplayName() {
   const { user } = useAuthenticatedUser();
 
   const getPathDisplayName = useCallback(
-    (api: string, system: string, path: string) =>
-      _getPathDisplayName(api, system, path, user?.username),
+    (api: string, system: string, path: string, label: string = 'Data Files') =>
+      _getPathDisplayName(api, system, path, label, user?.username),
     [user]
   );
 

--- a/client/modules/_hooks/src/datafiles/usePathDisplayName.ts
+++ b/client/modules/_hooks/src/datafiles/usePathDisplayName.ts
@@ -39,7 +39,7 @@ function _getPathDisplayName(
     return 'HPC Work';
   }
 
-  return decodeURIComponent(path).split('/').slice(-1)[0] || 'Data Files';
+  return decodeURIComponent(path).split('/').slice(-1)[0] || label;
 }
 
 export function usePathDisplayName() {

--- a/client/modules/workspace/src/SelectModal/SelectModal.tsx
+++ b/client/modules/workspace/src/SelectModal/SelectModal.tsx
@@ -377,6 +377,7 @@ export const SelectModal: React.FC<{
                     ? [{ title: 'My Projects', path: 'PROJECT_LISTING' }]
                     : []
                 }
+                systemLabel={systemLabel}
                 itemRender={(item) => {
                   return (
                     <Button

--- a/client/modules/workspace/src/SelectModal/SelectModal.tsx
+++ b/client/modules/workspace/src/SelectModal/SelectModal.tsx
@@ -41,7 +41,7 @@ const HeaderTitle: React.FC<{
       <i role="none" className="fa fa-folder-o">
         &nbsp;&nbsp;
       </i>
-      {getPathName(api, system, path)}
+      {getPathName(api, system, path, label)}
     </span>
   );
 };


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2876](https://tacc-main.atlassian.net/browse/DES-2876)

## Summary of Changes: ##
5 bugs fixed in this:
1) Select button is secondary button
2) Header now matches the label for System. Previously for Published, it showed Data Files
3) Default placeholder for search was empty - fixed the default state.
4) Disallow drilling into a file, change icon for file vs folder. 
5) Fix hyperlink for folder to not extend beyond the text.  Like this: 
![image](https://github.com/DesignSafe-CI/portal/assets/2568355/a51cc59c-42d7-4dd3-a31b-c9a8f99772e7)

## Testing Steps: ##
[Design reference](https://xd.adobe.com/view/bab9a62d-3f2a-45f8-be0f-5680c474d9c1-efea/screen/4f5c890c-a48d-4a55-8d5d-4d400dd9222e/specs/)

1. Open Select File for an app: https://designsafe.dev/rw/workspace/openfoam
2. See the file vs folder differentiation for icon and link
3. Select button is secondary. 
4. Hyperlink fix
5. default search placeholder as soon as opening the select modal should be correct.
6. Regression Testing on Data Files to make sure things are not broken.

## UI Photos:
<img width="586" alt="Screenshot 2024-06-03 at 2 20 20 PM" src="https://github.com/DesignSafe-CI/portal/assets/2568355/e107f37d-5dd4-4a0a-bc7b-1e808892755b">



## Notes: ##
