### PR TITLE
task/WG-294: improve links from DS projects to hazmapper maps

### DIFF
--- a/client/modules/datafiles/src/projects/BaseProjectDetails.tsx
+++ b/client/modules/datafiles/src/projects/BaseProjectDetails.tsx
@@ -167,7 +167,9 @@ export const BaseProjectDetails: React.FC<{
     ? parseInt(searchParams.get('version') ?? Math.max(...versions).toString())
     : 1;
 
-  const filteredHazmapperMaps = filterHazmapperMaps(projectValue.hazmapperMaps ?? []);
+  const filteredHazmapperMaps = filterHazmapperMaps(
+    projectValue.hazmapperMaps ?? []
+  );
 
   return (
     <section style={{ marginBottom: '20px' }}>

--- a/client/modules/datafiles/src/projects/BaseProjectDetails.tsx
+++ b/client/modules/datafiles/src/projects/BaseProjectDetails.tsx
@@ -8,6 +8,7 @@ import { RelateDataModal } from './modals';
 import { ProjectInfoModal } from './modals/ProjectInfoModal';
 import { VersionChangesModal } from './modals/VersionChangesModal';
 import { SubmitFeedbackModal } from '../publications/modals/SubmitFeedbackModal';
+import { filterHazmapperMaps, getHazmapperUrl } from './utils';
 
 export const DescriptionExpander: React.FC<React.PropsWithChildren> = ({
   children,
@@ -165,6 +166,8 @@ export const BaseProjectDetails: React.FC<{
   const currentVersion = versions
     ? parseInt(searchParams.get('version') ?? Math.max(...versions).toString())
     : 1;
+
+  const filteredHazmapperMaps = filterHazmapperMaps(projectValue.hazmapperMaps ?? []);
 
   return (
     <section style={{ marginBottom: '20px' }}>
@@ -341,16 +344,16 @@ export const BaseProjectDetails: React.FC<{
               {projectValue.keywords.join(', ')}
             </td>
           </tr>
-          {(projectValue.hazmapperMaps?.length ?? 0) > 0 && (
+          {(filteredHazmapperMaps?.length ?? 0) > 0 && (
             <tr className={styles['prj-row']}>
               <td>Hazmapper Maps</td>
               <td style={{ fontWeight: 'bold' }}>
-                {(projectValue.hazmapperMaps ?? []).map((m) => (
+                {(filteredHazmapperMaps ?? []).map((m) => (
                   <div key={m.uuid}>
                     {m.name}&nbsp;
                     <Tooltip title="Open in HazMapper">
                       <a
-                        href={`https://hazmapper.tacc.utexas.edu/hazmapper/project-public/${m.uuid}`}
+                        href={getHazmapperUrl(m, isPublished)}
                         rel="noopener noreferrer"
                         target="_blank"
                       >

--- a/client/modules/datafiles/src/projects/utils.ts
+++ b/client/modules/datafiles/src/projects/utils.ts
@@ -1,6 +1,5 @@
 import { THazmapperMap } from '@client/hooks';
 
-
 const HAZMAPPER_BASE_URL_MAP = {
   production: 'https://hazmapper.tacc.utexas.edu/hazmapper',
   staging: 'https://hazmapper.tacc.utexas.edu/staging',
@@ -11,33 +10,39 @@ const HAZMAPPER_BASE_URL_MAP = {
 
 /**
  * Generates the Hazmapper URL based on the provided map details and publication status.
- * 
+ *
  * Background:  We assume there is a public Hazmapper map-project for all published projects.  For non-published
  * projets, we assume that only members of the project are using this URL so we provide
- * the private Hazmapper map/project link.  
- * 
+ * the private Hazmapper map/project link.
+ *
  * Logs an error if the deployment type is invalid.
- * 
+ *
  * @returns The generated Hazmapper URL.
  */
-export const getHazmapperUrl = (map: THazmapperMap, isPublished: boolean = false): string => {
-  let baseUrl = HAZMAPPER_BASE_URL_MAP[map.deployment as keyof typeof HAZMAPPER_BASE_URL_MAP];
+export const getHazmapperUrl = (
+  map: THazmapperMap,
+  isPublished: boolean = false
+): string => {
+  let baseUrl =
+    HAZMAPPER_BASE_URL_MAP[
+      map.deployment as keyof typeof HAZMAPPER_BASE_URL_MAP
+    ];
 
   if (!baseUrl) {
-    console.error(`Invalid deployment type: ${map.deployment}.  Falling back to local`);
+    console.error(
+      `Invalid deployment type: ${map.deployment}.  Falling back to local`
+    );
     baseUrl = HAZMAPPER_BASE_URL_MAP['local'];
   }
-
 
   return isPublished
     ? `${baseUrl}/project-public/${map.uuid}`
     : `${baseUrl}/project/${map.uuid}`;
 };
 
-
 /**
  * Filters Hazmapper maps based on the deployment type.
- * 
+ *
  * On prod, we only want to see prod maps so we filter everything else
  * out.
  */

--- a/client/modules/datafiles/src/projects/utils.ts
+++ b/client/modules/datafiles/src/projects/utils.ts
@@ -1,0 +1,51 @@
+import { THazmapperMap } from '@client/hooks';
+
+
+const HAZMAPPER_BASE_URL_MAP = {
+  production: 'https://hazmapper.tacc.utexas.edu/hazmapper',
+  staging: 'https://hazmapper.tacc.utexas.edu/staging',
+  dev: 'https://hazmapper.tacc.utexas.edu/dev',
+  local: 'http://localhost:4200',
+  experimental: 'https://hazmapper.tacc.utexas.edu/exp',
+};
+
+/**
+ * Generates the Hazmapper URL based on the provided map details and publication status.
+ * 
+ * Background:  We assume there is a public Hazmapper map-project for all published projects.  For non-published
+ * projets, we assume that only members of the project are using this URL so we provide
+ * the private Hazmapper map/project link.  
+ * 
+ * Logs an error if the deployment type is invalid.
+ * 
+ * @returns The generated Hazmapper URL.
+ */
+export const getHazmapperUrl = (map: THazmapperMap, isPublished: boolean = false): string => {
+  let baseUrl = HAZMAPPER_BASE_URL_MAP[map.deployment as keyof typeof HAZMAPPER_BASE_URL_MAP];
+
+  if (!baseUrl) {
+    console.error(`Invalid deployment type: ${map.deployment}.  Falling back to local`);
+    baseUrl = HAZMAPPER_BASE_URL_MAP['local'];
+  }
+
+
+  return isPublished
+    ? `${baseUrl}/project-public/${map.uuid}`
+    : `${baseUrl}/project/${map.uuid}`;
+};
+
+
+/**
+ * Filters Hazmapper maps based on the deployment type.
+ * 
+ * On prod, we only want to see prod maps so we filter everything else
+ * out.
+ */
+export const filterHazmapperMaps = (maps: THazmapperMap[]): THazmapperMap[] => {
+  // Filter out non-production maps if we are DS prod (i.e. 'designsafe-ci.org')
+  if (window.location.origin.includes('designsafe-ci.org')) {
+    return maps.filter((map) => map.deployment === 'production');
+  }
+
+  return maps;
+};


### PR DESCRIPTION
## Overview: ##

Improve links from DS projects to hazmapper maps:
* each URL that is created should point to a specific map on either prod, staging, local, dev or experimental Hazmapper deployments
* when we are in production DesignSafe, we only show maps that are from production hazmapper
* **And** if we are viewing a published project, we only want to send users to the public map (we assume it exists).

## PR Status: ##

* [X] Ready.


## Related Jira tickets: ##

* [DES-294](https://tacc-main.atlassian.net/browse/DES-294)

## Testing Steps: ##
1. Find a map with link to hazmapper maps in staging, prod, dev, or experimental (if you need help with this, let me know, i got a quick script from confluence info to grab ds-next DB and populate locally). (note, this bug can get in your way https://tacc-main.atlassian.net/browse/DES-2886)
2. Check that links go to correct map on the proper hazmapper.

## UI Photos:

![Screenshot 2024-06-11 at 8 27 57 PM](https://github.com/DesignSafe-CI/portal/assets/8287580/0d56185e-ac7c-4f02-9752-5ac9f3dd55b9)

