### PR TITLE
task/DES-2911: Render `jobAttributes` `notes.label` as form field label if it exists

### DIFF
--- a/client/modules/_hooks/src/workspace/types.ts
+++ b/client/modules/_hooks/src/workspace/types.ts
@@ -6,6 +6,7 @@ type TParameterSetNotes = {
     message: string;
   };
   enum_values?: [{ [dynamic: string]: string }];
+  label?: string;
 };
 
 export type TJobArgSpec = {
@@ -13,7 +14,7 @@ export type TJobArgSpec = {
   arg?: string;
   description?: string;
   inputMode?: string;
-  notes?: TParameterSetNotes;
+  notes: TParameterSetNotes;
 };
 
 export type TJobKeyValuePair = {

--- a/client/modules/_hooks/src/workspace/types.ts
+++ b/client/modules/_hooks/src/workspace/types.ts
@@ -14,7 +14,7 @@ export type TJobArgSpec = {
   arg?: string;
   description?: string;
   inputMode?: string;
-  notes: TParameterSetNotes;
+  notes?: TParameterSetNotes;
 };
 
 export type TJobKeyValuePair = {
@@ -22,7 +22,7 @@ export type TJobKeyValuePair = {
   value: string;
   description?: string;
   inputMode: string;
-  notes: TParameterSetNotes;
+  notes?: TParameterSetNotes;
 };
 
 export type TJobArgSpecs = TJobArgSpec[];

--- a/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
+++ b/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
@@ -286,7 +286,9 @@ const FormSchema = (
           return;
         }
         const paramId =
-          param.notes.label ?? (<TJobArgSpec>param).name ?? (<TJobKeyValuePair>param).key;
+          param.notes.label ??
+          (<TJobArgSpec>param).name ??
+          (<TJobKeyValuePair>param).key;
 
         const field: TField = {
           label: paramId,

--- a/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
+++ b/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
@@ -286,7 +286,7 @@ const FormSchema = (
           return;
         }
         const paramId =
-          (<TJobArgSpec>param).name ?? (<TJobKeyValuePair>param).key;
+          param.notes.label ?? (<TJobArgSpec>param).name ?? (<TJobKeyValuePair>param).key;
 
         const field: TField = {
           label: paramId,

--- a/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
+++ b/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
@@ -286,7 +286,7 @@ const FormSchema = (
           return;
         }
         const paramId =
-          param.notes.label ??
+          param.notes?.label ??
           (<TJobArgSpec>param).name ??
           (<TJobKeyValuePair>param).key;
 


### PR DESCRIPTION
## Overview: ##

Render `jobAttributes` `notes.label` as form field label if it exists

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2911](https://tacc-main.atlassian.net/browse/DES-2911)


## Testing Steps: ##
1. Go to https://designsafe.dev/rw/workspace/opensees-express?appVersion=3.6.0 and confirm labels for fields in "Parameters" step are human readable labels with proper capitalization, i.e. "TCL Script" and not "tclScript"
