### PR TITLE
task/DES-2898: Active job status nav styling

### DIFF
--- a/client/modules/workspace/src/JobStatusNav/JobStatusNav.module.css
+++ b/client/modules/workspace/src/JobStatusNav/JobStatusNav.module.css
@@ -6,3 +6,16 @@
 .badge {
   margin: 0 10px;
 }
+
+.root:hover,
+.root:focus,
+.highlighted-row,
+.highlighted-row:hover,
+.highlighted-row:focus {
+  background-color: #cbdded;
+  text-decoration: none;
+}
+
+.highlighted-row:hover {
+  cursor: unset;
+}

--- a/client/modules/workspace/src/JobStatusNav/JobStatusNav.tsx
+++ b/client/modules/workspace/src/JobStatusNav/JobStatusNav.tsx
@@ -23,14 +23,21 @@ export const JobStatusNav: React.FC = () => {
     borderRight: '1px solid var(--global-color-primary--normal)',
   };
   return (
-    <Header style={headerStyle}>
-      <Badge count={unreadNotifs} size="small" className={styles.badge}>
-        <Icon
-          className={`ds-icon-Job-Status ${styles.icon}`}
-          label="Job-Status"
-        />
-      </Badge>
-      <NavLink to={`history`}>Job Status</NavLink>
-    </Header>
+    <NavLink
+      to={`history`}
+      className={({ isActive }) =>
+        isActive ? styles['highlighted-row'] : styles.root
+      }
+    >
+      <Header style={headerStyle}>
+        <Badge count={unreadNotifs} size="small" className={styles.badge}>
+          <Icon
+            className={`ds-icon-Job-Status ${styles.icon}`}
+            label="Job-Status"
+          />
+        </Badge>
+        Job Status
+      </Header>
+    </NavLink>
   );
 };

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -132,7 +132,7 @@
 }
 
 /* DO scroll app category menu */
-.ant-layout-sider-children > header + div + ul {
+.ant-layout-sider-children > a + div + ul {
   overflow: auto;
   height: 100%;
 }


### PR DESCRIPTION
## Overview: ##
Set background color for Job Status Nav when hovered and when selected.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2898](https://tacc-main.atlassian.net/browse/DES-2898)

## Testing Steps: ##
1. Ensure job status nav appears as below when hovered, and selected. Confirm no link cursor when active and hovered while in Job Status.

## UI Photos:

<img width="278" alt="Screenshot 2024-06-17 at 6 30 58 PM" src="https://github.com/DesignSafe-CI/portal/assets/20326896/6bf7d168-3e37-4e24-b85c-b83db2249b76">
