### PR TITLE
Workspace fixes from 6/12 testing session

### DIFF
--- a/client/modules/_hooks/src/notifications/useNotifications.ts
+++ b/client/modules/_hooks/src/notifications/useNotifications.ts
@@ -36,10 +36,11 @@ export type TGetNotificationsResponse = {
 };
 
 type TGetNotificationsParams = {
-  event_types?: TPortalEventType[];
+  eventTypes?: TPortalEventType[];
   read?: boolean;
   limit?: number;
   skip?: number;
+  markRead?: boolean;
 };
 
 async function getNotifications(params: TGetNotificationsParams) {
@@ -58,14 +59,14 @@ async function getUnreadNotifications(params: TGetNotificationsParams) {
   return res.data;
 }
 
-async function readNotifications(body: { event_types?: TPortalEventType[] }) {
+async function readNotifications(body: { eventTypes?: TPortalEventType[] }) {
   const res = await apiClient.patch('/api/notifications/', body);
   return res.data;
 }
 
 export function useReadNotifications() {
   return useMutation({
-    mutationFn: (body: { event_types?: TPortalEventType[] }) => {
+    mutationFn: (body: { eventTypes?: TPortalEventType[] }) => {
       return readNotifications(body);
     },
   });

--- a/client/modules/workspace/src/AppsSubmissionDetails/AppsSubmissionDetails.tsx
+++ b/client/modules/workspace/src/AppsSubmissionDetails/AppsSubmissionDetails.tsx
@@ -152,7 +152,8 @@ export const AppsSubmissionDetails: React.FC<{
           items={items}
           labelStyle={{
             textAlign: 'left',
-            width: '220px',
+            maxWidth: '240px',
+            minWidth: '220px',
             color: 'rgba(0, 0, 0, 0.88)',
             font: 'normal normal 14px Helvetica Neue',
             alignItems: 'center',

--- a/client/modules/workspace/src/AppsSubmissionDetails/AppsSubmissionDetails.tsx
+++ b/client/modules/workspace/src/AppsSubmissionDetails/AppsSubmissionDetails.tsx
@@ -63,8 +63,9 @@ export const AppsSubmissionDetails: React.FC<{
     };
   };
   isSubmitting: boolean;
+  current: string;
   setCurrent: CallableFunction;
-}> = ({ schema, fields, isSubmitting, setCurrent }) => {
+}> = ({ schema, fields, isSubmitting, current, setCurrent }) => {
   const {
     control,
     formState: { defaultValues, isValid },
@@ -182,13 +183,15 @@ export const AppsSubmissionDetails: React.FC<{
             <div style={{ flex: 1 }}>
               {key.charAt(0).toUpperCase() + key.slice(1)}
             </div>
-            <Button
-              type="link"
-              onClick={() => setCurrent(key)}
-              style={{ fontWeight: 'bold' }}
-            >
-              Edit
-            </Button>
+            {current !== key && (
+              <Button
+                type="link"
+                onClick={() => setCurrent(key)}
+                style={{ fontWeight: 'bold' }}
+              >
+                Edit
+              </Button>
+            )}
           </Flex>
         ),
         children: getChildren(key, value, schema[key] as z.AnyZodObject, index),

--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -149,12 +149,6 @@ export const AppsSubmissionForm: React.FC = () => {
 
   const missingLicense = license.type && !license.enabled;
 
-  const readOnly =
-    !!missingLicense ||
-    !hasStorageSystems ||
-    (definition.jobType === 'BATCH' && !!missingAllocation) ||
-    !!defaultSystemNeedsKeys;
-
   const methods = useForm({
     defaultValues: initialValues,
     resolver: zodResolver(z.object(schema)),
@@ -340,6 +334,13 @@ export const AppsSubmissionForm: React.FC = () => {
   const [pushKeysSystem, setPushKeysSystem] = useState<
     TTapisSystem | undefined
   >();
+
+  const readOnly =
+    !!missingLicense ||
+    !hasStorageSystems ||
+    (definition.jobType === 'BATCH' && !!missingAllocation) ||
+    !!defaultSystemNeedsKeys ||
+    isPending;
 
   useEffect(() => {
     if (submitResult?.execSys) {

--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -577,6 +577,7 @@ export const AppsSubmissionForm: React.FC = () => {
                         schema={schema}
                         fields={fields}
                         isSubmitting={isPending}
+                        current={current}
                         setCurrent={setCurrent}
                       />
                     </Col>

--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -477,7 +477,11 @@ export const AppsSubmissionForm: React.FC = () => {
                 {definition.notes.label || definition.id}
               </div>
               {definition.notes.helpUrl && (
-                <a href={definition.notes.helpUrl} target="_blank">
+                <a
+                  href={definition.notes.helpUrl}
+                  target="_blank"
+                  style={{ marginRight: 10 }}
+                >
                   View User Guide
                 </a>
               )}

--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -142,7 +142,7 @@ export const AppsSubmissionForm: React.FC = () => {
     fontSize: 16,
   };
   const layoutStyle = {
-    overflow: 'hidden',
+    overflow: 'auto',
   };
 
   const missingLicense = license.type && !license.enabled;

--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -86,9 +86,7 @@ export const AppsSubmissionForm: React.FC = () => {
     execSystems
   ) as TTapisSystem;
   const allocations = getAllocationList(defaultExecSystem, tasAllocations);
-  const portalAlloc = allocations.find(
-    (a) => a.startsWith('DesignSafe-DCV') || a.startsWith('DS-HPC')
-  );
+  const portalAlloc = allocations.find((a) => a.startsWith('DS-HPC'));
 
   const { fileInputs, parameterSet, configuration, outputs } = FormSchema(
     definition,

--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -141,9 +141,6 @@ export const AppsSubmissionForm: React.FC = () => {
     borderBottom: '1px solid #707070',
     fontSize: 16,
   };
-  const layoutStyle = {
-    overflow: 'auto',
-  };
 
   const missingLicense = license.type && !license.enabled;
 
@@ -471,7 +468,7 @@ export const AppsSubmissionForm: React.FC = () => {
 
   return (
     <>
-      <Layout style={layoutStyle}>
+      <Layout style={{ overflowY: 'scroll', overflowX: 'hidden' }}>
         <Space direction="vertical" style={{ width: '100%' }}>
           <Header style={headerStyle}>
             <Flex justify="space-between">

--- a/client/modules/workspace/src/AppsWizard/AppsWizard.tsx
+++ b/client/modules/workspace/src/AppsWizard/AppsWizard.tsx
@@ -50,15 +50,11 @@ export const AppsWizard: React.FC<{
     background: 'transparent',
     borderBottom: '1px solid #707070',
   };
-  const layoutStyle = {
-    overflow: 'hidden',
-  };
-
   const { Header, Content } = Layout;
 
   return (
     <Flex gap="middle" wrap="wrap">
-      <Layout style={layoutStyle}>
+      <Layout style={{ overflow: 'auto' }}>
         <Header style={headerStyle}>
           <Flex justify="space-between">
             <span>{step.title}</span>

--- a/client/modules/workspace/src/JobStatusNav/JobStatusNav.tsx
+++ b/client/modules/workspace/src/JobStatusNav/JobStatusNav.tsx
@@ -7,8 +7,9 @@ import { useGetNotifications } from '@client/hooks';
 
 export const JobStatusNav: React.FC = () => {
   const { data } = useGetNotifications({
-    event_types: ['interactive_session_ready', 'job'],
+    eventTypes: ['interactive_session_ready', 'job'],
     read: false,
+    markRead: false,
   });
   const unreadNotifs = new Set(data?.notifs.map((x) => x.extra.uuid)).size;
 

--- a/client/modules/workspace/src/JobStatusNav/JobStatusNav.tsx
+++ b/client/modules/workspace/src/JobStatusNav/JobStatusNav.tsx
@@ -3,12 +3,14 @@ import { NavLink } from 'react-router-dom';
 import { Layout, Badge } from 'antd';
 import { Icon } from '@client/common-components';
 import styles from './JobStatusNav.module.css';
-import { useGetUnreadNotifications } from '@client/hooks';
+import { useGetNotifications } from '@client/hooks';
 
 export const JobStatusNav: React.FC = () => {
-  const { data: unreadNotifs } = useGetUnreadNotifications({
+  const { data } = useGetNotifications({
     event_types: ['interactive_session_ready', 'job'],
+    read: false,
   });
+  const unreadNotifs = new Set(data?.notifs.map((x) => x.extra.uuid)).size;
 
   const { Header } = Layout;
 
@@ -21,7 +23,7 @@ export const JobStatusNav: React.FC = () => {
   };
   return (
     <Header style={headerStyle}>
-      <Badge count={unreadNotifs?.unread} size="small" className={styles.badge}>
+      <Badge count={unreadNotifs} size="small" className={styles.badge}>
         <Icon
           className={`ds-icon-Job-Status ${styles.icon}`}
           label="Job-Status"

--- a/client/modules/workspace/src/JobsDetailModal/JobsDetailModal.tsx
+++ b/client/modules/workspace/src/JobsDetailModal/JobsDetailModal.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { useGetJobs, TTapisJob } from '@client/hooks';
 import styles from './JobsDetailModal.module.css';
 import { getStatusText, isOutputState, isTerminalState } from '../utils/jobs';
-import { formatDateTime } from '../utils/timeFormat';
+import { formatDateTimeFromValue } from '../utils/timeFormat';
 import { JobActionButton } from '../JobsListing/JobsListing';
 import { Spinner } from '@client/common-components';
 
@@ -84,9 +84,13 @@ export const JobsDetailModalBody: React.FC<{
         <dt>Status</dt>
         <dd>{getStatusText(jobData.status)}</dd>
         <dt>Submitted</dt>
-        <dd>{formatDateTime(new Date(jobData.created))}</dd>
-        <dt>Finished</dt>
-        <dd>{formatDateTime(new Date(jobData.ended))}</dd>
+        <dd>{formatDateTimeFromValue(jobData.created)}</dd>
+        {jobData.ended && (
+          <>
+            <dt>Finished</dt>
+            <dd>{formatDateTimeFromValue(jobData.ended)}</dd>
+          </>
+        )}
         <dt>Last Status Message</dt>
         <dd>{jobData.lastMessage}</dd>
       </dl>

--- a/client/modules/workspace/src/JobsDetailModal/JobsDetailModal.tsx
+++ b/client/modules/workspace/src/JobsDetailModal/JobsDetailModal.tsx
@@ -66,6 +66,7 @@ export const JobsDetailModalBody: React.FC<{
             title="Cancel Job"
             operation="cancelJob"
             type="primary"
+            danger
           />
         )}
       </div>

--- a/client/modules/workspace/src/JobsListing/JobsListing.tsx
+++ b/client/modules/workspace/src/JobsListing/JobsListing.tsx
@@ -92,6 +92,7 @@ export const JobsListing: React.FC<Omit<TableProps, 'columns'>> = ({
   const queryClient = useQueryClient();
   const { data: interactiveSessionNotifs } = useGetNotifications({
     eventTypes: ['interactive_session_ready'],
+    markRead: false,
   });
   const { mutate: readNotifications } = useReadNotifications();
 

--- a/client/modules/workspace/src/JobsListing/JobsListing.tsx
+++ b/client/modules/workspace/src/JobsListing/JobsListing.tsx
@@ -11,6 +11,7 @@ import {
   usePostJobs,
   TJobPostOperations,
   useReadNotifications,
+  TGetNotificationsResponse,
 } from '@client/hooks';
 import {
   JobsListingTable,
@@ -89,29 +90,36 @@ export const JobsListing: React.FC<Omit<TableProps, 'columns'>> = ({
 }) => {
   const queryClient = useQueryClient();
   const { data: interactiveSessionNotifs } = useGetNotifications({
-    event_types: ['interactive_session_ready'],
+    eventTypes: ['interactive_session_ready'],
   });
   const { mutate: readNotifications } = useReadNotifications();
 
   // mark all as read on component mount
   useEffect(() => {
     readNotifications({
-      event_types: ['interactive_session_ready', 'job'],
+      eventTypes: ['interactive_session_ready', 'job'],
     });
-  }, []);
 
-  // update unread count state
-  queryClient.setQueryData(
-    [
-      'workspace',
-      'notifications',
-      'badge',
-      {
-        event_types: ['interactive_session_ready', 'job'],
-      },
-    ],
-    0
-  );
+    // update unread count state
+    queryClient.setQueryData(
+      [
+        'workspace',
+        'notifications',
+        {
+          eventTypes: ['interactive_session_ready', 'job'],
+          read: false,
+          markRead: false,
+        },
+      ],
+      (oldData: TGetNotificationsResponse) => {
+        return {
+          ...oldData,
+          notifs: [],
+          unread: 0,
+        };
+      }
+    );
+  }, []);
 
   const columns: TJobsListingColumns = useMemo(
     () => [

--- a/client/modules/workspace/src/JobsListing/JobsListing.tsx
+++ b/client/modules/workspace/src/JobsListing/JobsListing.tsx
@@ -27,6 +27,7 @@ import {
 } from '../utils';
 import { InteractiveSessionModal } from '../InteractiveSessionModal';
 import styles from './JobsListing.module.css';
+import { formatDateTimeFromValue } from '../utils/timeFormat';
 
 export const JobActionButton: React.FC<{
   uuid: string;
@@ -204,27 +205,6 @@ export const JobsListing: React.FC<Omit<TableProps, 'columns'>> = ({
         title: 'Time Submitted - Finished',
         dataIndex: 'created',
         render: (_, job) => {
-          const formatDate = (dateString: string) => {
-            if (!dateString) return '';
-            const date = new Date(dateString);
-            const month = date.getMonth() + 1; // getMonth() is zero-indexed
-            const day = date.getDate();
-            const year = date.getFullYear();
-            let hours = date.getHours();
-            const minutes = date.getMinutes();
-            // const amPm = hours >= 12 ? 'PM' : 'AM';
-            hours = hours % 12;
-            hours = hours ? hours : 12; // the hour '0' should be '12'
-            // Format the date and time parts to ensure two digits
-            const formattedDate = `${month.toString().padStart(2, '0')}/${day
-              .toString()
-              .padStart(2, '0')}/${year}`;
-            const formattedTime = `${hours
-              .toString()
-              .padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
-            return `${formattedDate} ${formattedTime}`;
-          };
-
           const formatDuration = (start: string, end: string) => {
             if (!start || !end) return '';
             const startDate = new Date(start).getTime();
@@ -240,8 +220,8 @@ export const JobsListing: React.FC<Omit<TableProps, 'columns'>> = ({
               .toString()
               .padStart(2, '0')}`;
           };
-          const formattedStart = formatDate(job.created);
-          const formattedEnd = formatDate(job.ended);
+          const formattedStart = formatDateTimeFromValue(job.created);
+          const formattedEnd = formatDateTimeFromValue(job.ended);
           const runtime = formatDuration(job.created, job.ended);
 
           return (

--- a/client/modules/workspace/src/JobsListing/JobsListing.tsx
+++ b/client/modules/workspace/src/JobsListing/JobsListing.tsx
@@ -1,9 +1,10 @@
 import React, { useMemo, useState, useEffect } from 'react';
-import { TableProps, Row, Flex } from 'antd';
+import { TableProps, Row, Flex, Button as AntButton } from 'antd';
 import type { ButtonSize } from 'antd/es/button';
 import { useQueryClient } from '@tanstack/react-query';
 import { NavLink } from 'react-router-dom';
 import { PrimaryButton, SecondaryButton } from '@client/common-components';
+import { BaseButtonProps } from 'antd/es/button/button';
 import {
   useGetNotifications,
   TJobStatusNotification,
@@ -30,17 +31,21 @@ export const JobActionButton: React.FC<{
   uuid: string;
   operation: TJobPostOperations;
   title: string;
-  type?: 'primary' | 'secondary';
+  type?: BaseButtonProps['type'];
   size?: ButtonSize;
-}> = ({ uuid, operation, title, type, size, ...props }) => {
+  danger?: boolean;
+}> = ({ uuid, operation, title, type, size, danger = false }) => {
   const { mutate: mutateJob, isPending, isSuccess } = usePostJobs();
-  const Button = type === 'primary' ? PrimaryButton : SecondaryButton;
+  const Button =
+    type === 'primary' ? (danger ? AntButton : PrimaryButton) : SecondaryButton;
   return (
     <Button
       size={size || 'middle'}
       onClick={() => mutateJob({ uuid, operation })}
       loading={isPending}
-      disabled={isPending}
+      disabled={isPending || isSuccess}
+      danger={danger}
+      type={type}
     >
       {title}
       {isSuccess && <i className="fa fa-check" style={{ marginLeft: 5 }} />}

--- a/client/modules/workspace/src/JobsListing/JobsListingTable/JobsListingTable.module.css
+++ b/client/modules/workspace/src/JobsListing/JobsListingTable/JobsListingTable.module.css
@@ -1,3 +1,7 @@
 .listing-table-base {
   height: 100%;
 }
+
+.highlighted-row {
+  background-color: #e6f4ff;
+}

--- a/client/modules/workspace/src/Toast/Toast.tsx
+++ b/client/modules/workspace/src/Toast/Toast.tsx
@@ -22,14 +22,7 @@ const Notifications = () => {
       notification.event_type === 'interactive_session_ready'
     ) {
       queryClient.invalidateQueries({
-        queryKey: [
-          'workspace',
-          'notifications',
-          'badge',
-          {
-            event_types: ['interactive_session_ready', 'job'],
-          },
-        ],
+        queryKey: ['workspace', 'notifications'],
       });
       queryClient.invalidateQueries({
         queryKey: ['workspace', 'jobsListing'],

--- a/client/modules/workspace/src/utils/timeFormat.ts
+++ b/client/modules/workspace/src/utils/timeFormat.ts
@@ -43,7 +43,12 @@ export function formatDateTime(dateTime: Date) {
  * @param {DateTimeValue} dateTimeValue - A single value date-time representation
  * @returns {string}
  */
-export function formatDateTimeFromValue(dateTimeValue: number) {
+export function formatDateTimeFromValue(
+  dateTimeValue?: string | number | Date
+) {
+  if (!dateTimeValue) {
+    return '';
+  }
   const date = new Date(dateTimeValue);
 
   return formatDateTime(date);

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -124,7 +124,7 @@
 
 /* Do NOT scroll "Applications:" and "Job Status" */
 .ant-layout-sider-children {
-  overflow-y: hidden;
+  overflow-y: scroll;
   display: flex;
   flex-flow: column;
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -73,12 +73,14 @@
   padding-inline: 0px !important;
   height: unset;
   padding: 0px !important;
-  color: #337ab7 !important;
-}
+  &:not(.ant-btn-disabled, [disabled]) {
+    color: #337ab7 !important;
 
-.ant-btn-link:hover span {
-  color: #23527c !important;
-  text-decoration: underline !important;
+    &:hover span {
+      color: #23527c !important;
+      text-decoration: underline !important;
+    }
+  }
 }
 
 .listing-nav-link {

--- a/client/src/workspace/layouts/AppsPlaceholderLayout.tsx
+++ b/client/src/workspace/layouts/AppsPlaceholderLayout.tsx
@@ -14,7 +14,7 @@ export const AppsPlaceholderLayout: React.FC = () => {
         className={`${styles['appDetail-wrapper']} ${styles['has-message']} ${styles['appDetail-placeholder-message']}`}
       >
         {hasApps
-          ? `Select an app from the tray to submit a job.`
+          ? `Select an app from the menu on the left to submit a job.`
           : `No apps to show.`}
       </Layout.Content>
     </Layout>

--- a/client/src/workspace/layouts/WorkspaceBaseLayout.tsx
+++ b/client/src/workspace/layouts/WorkspaceBaseLayout.tsx
@@ -58,7 +58,7 @@ const WorkspaceRoot: React.FC = () => {
           }}
         >
           <Sider
-            width={200}
+            width={250}
             theme="light"
             breakpoint="md"
             collapsedWidth={0}

--- a/designsafe/apps/api/notifications/views/api.py
+++ b/designsafe/apps/api/notifications/views/api.py
@@ -16,7 +16,7 @@ class ManageNotificationsView(SecureMixin, JSONResponseMixin, BaseApiView):
         limit = request.GET.get("limit", 0)
         page = request.GET.get("page", 0)
         read = request.GET.get("read")
-        event_types = request.GET.getlist("eventTypes")
+        event_types = request.GET.getlist("eventTypes[]")
         mark_read = request.GET.get(
             "markRead", True
         )  # mark read by default to support legacy behavior
@@ -119,7 +119,7 @@ class NotificationsBadgeView(SecureMixin, JSONResponseMixin, BaseApiView):
 
     def get(self, request, *args, **kwargs):
         """Get count of unread notifications of a certain event type."""
-        event_types = request.GET.getlist("eventTypes")
+        event_types = request.GET.getlist("eventTypes[]")
 
         if event_types:
             unread = Notification.objects.filter(

--- a/designsafe/apps/api/notifications/views/api.py
+++ b/designsafe/apps/api/notifications/views/api.py
@@ -17,6 +17,9 @@ class ManageNotificationsView(SecureMixin, JSONResponseMixin, BaseApiView):
         page = request.GET.get("page", 0)
         read = request.GET.get("read")
         event_types = request.GET.getlist("eventTypes")
+        mark_read = request.GET.get(
+            "markRead", True
+        )  # mark read by default to support legacy behavior
 
         query_params = {}
         if read is not None:
@@ -54,9 +57,10 @@ class ManageNotificationsView(SecureMixin, JSONResponseMixin, BaseApiView):
             offset = page * limit
             notifs = notifs[offset : offset + limit]
 
-        for n in notifs:
-            if not n.read:
-                n.mark_read()
+        if mark_read:
+            for n in notifs:
+                if not n.read:
+                    n.mark_read()
 
         notifs = [n.to_dict() for n in notifs]
         return JsonResponse(

--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -122,7 +122,7 @@ AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
 )
 
-LOGIN_REDIRECT_URL = os.environ.get('LOGIN_REDIRECT_URL', '/account/')
+LOGIN_REDIRECT_URL = os.environ.get('LOGIN_REDIRECT_URL', '/dashboard/')
 LOGOUT_REDIRECT_URL = os.environ.get('LOGOUT_REDIRECT_URL', '/auth/logged-out/')
 
 CACHES = {

--- a/designsafe/static/scripts/ng-designsafe/components/notification-badge/notification-badge.component.html
+++ b/designsafe/static/scripts/ng-designsafe/components/notification-badge/notification-badge.component.html
@@ -20,7 +20,7 @@
       <div class="notifications-wrapper">
         <li ng-repeat="x in data.notifications">
           <div class="notification-item">
-            <a class="content" href="{{x.action_link}}" ng-attr-target="{{ x.operation === 'web_link' ? '_blank' : undefined }}">
+            <a class="content" href="{{x.action_link}}" ng-attr-target="{{ x.event_type === 'interactive_session_ready' ? '_blank' : undefined }}">
                 <dl class="dl-horizontal">
                   <dt>{{x.datetime| date:'MMM dd, yyyy'}}<br>
                       {{x.datetime| date:'h:mm a'}}

--- a/designsafe/static/scripts/ng-designsafe/controllers/notifications.js
+++ b/designsafe/static/scripts/ng-designsafe/controllers/notifications.js
@@ -40,12 +40,13 @@ export function NotificationBadgeCtrl(
             $scope.data.unread = 0;
           }
 
-          for (var i=0; i < $scope.data.notifications.length; i++){
-            if ($scope.data.notifications[i]['event_type'] == 'job') {
-              $scope.data.notifications[i]['action_link']=$scope.data.notifications[i]['action_link']=`/rw/workspace/notification/process/${$scope.data.notifications[i]['pk']}`;
-            } else if ($scope.data.notifications[i]['event_type'] == 'data_depot') {
-              $scope.data.notifications[i]['action_link']=$scope.data.notifications[i]['action_link']=`/rw/workspace/notification/process/${$scope.data.notifications[i]['pk']}`;
-            }
+          for (var i = 0; i < $scope.data.notifications.length; i++) {
+              const notification = $scope.data.notifications[i];
+              if (notification['event_type'] == 'job') {
+                  notification['action_link'] = `/rw/workspace/history`;
+              } else if (notification['event_type'] == 'data_depot') {
+                  notification['action_link'] = `/data/browser`;
+              }
           }
         });
       };

--- a/designsafe/static/scripts/ng-designsafe/providers/notifications-provider.js
+++ b/designsafe/static/scripts/ng-designsafe/providers/notifications-provider.js
@@ -33,10 +33,10 @@ function NotificationService(
             url = processors[eventType].renderLink(msg);
         }
         if (msg.status != 'ERROR') {
-            if (msg.event_type == 'job') {
-                url=`/rw/workspace/notification/process/${msg.pk}`
+            if (msg.event_type === 'job') {
+                url = `/rw/workspace/history`;
             } else if (msg.event_type == 'data_depot') {
-                url=`/rw/workspace/notification/process/${msg.pk}`
+                url = `/data/browser`;
             }
         }
         return url;

--- a/designsafe/static/scripts/notifications/app.js
+++ b/designsafe/static/scripts/notifications/app.js
@@ -31,14 +31,12 @@ angular.module('designsafe').controller('NotificationListCtrl', ['$scope','$root
         $scope.data.pagination.total = resp.total;
         $scope.data.notifications = resp.notifs;
 
-        for (var i=0; i < $scope.data.notifications.length; i++){
-            // $scope.data.notifications[i] = angular.fromJson($scope.data.notifications[i]);
-            // $scope.data.notifications[i]['fields']['extra'] = angular.fromJson($scope.data.notifications[i]['fields']['extra']);
-            // $scope.data.notifications[i]['datetime'] = Date($scope.data.notifications[i]['datetime']);
-            if ($scope.data.notifications[i]['event_type'] == 'job') {
-            $scope.data.notifications[i]['action_link']=`/rw/workspace/notification/process/${$scope.data.notifications[i]['pk']}`;
-            } else if ($scope.data.notifications[i]['event_type'] == 'data_depot') {
-            $scope.data.notifications[i]['action_link']=`/rw/workspace/notification/process/${$scope.data.notifications[i]['pk']}`;
+        for (var i = 0; i < $scope.data.notifications.length; i++) {
+            const notification = $scope.data.notifications[i];
+            if (notification['event_type'] == 'job') {
+                notification['action_link'] = `/rw/workspace/history`;
+            } else if (notification['event_type'] == 'data_depot') {
+                notification['action_link'] = '/data/browser';
             }
         }
 


### PR DESCRIPTION
## Overview: ##

Fixes for issues discovered during the [testing session](https://tacc-main.atlassian.net/wiki/x/AYDiD) on 6/12/24.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2831](https://tacc-main.atlassian.net/browse/DES-2831)
* [DES-2887](https://tacc-main.atlassian.net/browse/DES-2887)
* [DES-2889](https://tacc-main.atlassian.net/browse/DES-2889)
* [DES-2890](https://tacc-main.atlassian.net/browse/DES-2890)
* [DES-2891](https://tacc-main.atlassian.net/browse/DES-2891)
* [DES-2893](https://tacc-main.atlassian.net/browse/DES-2893)
* [DES-2899](https://tacc-main.atlassian.net/browse/DES-2899)
* [DES-2900](https://tacc-main.atlassian.net/browse/DES-2900)

## Summary of Changes: ##

- Fix bad job finished date while job is running
- Fix scroll for long app form
- Fix login redirect always going to /account
- Fix disabled state styling for AntD button elements, .e.g. in app form
- Fix notification bell notification action links
- Job Status notification count is now a count of notifications with unique job uuids
- Disable Job Action buttons after success (e.g. "Cancel Job"), and cancel button is now red
- Newest incoming notification now highlights row for that job
- Removed DesignSafe-DCV allocation as default
- Other small fixes for notifications and app form styling

## Testing Steps: ##
1. Logout, then go directly to https://designsafe.dev/rw/workspace in your browser, ensure the redirect after login takes you there instead of /account
2. Load https://designsafe.dev/rw/workspace/swbatch?appVersion=0.4.1, and ensure you can scroll down to see full form. Do this for all steps of an app form.
3. Submit a single job, and ensure notification bell on left side "Job Status" never has more than (1) notification
4. Click on Job Status, and see that new incoming notifications highlight the row for that job
5. Click "View Details", and see that "Cancel Job" is red, and "Output Pending" displays as disabled
6. Click "Cancel Job" and see that button is disabled after success

## UI Photos:
- Highlighted row for incoming notification
![Screenshot 2024-06-14 at 10 47 22 AM](https://github.com/DesignSafe-CI/portal/assets/20326896/43e4fabc-8274-4fa2-96ad-5ecb13f895c3)
- Fixed disabled state style for AntD button (button as link here for "Output Pending"), and red "Cancel Job" button
![Screenshot 2024-06-14 at 10 46 05 AM](https://github.com/DesignSafe-CI/portal/assets/20326896/24ec9d9c-3427-4734-962c-0dd2b8be75a9)
- Disabled action button after successful cancel
![Screenshot 2024-06-14 at 10 46 14 AM](https://github.com/DesignSafe-CI/portal/assets/20326896/1e0c43e7-90a7-4637-bfa4-408a64e5d66f)

