### PR TITLE
Task/des 2842 deselect app from nav

### DIFF
--- a/client/modules/workspace/src/AppsSideNav/AppsSideNav.tsx
+++ b/client/modules/workspace/src/AppsSideNav/AppsSideNav.tsx
@@ -112,7 +112,7 @@ export const AppsSideNav: React.FC<{ categories: TAppCategory[] }> = ({
   const currentSubMenu = currentApp?.is_bundled
     ? `${currentApp.bundle_label}${currentApp.bundle_id}`
     : '';
-  const defaultKey = `${appId}${appVersion || ''}${currentApp?.bundle_id}`;
+  const selectedKey = `${appId}${appVersion || ''}${currentApp?.bundle_id}`;
 
   return (
     <>
@@ -133,7 +133,7 @@ export const AppsSideNav: React.FC<{ categories: TAppCategory[] }> = ({
           (currentCategory as TAppCategory)?.title,
           currentSubMenu,
         ]}
-        defaultSelectedKeys={[defaultKey]}
+        selectedKeys={[selectedKey]}
         items={items}
         inlineIndent={10}
       />


### PR DESCRIPTION
## Overview: ##
Based on route, select/deselect menu items so that only the active app is ever selected

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2842](https://tacc-main.atlassian.net/browse/DES-2842)

## Summary of Changes: ##
Used selecteKey property of menu rather than defaultKey so that the useGetAppParams correctly passes the app id and app version to the menu component
## Testing Steps: ##
1. Select an app from [https://designsafe.dev/rw/workspace/](https://designsafe.dev/rw/workspace/) and make sure the menu item is highlighted and active as expected
2. Select Job Status from this page and make sure the app menu item is no longer set to active

## UI Photos:
![Screenshot 2024-06-14 at 1 57 59 PM](https://github.com/DesignSafe-CI/portal/assets/96220951/97f57a46-9dca-48ae-b2e2-e1c776f2ab62)

![Screenshot 2024-06-14 at 1 58 26 PM](https://github.com/DesignSafe-CI/portal/assets/96220951/2b0902a3-4d83-4b40-892e-85d9a49c38e5)


## Notes: ##
