### PR TITLE
task/DES-2875: prevent zooming out too far and endless scrolling in ReconPortal

### DIFF
--- a/designsafe/static/scripts/rapid/controllers/rapid-main-ctrl.js
+++ b/designsafe/static/scripts/rapid/controllers/rapid-main-ctrl.js
@@ -46,7 +46,12 @@ export default class RapidMainCtrl {
         );
         this.map = L.map('map', {
             layers: [streets, satellite],
-            scrollWheelZoom: true
+            scrollWheelZoom: true,
+            minZoom: 2, // 2 typically prevents zooming out to far to see multiple earths
+            maxBounds: [
+                [-90, -180], // Southwest coordinates
+                [90, 180], // Northeast coordinates
+            ]
         });
         this.map.setView([30.2672, -97.7431], 2);
         this.map.zoomControl.setPosition('topright');


### PR DESCRIPTION
## Overview: ##
DES-2875

In ReconPortal (`/recon-portal/`), user could zoom out too far and also do an endless scrolling.  See [DES-2875](https://tacc-main.atlassian.net/browse/DES-2875).  Now we limit where users can scroll to on the map and we do not let them zoom out farther than 2.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2875](https://tacc-main.atlassian.net/browse/DES-2875)

## Testing Steps: ##
1. go to /recon-portal
2. try to zoom out
3. try to pan left or right

## UI Photos:
before:
<img width="1729" alt="Screenshot 2024-06-07 at 2 46 42 PM" src="https://github.com/DesignSafe-CI/portal/assets/8287580/532f4c75-a285-47dc-8f90-c3a1ddf7ef85">

after:
<img width="1714" alt="Screenshot 2024-06-07 at 2 47 10 PM" src="https://github.com/DesignSafe-CI/portal/assets/8287580/3880ce78-9d9b-4338-abe3-1238ec9ecad0">




