### PR TITLE
Bug/DES-2896  Do not block continue to next step on invalid fields

### DIFF
--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -301,17 +301,14 @@ export const AppsSubmissionForm: React.FC = () => {
     setSteps(updatedSteps);
   }, [fields]);
 
-  // Only allow transition to next step, if the current step has
-  // no validation errors.
+  // next step transition does not block on invalid fields
   const handleNextStep = useCallback(async () => {
     const stepFields = Object.keys(fieldValues).filter((key) =>
       key.startsWith(current)
     ) as FieldNameUnion[];
-    const isValid = await methods.trigger(stepFields);
-    if (isValid) {
-      const nextPage = steps[current].nextPage;
-      nextPage && setCurrent(nextPage);
-    }
+    await methods.trigger(stepFields);
+    const nextPage = steps[current].nextPage;
+    nextPage && setCurrent(nextPage);
   }, [current, methods]);
   const handlePreviousStep = useCallback(() => {
     const prevPage = steps[current].prevPage;


### PR DESCRIPTION
## Overview: ##
 Do not block continue to next step on invalid fields. Previously continue button was disabled or did nothing if there are validation errors. This bug removes that restriction

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2896](https://tacc-main.atlassian.net/browse/DES-2896)

## Summary of Changes: ##

## Testing Steps: ##
1. https://designsafe.dev/rw/workspace/swbatch?appVersion=0.4.1
2. Click through continue without entering values
3. Click back and see that required fields have validation error messages.

## UI Photos:

## Notes: ##
