### PR TITLE
Task/des 2905 cite this data type other

### DIFF
--- a/client/modules/datafiles/src/projects/ProjectCitation/ProjectCitation.tsx
+++ b/client/modules/datafiles/src/projects/ProjectCitation/ProjectCitation.tsx
@@ -4,7 +4,7 @@ import {
   useProjectDetail,
   usePublicationDetail,
 } from '@client/hooks';
-import { MetricsModal } from '@client/datafiles';
+import { MetricsModal } from '../modals/MetricsModal';
 import styles from './ProjectCitation.module.css';
 
 export const ProjectCitation: React.FC<{

--- a/client/modules/datafiles/src/projects/ProjectCitation/ProjectCitation.tsx
+++ b/client/modules/datafiles/src/projects/ProjectCitation/ProjectCitation.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   useCitationMetrics,
   useProjectDetail,
   usePublicationDetail,
 } from '@client/hooks';
-// import { MetricsModal } from '../modals/MetricsModal';
+import { MetricsModal } from '@client/datafiles';
 import styles from './ProjectCitation.module.css';
 
 export const ProjectCitation: React.FC<{
@@ -91,6 +91,8 @@ export const DownloadCitation: React.FC<{
     error: projectError,
   } = usePublicationDetail(projectId);
 
+  const [isModalVisible, setIsModalVisible] = useState(false);
+
   const entityDetails = (data?.tree.children ?? []).find(
     (child) => child.uuid === entityUuid
   );
@@ -101,6 +103,14 @@ export const DownloadCitation: React.FC<{
       : '';
 
   const { data: citationMetrics, isLoading, isError } = useCitationMetrics(doi);
+
+  const openModal = () => {
+    setIsModalVisible(true);
+  };
+
+  const closeModal = () => {
+    setIsModalVisible(false);
+  };
 
   if (isProjectLoading) return <div>Loading project details...</div>;
   if (isProjectError)
@@ -154,13 +164,18 @@ export const DownloadCitation: React.FC<{
               Citations
             </span>
             &nbsp;&nbsp;&nbsp;&nbsp;
-            {/* <span
+            <span
               onClick={openModal}
               style={{ cursor: 'pointer', color: '#337AB7', fontWeight: 'bold' }}
             >
               Details
-            </span> */}
-            {/* <MetricsModal isOpen={isModalVisible} handleCancel={closeModal} data1={citationMetrics?.data1} /> */}
+            </span>
+            <MetricsModal
+                  isOpen={isModalVisible}
+                  handleCancel={closeModal}
+                  eventMetricsData={citationMetrics?.data1}
+                  usageMetricsData={citationMetrics?.data2}
+                />
           </div>
         </div>
       )}

--- a/client/modules/datafiles/src/projects/ProjectCitation/ProjectCitation.tsx
+++ b/client/modules/datafiles/src/projects/ProjectCitation/ProjectCitation.tsx
@@ -166,16 +166,20 @@ export const DownloadCitation: React.FC<{
             &nbsp;&nbsp;&nbsp;&nbsp;
             <span
               onClick={openModal}
-              style={{ cursor: 'pointer', color: '#337AB7', fontWeight: 'bold' }}
+              style={{
+                cursor: 'pointer',
+                color: '#337AB7',
+                fontWeight: 'bold',
+              }}
             >
               Details
             </span>
             <MetricsModal
-                  isOpen={isModalVisible}
-                  handleCancel={closeModal}
-                  eventMetricsData={citationMetrics?.data1}
-                  usageMetricsData={citationMetrics?.data2}
-                />
+              isOpen={isModalVisible}
+              handleCancel={closeModal}
+              eventMetricsData={citationMetrics?.data1}
+              usageMetricsData={citationMetrics?.data2}
+            />
           </div>
         </div>
       )}

--- a/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
@@ -239,11 +239,37 @@ export const PublishedEntityDisplay: React.FC<{
         ) : (
           <PublishedCitation projectId={projectId} entityUuid={treeData.uuid} />
         )}
+        <br />
         {isLoading && <div>Loading citation metrics...</div>}
         {isError && <div>Error fetching citation metrics</div>}
         {citationMetrics && (
           <div>
             <strong>Download Citation:</strong>
+            <a
+              href={`https://data.datacite.org/application/vnd.datacite.datacite+xml/${dois}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              DataCite XML
+            </a>{' '}
+            |
+            <a
+              href={`https://data.datacite.org/application/x-research-info-systems/${dois}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {' '}
+              RIS
+            </a>{' '}
+            |
+            <a
+              href={`https://data.datacite.org/application/x-bibtex/${dois}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {' '}
+              BibTeX
+            </a>
             <div>
               <span className={styles['yellow-highlight']}>
                 {citationMetrics?.data2?.data.attributes.downloadCount ?? '--'}{' '}

--- a/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
@@ -23,7 +23,6 @@ import {
 } from '@client/common-components';
 import { Link } from 'react-router-dom';
 import { PublishedEntityDetails } from '../PublishedEntityDetails';
-import { MetricsModal } from '../modals/MetricsModal';
 import { PreviewModalBody } from '../../DatafilesModal/PreviewModal';
 import { SubEntityDetails } from '../SubEntityDetails';
 
@@ -173,7 +172,6 @@ export const PublishedEntityDisplay: React.FC<{
   defaultOpenChildren = false,
 }) => {
   const [active, setActive] = useState<boolean>(defaultOpen);
-  const [isModalVisible, setIsModalVisible] = useState(false);
   const sortedChildren = useMemo(
     () => [...(treeData.children ?? [])].sort((a, b) => a.order - b.order),
     [treeData]
@@ -190,13 +188,6 @@ export const PublishedEntityDisplay: React.FC<{
     error,
   } = useCitationMetrics(dois);
 
-  const openModal = () => {
-    setIsModalVisible(true);
-  };
-
-  const closeModal = () => {
-    setIsModalVisible(false);
-  };
   useEffect(() => {
     if (isError) {
       console.error('Error fetching citation metrics:', error);

--- a/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
@@ -14,7 +14,7 @@ import { ProjectCollapse } from '../ProjectCollapser/ProjectCollapser';
 import {
   ProjectCitation,
   PublishedCitation,
-  DownloadCitation
+  DownloadCitation,
 } from '../ProjectCitation/ProjectCitation';
 import {
   FileListingTable,
@@ -242,10 +242,13 @@ export const PublishedEntityDisplay: React.FC<{
         )}
         <br />
         {citationMetrics && (
-            <div>
-              <DownloadCitation projectId={projectId} entityUuid={treeData.uuid} />
-            </div>
-          )}
+          <div>
+            <DownloadCitation
+              projectId={projectId}
+              entityUuid={treeData.uuid}
+            />
+          </div>
+        )}
       </article>
       <Collapse
         expandIcon={() => null}

--- a/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
@@ -14,6 +14,7 @@ import { ProjectCollapse } from '../ProjectCollapser/ProjectCollapser';
 import {
   ProjectCitation,
   PublishedCitation,
+  DownloadCitation
 } from '../ProjectCitation/ProjectCitation';
 import {
   FileListingTable,
@@ -240,71 +241,11 @@ export const PublishedEntityDisplay: React.FC<{
           <PublishedCitation projectId={projectId} entityUuid={treeData.uuid} />
         )}
         <br />
-        {isLoading && <div>Loading citation metrics...</div>}
-        {isError && <div>Error fetching citation metrics</div>}
         {citationMetrics && (
-          <div>
-            <strong>Download Citation: </strong>
-            <a
-              href={`https://data.datacite.org/application/vnd.datacite.datacite+xml/${dois}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              DataCite XML
-            </a>{' '}
-            |
-            <a
-              href={`https://data.datacite.org/application/x-research-info-systems/${dois}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {' '}
-              RIS
-            </a>{' '}
-            |
-            <a
-              href={`https://data.datacite.org/application/x-bibtex/${dois}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {' '}
-              BibTeX
-            </a>
             <div>
-              <span className={styles['yellow-highlight']}>
-                {citationMetrics?.data2?.data.attributes.downloadCount ?? '--'}{' '}
-                Downloads
-              </span>
-              &nbsp;&nbsp;&nbsp;&nbsp;
-              <span className={styles['yellow-highlight']}>
-                {citationMetrics?.data2?.data.attributes.viewCount ?? '--'}{' '}
-                Views
-              </span>
-              &nbsp;&nbsp;&nbsp;&nbsp;
-              <span className={styles['yellow-highlight']}>
-                {citationMetrics?.data2?.data.attributes.citationCount ?? '--'}{' '}
-                Citations
-              </span>
-              &nbsp;&nbsp;&nbsp;&nbsp;
-              <span
-                onClick={openModal}
-                style={{
-                  cursor: 'pointer',
-                  color: '#337AB7',
-                  fontWeight: 'bold',
-                }}
-              >
-                Details
-              </span>
-              <MetricsModal
-                isOpen={isModalVisible}
-                handleCancel={closeModal}
-                eventMetricsData={citationMetrics?.data1}
-                usageMetricsData={citationMetrics?.data2}
-              />
+              <DownloadCitation projectId={projectId} entityUuid={treeData.uuid} />
             </div>
-          </div>
-        )}
+          )}
       </article>
       <Collapse
         expandIcon={() => null}

--- a/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
@@ -244,7 +244,7 @@ export const PublishedEntityDisplay: React.FC<{
         {isError && <div>Error fetching citation metrics</div>}
         {citationMetrics && (
           <div>
-            <strong>Download Citation:</strong>
+            <strong>Download Citation: </strong>
             <a
               href={`https://data.datacite.org/application/vnd.datacite.datacite+xml/${dois}`}
               target="_blank"

--- a/client/modules/datafiles/src/projects/index.ts
+++ b/client/modules/datafiles/src/projects/index.ts
@@ -13,5 +13,6 @@ export {
 export {
   ProjectCitation,
   PublishedCitation,
+  DownloadCitation
 } from './ProjectCitation/ProjectCitation';
 export * from './modals';

--- a/client/modules/datafiles/src/projects/index.ts
+++ b/client/modules/datafiles/src/projects/index.ts
@@ -13,6 +13,6 @@ export {
 export {
   ProjectCitation,
   PublishedCitation,
-  DownloadCitation
+  DownloadCitation,
 } from './ProjectCitation/ProjectCitation';
 export * from './modals';

--- a/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
+++ b/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
@@ -196,16 +196,15 @@ export const MetricsModal: React.FC<MetricsModalProps> = ({
     return sumsByQuarter;
   }
 
-  const orderedYears = useMemo(
-    () =>{
-      return usageMetricsData.data.attributes.viewsOverTime
-        .map(entry => entry.yearMonth.split('-')[0]) // Get only the years
-        .filter((year, index, array) => array.indexOf(year) === index) // Unique years
-        .sort((a, b) => b.localeCompare(a)); // Sort descending
-    }, [usageMetricsData.data.attributes.viewsOverTime]);
-  
+  const orderedYears = useMemo(() => {
+    return usageMetricsData.data.attributes.viewsOverTime
+      .map((entry) => entry.yearMonth.split('-')[0]) // Get only the years
+      .filter((year, index, array) => array.indexOf(year) === index) // Unique years
+      .sort((a, b) => b.localeCompare(a)); // Sort descending
+  }, [usageMetricsData.data.attributes.viewsOverTime]);
+
   const defaultYear = orderedYears[0];
-  
+
   const [selectedYear, setSelectedYear] = useState(defaultYear);
 
   const [quarterSums, setQuarterSums] = useState<{
@@ -228,7 +227,7 @@ export const MetricsModal: React.FC<MetricsModalProps> = ({
         defaultYear
       );
       defaultSums['views'] = viewsByQuarter;
-      defaultSums['downloads'] = downloadsByQuarter; 
+      defaultSums['downloads'] = downloadsByQuarter;
     }
 
     return defaultSums;

--- a/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
+++ b/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
@@ -196,13 +196,16 @@ export const MetricsModal: React.FC<MetricsModalProps> = ({
     return sumsByQuarter;
   }
 
-  const defaultYear = useMemo(
-    () =>
-      usageMetricsData.data.attributes.viewsOverTime
-        .slice(-1)[0]
-        ?.yearMonth.split('-')[0],
-    [usageMetricsData.data.attributes.viewsOverTime]
-  );
+  const orderedYears = useMemo(
+    () =>{
+      return usageMetricsData.data.attributes.viewsOverTime
+        .map(entry => entry.yearMonth.split('-')[0]) // Get only the years
+        .filter((year, index, array) => array.indexOf(year) === index) // Unique years
+        .sort((a, b) => b.localeCompare(a)); // Sort descending
+    }, [usageMetricsData.data.attributes.viewsOverTime]);
+  
+  const defaultYear = orderedYears[0];
+  
   const [selectedYear, setSelectedYear] = useState(defaultYear);
 
   const [quarterSums, setQuarterSums] = useState<{
@@ -225,7 +228,7 @@ export const MetricsModal: React.FC<MetricsModalProps> = ({
         defaultYear
       );
       defaultSums['views'] = viewsByQuarter;
-      defaultSums['downloads'] = downloadsByQuarter;
+      defaultSums['downloads'] = downloadsByQuarter; 
     }
 
     return defaultSums;

--- a/client/src/datafiles/layouts/published/PublishedDetailLayout.module.css
+++ b/client/src/datafiles/layouts/published/PublishedDetailLayout.module.css
@@ -1,0 +1,3 @@
+.yellow-highlight {
+  background-color: #ece4bf;
+}

--- a/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
+++ b/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
@@ -51,9 +51,7 @@ export const PublishedDetailLayout: React.FC = () => {
   const { allVersions } = usePublicationVersions(projectId ?? '');
 
   const dois = data?.baseProject.dois[0] ? data?.baseProject.dois[0] : '';
-  const {
-    data: citationMetrics,
-  } = useCitationMetrics(dois);
+  const { data: citationMetrics } = useCitationMetrics(dois);
 
   const version = (projectId ?? '').split('v')[1];
   useEffect(() => {

--- a/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
+++ b/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
@@ -10,7 +10,7 @@ import {
   usePublicationVersions,
   useCitationMetrics,
 } from '@client/hooks';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { Button, Form, Input, Layout, Spin } from 'antd';
 import { Navigate, Outlet, useParams, useSearchParams } from 'react-router-dom';
 

--- a/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
+++ b/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
@@ -57,7 +57,6 @@ export const PublishedDetailLayout: React.FC = () => {
     data: citationMetrics,
     isLoading,
     isError,
-    error,
   } = useCitationMetrics(dois);
 
   const openModal = () => {

--- a/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
+++ b/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
@@ -146,7 +146,7 @@ export const PublishedDetailLayout: React.FC = () => {
           {isError && <div>Error fetching citation metrics</div>}
           {citationMetrics && (
             <div>
-              <strong>Download Citation:</strong>
+              <strong>Download Citation: </strong>
               <a
                 href={`https://data.datacite.org/application/vnd.datacite.datacite+xml/${dois}`}
                 target="_blank"

--- a/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
+++ b/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
@@ -3,7 +3,7 @@ import {
   DatafilesToolbar,
   DownloadDatasetModal,
   PublishedCitation,
-  DownloadCitation
+  DownloadCitation,
 } from '@client/datafiles';
 import {
   usePublicationDetail,
@@ -143,7 +143,10 @@ export const PublishedDetailLayout: React.FC = () => {
           <br />
           {citationMetrics && (
             <div>
-              <DownloadCitation projectId={projectId} entityUuid={data.tree.children[0].uuid} />
+              <DownloadCitation
+                projectId={projectId}
+                entityUuid={data.tree.children[0].uuid}
+              />
             </div>
           )}
         </section>

--- a/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
+++ b/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
@@ -13,8 +13,6 @@ import {
 import React, { useEffect, useState } from 'react';
 import { Button, Form, Input, Layout, Spin } from 'antd';
 import { Navigate, Outlet, useParams, useSearchParams } from 'react-router-dom';
-import { MetricsModal } from '@client/datafiles';
-import styles from './PublishedDetailLayout.module.css';
 
 const FileListingSearchBar = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -51,22 +49,11 @@ export const PublishedDetailLayout: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const { data } = usePublicationDetail(projectId ?? '');
   const { allVersions } = usePublicationVersions(projectId ?? '');
-  const [isModalVisible, setIsModalVisible] = useState(false);
 
   const dois = data?.baseProject.dois[0] ? data?.baseProject.dois[0] : '';
   const {
     data: citationMetrics,
-    isLoading,
-    isError,
   } = useCitationMetrics(dois);
-
-  const openModal = () => {
-    setIsModalVisible(true);
-  };
-
-  const closeModal = () => {
-    setIsModalVisible(false);
-  };
 
   const version = (projectId ?? '').split('v')[1];
   useEffect(() => {

--- a/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
+++ b/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
@@ -3,6 +3,7 @@ import {
   DatafilesToolbar,
   DownloadDatasetModal,
   PublishedCitation,
+  DownloadCitation
 } from '@client/datafiles';
 import {
   usePublicationDetail,
@@ -140,72 +141,9 @@ export const PublishedDetailLayout: React.FC = () => {
             entityUuid={data.tree.children[0].uuid}
           />
           <br />
-
-          {isLoading && <div>Loading citation metrics...</div>}
-          {isError && <div>Error fetching citation metrics</div>}
           {citationMetrics && (
             <div>
-              <strong>Download Citation: </strong>
-              <a
-                href={`https://data.datacite.org/application/vnd.datacite.datacite+xml/${dois}`}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                DataCite XML
-              </a>{' '}
-              |
-              <a
-                href={`https://data.datacite.org/application/x-research-info-systems/${dois}`}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {' '}
-                RIS
-              </a>{' '}
-              |
-              <a
-                href={`https://data.datacite.org/application/x-bibtex/${dois}`}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {' '}
-                BibTeX
-              </a>
-              <div>
-                <span className={styles['yellow-highlight']}>
-                  {citationMetrics?.data2?.data.attributes.downloadCount ??
-                    '--'}{' '}
-                  Downloads
-                </span>
-                &nbsp;&nbsp;&nbsp;&nbsp;
-                <span className={styles['yellow-highlight']}>
-                  {citationMetrics?.data2?.data.attributes.viewCount ?? '--'}{' '}
-                  Views
-                </span>
-                &nbsp;&nbsp;&nbsp;&nbsp;
-                <span className={styles['yellow-highlight']}>
-                  {citationMetrics?.data2?.data.attributes.citationCount ??
-                    '--'}{' '}
-                  Citations
-                </span>
-                &nbsp;&nbsp;&nbsp;&nbsp;
-                <span
-                  onClick={openModal}
-                  style={{
-                    cursor: 'pointer',
-                    color: '#337AB7',
-                    fontWeight: 'bold',
-                  }}
-                >
-                  Details
-                </span>
-                <MetricsModal
-                  isOpen={isModalVisible}
-                  handleCancel={closeModal}
-                  eventMetricsData={citationMetrics?.data1}
-                  usageMetricsData={citationMetrics?.data2}
-                />
-              </div>
+              <DownloadCitation projectId={projectId} entityUuid={data.tree.children[0].uuid} />
             </div>
           )}
         </section>


### PR DESCRIPTION
## Overview: ##
Added back the download citation options (DataCite XML | RIS | BibTeX) for all project types.
For type OTHER, added Downloads/Views/Citations, as well as Metrics Modal. 

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2905](https://tacc-main.atlassian.net/browse/DES-2905)

## Summary of Changes: ##
In the PublishedDetailLayout.tsx, I added the 'Download Citation' section for project type Other
I also added back the citation download options.

## Testing Steps: ##
1. Verify the Download Citation section appears in type Other like it does for FR, Exp, Sim, Hyb Sim
2. Verify that the Metrics Modal loads and the data is correct
3. Verify that the download citation links work and the downloads show correct data.

## UI Photos:
Experiment with 'Download Citation' options as hyperlinks
<img width="814" alt="Screen Shot 2024-06-17 at 10 03 05 AM" src="https://github.com/DesignSafe-CI/portal/assets/35277477/25c5f61f-9bd9-4578-a374-f34f0423a4c1">

Other with Download Citation options, Downloads/Views/Citations, and Metrics Modal.
<img width="900" alt="Screen Shot 2024-06-17 at 10 03 47 AM" src="https://github.com/DesignSafe-CI/portal/assets/35277477/ec76a417-eb3b-4b97-a256-6017a3018ebf">

## Notes: ##
