### PR TITLE
Bugs/DES-2907: Exclude allocations at portal level

### DIFF
--- a/conf/env_files/designsafe.sample.env
+++ b/conf/env_files/designsafe.sample.env
@@ -26,6 +26,12 @@ TAS_CLIENT_SECRET=
 TAS_URL=
 
 ###
+# ALLOCATION
+# Add any allocation to exclude only from portal
+# This will be a comma separated list.
+ALLOCATIONS_TO_EXCLUDE=
+
+###
 # EMAIL
 #
 SMTP_HOST=

--- a/designsafe/apps/workspace/api/views.py
+++ b/designsafe/apps/workspace/api/views.py
@@ -880,8 +880,12 @@ class AllocationsView(AuthenticatedApiView):
         """
         data = self._get_allocations(request.user)
         # Exclude allocation based on allocation setting list.
-        for host, allocations in data['hosts'].items():
-            data['hosts'][host] = [allocation for allocation in allocations if allocation not in settings.ALLOCATIONS_TO_EXCLUDE]
+        for host, allocations in data["hosts"].items():
+            data["hosts"][host] = [
+                allocation
+                for allocation in allocations
+                if allocation not in settings.ALLOCATIONS_TO_EXCLUDE
+            ]
 
         return JsonResponse(
             {

--- a/designsafe/apps/workspace/api/views.py
+++ b/designsafe/apps/workspace/api/views.py
@@ -879,6 +879,9 @@ class AllocationsView(AuthenticatedApiView):
         : rtype: dict
         """
         data = self._get_allocations(request.user)
+        # Exclude allocation based on allocation setting list.
+        for host, allocations in data['hosts'].items():
+            data['hosts'][host] = [allocation for allocation in allocations if allocation not in settings.ALLOCATIONS_TO_EXCLUDE]
 
         return JsonResponse(
             {

--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -499,6 +499,10 @@ TAS_CLIENT_KEY = os.environ.get('TAS_CLIENT_KEY', None)
 TAS_CLIENT_SECRET = os.environ.get('TAS_CLIENT_SECRET', None)
 TAS_URL = os.environ.get('TAS_URL', None)
 
+# Allocations
+#
+ALLOCATIONS_TO_EXCLUDE = ["DesignSafe-DCV"]
+
 ###
 # Agave Integration
 #

--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -499,9 +499,10 @@ TAS_CLIENT_KEY = os.environ.get('TAS_CLIENT_KEY', None)
 TAS_CLIENT_SECRET = os.environ.get('TAS_CLIENT_SECRET', None)
 TAS_URL = os.environ.get('TAS_URL', None)
 
-# Allocations
+# Allocations to exclude
 #
-ALLOCATIONS_TO_EXCLUDE = ["DesignSafe-DCV"]
+ALLOCATIONS_TO_EXCLUDE = os.environ.get("ALLOCATIONS_TO_EXCLUDE", "").split(",") if os.environ.get("ALLOCATIONS_TO_EXCLUDE") else []
+
 
 ###
 # Agave Integration


### PR DESCRIPTION
## Overview: ##
This is a request to remove certain allocation from list. Adding is as part of settings to customize exclusion
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2907](https://tacc-main.atlassian.net/browse/DES-2907)

## Summary of Changes: ##

## Testing Steps: ##
Edit designsafe.env to add the following and make start and go to  https://designsafe.dev/rw/workspace/swbatch?appVersion=0.4.1

-     Test Case 1: ALLOCATIONS_TO_EXCLUDE=DesignSafe-DCV,TACC-ACI
        This will show image at the bottom
-     Test Case 2: ALLOCATIONS_TO_EXCLUDE=DesignSafe-DCV
        DesignSafe-DCV is not shown.
-     Test Case 3: No change in env file.
        App form and Allocations functions as before.
-     Test Case 4: ALLOCATIONS_TO_EXCLUDE=
        App form and Allocations functions as before.

    
<img width="869" alt="Screenshot 2024-06-17 at 4 25 28 PM" src="https://github.com/DesignSafe-CI/portal/assets/2568355/ea4fd5d3-1f0d-43bf-ab38-8968cf932f16">

## UI Photos:

## Notes: ##
