### PR TITLE
Bugs/DES-2828 and DES-2829: Select Modal system selection and validation bugs

### DIFF
--- a/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
+++ b/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
@@ -95,6 +95,8 @@ export type TAppFormSchema = {
   };
 };
 
+export const inputFileRegex = /^tapis:\/\/(?<storageSystem>[^/]+)\/[^/]+$/;
+
 // See https://github.com/colinhacks/zod/issues/310 for Zod issue
 const emptyStringToUndefined = z.literal('').transform(() => undefined);
 function asOptionalField<T extends z.ZodTypeAny>(schema: T) {

--- a/client/modules/workspace/src/AppsWizard/FormField.tsx
+++ b/client/modules/workspace/src/AppsWizard/FormField.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Button, Form, Input, Select } from 'antd';
 import { FormItem } from 'react-hook-form-antd';
 import { useFormContext, useWatch } from 'react-hook-form';
-import { TFieldOptions } from '../AppsWizard/AppsFormSchema';
+import { TFieldOptions, inputFileRegex } from '../AppsWizard/AppsFormSchema';
 import { SecondaryButton } from '@client/common-components';
 import { SelectModal } from '../SelectModal/SelectModal';
 
@@ -26,13 +26,27 @@ export const FormField: React.FC<{
   type,
   ...props
 }) => {
-  const { resetField, control, getValues, setValue } = useFormContext();
+  const { resetField, control, getValues, setValue, trigger } =
+    useFormContext();
   const fieldState = useWatch({ control, name });
   let parameterSetLabel: React.ReactElement | null = null;
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [storageSystem, setStorageSystem] = useState<string | null>(null);
+
   const handleSelectModalOpen = () => {
     setIsModalOpen(true);
   };
+  useEffect(() => {
+    if (tapisFile) {
+      const inputFileValue = getValues(name);
+      const match = inputFileValue?.match(inputFileRegex);
+      if (match && match.groups) {
+        setStorageSystem(match.groups.storageSystem);
+      } else {
+        setStorageSystem(null);
+      }
+    }
+  }, [tapisFile, name, fieldState]);
 
   if (parameterSet) {
     parameterSetLabel = (
@@ -120,9 +134,13 @@ export const FormField: React.FC<{
       {tapisFile && (
         <SelectModal
           inputLabel={label}
+          system={storageSystem}
           isOpen={isModalOpen}
           onClose={() => setIsModalOpen(false)}
-          onSelect={(value: string) => setValue(name, value)}
+          onSelect={(value: string) => {
+            setValue(name, value);
+            trigger(name);
+          }}
         />
       )}
     </div>

--- a/client/modules/workspace/src/SelectModal/SelectModal.tsx
+++ b/client/modules/workspace/src/SelectModal/SelectModal.tsx
@@ -195,10 +195,11 @@ function getFilesColumns(
 
 export const SelectModal: React.FC<{
   inputLabel: string;
+  system: string | null;
   isOpen: boolean;
   onClose: () => void;
   onSelect: (value: string) => void;
-}> = ({ inputLabel, isOpen, onClose, onSelect }) => {
+}> = ({ inputLabel, system, isOpen, onClose, onSelect }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState<string | null>(null);
   const [form] = Form.useForm();
@@ -296,6 +297,18 @@ export const SelectModal: React.FC<{
     // Intended to indicate searching the root path of a project.
     setSystemLabel('root');
   };
+
+  useEffect(() => {
+    if (isModalOpen) {
+      let systemValue = system;
+      if (!system) {
+        systemValue = defaultStorageSystem.id;
+      } else if (system.startsWith('project-')) {
+        systemValue = 'myprojects';
+      }
+      dropdownCallback(systemValue);
+    }
+  }, [system, isModalOpen]);
 
   const navCallback = useCallback(
     (path: string) => {

--- a/client/modules/workspace/src/SelectModal/SelectModal.tsx
+++ b/client/modules/workspace/src/SelectModal/SelectModal.tsx
@@ -300,10 +300,8 @@ export const SelectModal: React.FC<{
 
   useEffect(() => {
     if (isModalOpen) {
-      let systemValue = system;
-      if (!system) {
-        systemValue = defaultStorageSystem.id;
-      } else if (system.startsWith('project-')) {
+      let systemValue = system ?? defaultStorageSystem.id;
+      if (systemValue.startsWith('project-')) {
         systemValue = 'myprojects';
       }
       dropdownCallback(systemValue);


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2829 - System Selection bug](https://tacc-main.atlassian.net/browse/DES-2829)
* [DES-2828 - Validation bug](https://tacc-main.atlassian.net/browse/DES-2828)

## Summary of Changes: ##
* Use the file input value and pass the system information to select modal
* Adjust the values in the modal based on the system information
* Validation: trigger validation on return from modal selection

## Testing Steps: ##
Use this app: https://designsafe.dev/rw/workspace/openfoam#!/
1. Validation bug:
    * Add invalid file path in input file text box
    * Error “Input file must be a valid Tapis URI, starting with 'tapis://'“ shows up.
    * Use Select file and select a file.
    * Error goes away
2. System selection bug:
    * Select a file from community, hit continue.
    * go back and select file again. The system name and all relevant labels should show community.
    * set file path to tapis://project-7313903999355121175-242ac119-0001-012/00000.jpg, hit continue and go back.
    * Open the file and it should show projects
    * Similarly repeat for published.

## UI Photos:

## Notes: ##
