### PR TITLE
task/DES-2906: Enable JWT auth for License API

### DIFF
--- a/designsafe/apps/api/licenses/views.py
+++ b/designsafe/apps/api/licenses/views.py
@@ -1,31 +1,32 @@
-from designsafe.apps.api.views import BaseApiView
-from designsafe.apps.api.mixins import SecureMixin
-from designsafe.libs.common.decorators import profile as profile_fn
+"""Views for the licenses API."""
+
 from django.contrib.auth import get_user_model
 from django.http.response import HttpResponseForbidden, HttpResponseNotFound
 from django.http import JsonResponse
 from django.apps import apps
-from designsafe.apps.data.models.agave.util import AgaveJSONEncoder
+from designsafe.apps.api.views import AuthenticatedAllowJwtApiView
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-class LicenseView(SecureMixin, BaseApiView):
-    @profile_fn
+class LicenseView(AuthenticatedAllowJwtApiView):
+    """View for retrieving licenses for a specific app."""
+
     def get(self, request, app_name):
+        """Return the license for the given app."""
         if not request.user.is_staff:
             return HttpResponseForbidden()
 
         try:
-            app_license = apps.get_model('designsafe_licenses', '{}License'.format(app_name))
+            app_license = apps.get_model("designsafe_licenses", f"{app_name}License")
         except LookupError:
             return HttpResponseNotFound()
-        username = request.GET.get('username', None)
+        username = request.GET.get("username", None)
         if not username:
             return HttpResponseNotFound()
         user = get_user_model().objects.get(username=username)
         licenses = app_license.objects.filter(user=user)
 
-        user_license = licenses[0].license_as_str() if len(licenses) > 0 else ''
-        return JsonResponse({'license': user_license}, encoder=AgaveJSONEncoder)
+        user_license = licenses[0].license_as_str() if len(licenses) > 0 else ""
+        return JsonResponse({"license": user_license})


### PR DESCRIPTION
## Overview: ##

JupyterHub uses the Licenses API to enable MATLAB or LSDYNA for users in JupyterHub. This enables Tapis v3 JWT auth for this endpoint.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2906](https://tacc-main.atlassian.net/browse/DES-2906)

## Testing Steps: ##
1. Grab a jwt for your user, who is set as staff locally
  a. e.g. via tapipy: `user.get_tokens()`, then `user.access_token.access_token`
2. curl your local endpoint: 
  ```
❯ curl -H "x-tapis-token: $jwt" -X GET https://designsafe.dev/api/licenses/MATLAB/\?username\=sal
{"license": "LICENSE HERE"}%
```

