### PR TITLE
task/DES-1989 - Redirect guest users when accessing non-published project

### DIFF
--- a/client/src/datafiles/layouts/projects/ProjectDetailLayout.tsx
+++ b/client/src/datafiles/layouts/projects/ProjectDetailLayout.tsx
@@ -40,13 +40,6 @@ export const ProjectDetailLayout: React.FC = () => {
   const { projectId } = useParams();
   const { data } = useProjectDetail(projectId ?? '');
 
-  if ((!data || !projectId) && user)
-    return (
-      <Layout style={{ position: 'relative' }}>
-        <Spin style={{ position: 'absolute', top: '50%', left: '50%' }} />
-      </Layout>
-    );
-
   if (!user)
     return (
       <Layout>
@@ -59,6 +52,13 @@ export const ProjectDetailLayout: React.FC = () => {
         />
       </Layout>
     );
+
+    if ((!data || !projectId))
+      return (
+        <Layout style={{ position: 'relative' }}>
+          <Spin style={{ position: 'absolute', top: '50%', left: '50%' }} />
+        </Layout>
+      );
 
   return (
     <Layout>

--- a/client/src/datafiles/layouts/projects/ProjectDetailLayout.tsx
+++ b/client/src/datafiles/layouts/projects/ProjectDetailLayout.tsx
@@ -5,8 +5,8 @@ import {
   DatafilesToolbar,
   ProjectTitleHeader,
 } from '@client/datafiles';
-import { Button, Form, Input, Layout, Spin } from 'antd';
-import { useProjectDetail } from '@client/hooks';
+import { Button, Form, Input, Layout, Spin, Alert } from 'antd';
+import { useProjectDetail, useAuthenticatedUser } from '@client/hooks';
 
 const FileListingSearchBar = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -36,14 +36,29 @@ const FileListingSearchBar = () => {
 };
 
 export const ProjectDetailLayout: React.FC = () => {
+  const { user } = useAuthenticatedUser();
   const { projectId } = useParams();
   const { data } = useProjectDetail(projectId ?? '');
-  if (!data || !projectId)
+
+  if ((!data || !projectId) && user)
     return (
       <Layout style={{ position: 'relative' }}>
         <Spin style={{ position: 'absolute', top: '50%', left: '50%' }} />
       </Layout>
     );
+  
+  if (!user)
+    return(
+      <Layout>
+        <DatafilesToolbar searchInput={<FileListingSearchBar />} />
+        <Alert
+          showIcon
+          type="error"
+          style={{marginTop: '16px', color: '#d9534f', textAlign: 'center'}}
+          message={"Please log in to access this feature."}
+        />
+      </Layout>
+    )
 
   return (
     <Layout>

--- a/client/src/datafiles/layouts/projects/ProjectDetailLayout.tsx
+++ b/client/src/datafiles/layouts/projects/ProjectDetailLayout.tsx
@@ -53,12 +53,12 @@ export const ProjectDetailLayout: React.FC = () => {
       </Layout>
     );
 
-    if ((!data || !projectId))
-      return (
-        <Layout style={{ position: 'relative' }}>
-          <Spin style={{ position: 'absolute', top: '50%', left: '50%' }} />
-        </Layout>
-      );
+  if (!data || !projectId)
+    return (
+      <Layout style={{ position: 'relative' }}>
+        <Spin style={{ position: 'absolute', top: '50%', left: '50%' }} />
+      </Layout>
+    );
 
   return (
     <Layout>

--- a/client/src/datafiles/layouts/projects/ProjectDetailLayout.tsx
+++ b/client/src/datafiles/layouts/projects/ProjectDetailLayout.tsx
@@ -46,19 +46,19 @@ export const ProjectDetailLayout: React.FC = () => {
         <Spin style={{ position: 'absolute', top: '50%', left: '50%' }} />
       </Layout>
     );
-  
+
   if (!user)
-    return(
+    return (
       <Layout>
         <DatafilesToolbar searchInput={<FileListingSearchBar />} />
         <Alert
           showIcon
           type="error"
-          style={{marginTop: '16px', color: '#d9534f', textAlign: 'center'}}
-          message={"Please log in to access this feature."}
+          style={{ marginTop: '16px', color: '#d9534f', textAlign: 'center' }}
+          message={'Please log in to access this feature.'}
         />
       </Layout>
-    )
+    );
 
   return (
     <Layout>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -135,9 +135,9 @@
   height: 100%;
 }
 
-.o-site__body, 
-#datafiles-root, 
+.o-site__body,
+#datafiles-root,
 #datafiles-root > div.ant-layout > .ant-alert-error,
-div[role=alert] {
+div[role='alert'] {
   display: flex !important;
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -134,3 +134,10 @@
   overflow: auto;
   height: 100%;
 }
+
+.o-site__body, 
+#datafiles-root, 
+#datafiles-root > div.ant-layout > .ant-alert-error,
+div[role=alert] {
+  display: flex !important;
+}


### PR DESCRIPTION
## Overview: ##
Redirect guest users to login (authorization page) when accessing non-published project

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-1989](https://tacc-main.atlassian.net/browse/DES-1989)

## Summary of Changes: ##
Prevents an infinite spinner and api call when unauth'd users attempt to access a project. Also some minor styling changes to the alert error jsx component to make it look like the one provided by django for file listings.

## Testing Steps: ##
1. Find the URL for an unpublished project that you should have access to.
2. Log out of DS  (may need to go to incognito mode of your browser)
3. Attempt to go to the URL of your project. It should present you with an error message, not a spinner.

## UI Photos:
![image (1)](https://github.com/DesignSafe-CI/portal/assets/7462330/4e8d1799-2dad-4b8c-ba08-9b850ab08b02)

## Notes: ##
