### PR TITLE
task/DES-2794: Workspace Layout Adjustments

### DIFF
--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -112,3 +112,23 @@
 .ant-collapse-header:focus-visible {
   outline: -webkit-focus-ring-color auto 1px !important;
 }
+
+.o-site__body,
+#apps-root,
+#apps-root > div.ant-flex,
+.ant-layout-has-sider,
+.ant-layout-sider {
+  height: 100%;
+  overflow: hidden;
+}
+
+/* Do NOT scroll "Applications:" and "Job Status" */
+.ant-layout-sider-children {
+  overflow-y: hidden;
+}
+
+/* DO scroll app category menu */
+.ant-layout-sider-children > header + div + ul {
+  overflow: auto;
+  height: 100%;
+}

--- a/designsafe/static/styles/main.css
+++ b/designsafe/static/styles/main.css
@@ -959,7 +959,7 @@ li .popover.right {
   flex-direction: column;
   flex-grow: 1;
   flex-shrink: 0;
-  flex-basis: auto;
+  flex-basis: 0;
 }
 
 .o-site__body > .container-fluid {


### PR DESCRIPTION
## Overview: ##
- Workspace content has full height of screen
- Workspace side nav is limited to full height of screen, and overflow scrolls
- Adjusts the `flex-basis` of `.o-site__body` to `0`, to account for DS header, removing annoying extra scroll from any react content

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2794](https://tacc-main.atlassian.net/browse/DES-2794)

## Testing Steps: ##
1. Go to https://designsafe.dev/rw/workspace/opensees-sp-s3?appVersion=3.6.0 and confirm layout looks good. Side nav should scroll in place
2. Go to https://designsafe.dev/rw/workspace/history and confirm side nav and job status listing scroll in place, separately.
3. Confirm "Job Status" and "Applications:" headers above side nav do NOT scroll

## UI Photos:
<img width="1713" alt="Screenshot 2024-06-11 at 5 05 15 PM" src="https://github.com/DesignSafe-CI/portal/assets/20326896/504957a1-cff8-4fd2-81ff-a05fea6e08ba">
<img width="1712" alt="Screenshot 2024-06-11 at 5 05 05 PM" src="https://github.com/DesignSafe-CI/portal/assets/20326896/1a6a493c-e3cc-42ff-8e4e-3aaf1fdbcf79">

