### PR TITLE
Bugs/DES-2888: Select Modal - regex fix to detect storage system and file selection modes

### DIFF
--- a/client/modules/_hooks/src/workspace/types.ts
+++ b/client/modules/_hooks/src/workspace/types.ts
@@ -36,7 +36,7 @@ export type TAppFileInput = {
   notes?: {
     showTargetPath?: boolean;
     isHidden?: boolean;
-    selectionMode?:string;
+    selectionMode?: string;
   };
   sourceUrl?: string;
   targetPath?: string;

--- a/client/modules/_hooks/src/workspace/types.ts
+++ b/client/modules/_hooks/src/workspace/types.ts
@@ -36,6 +36,7 @@ export type TAppFileInput = {
   notes?: {
     showTargetPath?: boolean;
     isHidden?: boolean;
+    selectionMode?:string;
   };
   sourceUrl?: string;
   targetPath?: string;

--- a/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
+++ b/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
@@ -57,6 +57,7 @@ export type TField = {
   description?: string;
   options?: TFieldOptions[];
   tapisFile?: boolean;
+  tapisFileSelectionMode?:string;
   placeholder?: string;
   readOnly?: boolean;
 };
@@ -95,7 +96,7 @@ export type TAppFormSchema = {
   };
 };
 
-export const inputFileRegex = /^tapis:\/\/(?<storageSystem>[^/]+)\/[^/]+$/;
+export const inputFileRegex = /^tapis:\/\/(?<storageSystem>[^/]+)/;
 
 // See https://github.com/colinhacks/zod/issues/310 for Zod issue
 const emptyStringToUndefined = z.literal('').transform(() => undefined);
@@ -384,6 +385,7 @@ const FormSchema = (
       type: 'text',
       placeholder: 'Browse Data Files',
       readOnly: input.inputMode === 'FIXED',
+      tapisFileSelectionMode: input.notes?.selectionMode??'both',
     };
 
     appFields.fileInputs.schema[input.name] = z.string();

--- a/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
+++ b/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
@@ -57,7 +57,7 @@ export type TField = {
   description?: string;
   options?: TFieldOptions[];
   tapisFile?: boolean;
-  tapisFileSelectionMode?:string;
+  tapisFileSelectionMode?: string;
   placeholder?: string;
   readOnly?: boolean;
 };
@@ -385,7 +385,7 @@ const FormSchema = (
       type: 'text',
       placeholder: 'Browse Data Files',
       readOnly: input.inputMode === 'FIXED',
-      tapisFileSelectionMode: input.notes?.selectionMode??'both',
+      tapisFileSelectionMode: input.notes?.selectionMode ?? 'both',
     };
 
     appFields.fileInputs.schema[input.name] = z.string();

--- a/client/modules/workspace/src/AppsWizard/FormField.tsx
+++ b/client/modules/workspace/src/AppsWizard/FormField.tsx
@@ -14,6 +14,7 @@ export const FormField: React.FC<{
   label: string;
   required?: boolean;
   type: string;
+  tapisFileSelectionMode?: string,
   placeholder?: string;
   options?: TFieldOptions[];
 }> = ({
@@ -24,6 +25,7 @@ export const FormField: React.FC<{
   label,
   required = false,
   type,
+  tapisFileSelectionMode = null,
   ...props
 }) => {
   const { resetField, control, getValues, setValue, trigger } =
@@ -135,6 +137,7 @@ export const FormField: React.FC<{
         <SelectModal
           inputLabel={label}
           system={storageSystem}
+          selectionMode={tapisFileSelectionMode??'both'}
           isOpen={isModalOpen}
           onClose={() => setIsModalOpen(false)}
           onSelect={(value: string) => {

--- a/client/modules/workspace/src/AppsWizard/FormField.tsx
+++ b/client/modules/workspace/src/AppsWizard/FormField.tsx
@@ -14,7 +14,7 @@ export const FormField: React.FC<{
   label: string;
   required?: boolean;
   type: string;
-  tapisFileSelectionMode?: string,
+  tapisFileSelectionMode?: string;
   placeholder?: string;
   options?: TFieldOptions[];
 }> = ({
@@ -137,7 +137,7 @@ export const FormField: React.FC<{
         <SelectModal
           inputLabel={label}
           system={storageSystem}
-          selectionMode={tapisFileSelectionMode??'both'}
+          selectionMode={tapisFileSelectionMode ?? 'both'}
           isOpen={isModalOpen}
           onClose={() => setIsModalOpen(false)}
           onSelect={(value: string) => {

--- a/client/modules/workspace/src/SelectModal/SelectModal.tsx
+++ b/client/modules/workspace/src/SelectModal/SelectModal.tsx
@@ -123,6 +123,7 @@ function getFilesColumns(
   system: string,
   path: string,
   systemLabel: string,
+  selectionMode: string,
   selectionCallback: (path: string) => void,
   navCallback: (path: string) => void
 ): TFileListingColumns {
@@ -180,15 +181,22 @@ function getFilesColumns(
       dataIndex: 'path',
       align: 'end',
       title: '',
-      render: (_, record) => (
-        <SecondaryButton
-          onClick={() =>
-            selectionCallback(`${api}://${record.system}${record.path}`)
-          }
-        >
-          Select
-        </SecondaryButton>
-      ),
+      render: (_: any, record: any) => {
+        const shouldRenderSelectButton = 
+          (record.type === 'dir' && selectionMode === 'directory') ||
+          (record.type === 'file' && selectionMode === 'file') ||
+          selectionMode === 'both';
+
+        return shouldRenderSelectButton ? (
+          <SecondaryButton
+            onClick={() =>
+              selectionCallback(`${api}://${record.system}${record.path}`)
+            }
+          >
+            Select
+          </SecondaryButton>
+        ) : null;
+      },
     },
   ];
 }
@@ -196,10 +204,11 @@ function getFilesColumns(
 export const SelectModal: React.FC<{
   inputLabel: string;
   system: string | null;
+  selectionMode: string;
   isOpen: boolean;
   onClose: () => void;
   onSelect: (value: string) => void;
-}> = ({ inputLabel, system, isOpen, onClose, onSelect }) => {
+}> = ({ inputLabel, system, selectionMode, isOpen, onClose, onSelect }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState<string | null>(null);
   const [form] = Form.useForm();
@@ -335,6 +344,7 @@ export const SelectModal: React.FC<{
         selectedSystem,
         selectedPath,
         systemLabel,
+        selectionMode,
         (selection: string) => selectCallback(selection),
         navCallback
       ),
@@ -344,6 +354,7 @@ export const SelectModal: React.FC<{
       selectedSystem,
       selectedPath,
       systemLabel,
+      selectionMode,
       selectCallback,
     ]
   );

--- a/client/modules/workspace/src/SelectModal/SelectModal.tsx
+++ b/client/modules/workspace/src/SelectModal/SelectModal.tsx
@@ -181,8 +181,8 @@ function getFilesColumns(
       dataIndex: 'path',
       align: 'end',
       title: '',
-      render: (_: any, record: any) => {
-        const shouldRenderSelectButton = 
+      render: (_, record) => {
+        const shouldRenderSelectButton =
           (record.type === 'dir' && selectionMode === 'directory') ||
           (record.type === 'file' && selectionMode === 'file') ||
           selectionMode === 'both';


### PR DESCRIPTION
## Overview: ##
* Adjust the select modal to allow selection based on type (file, directory or both). See [design](https://xd.adobe.com/view/bab9a62d-3f2a-45f8-be0f-5680c474d9c1-efea/screen/4f5c890c-a48d-4a55-8d5d-4d400dd9222e/specs/).
Input field in app, will have this note (see [mpm](https://github.com/TACC/WMA-Tapis-Templates/blob/main/applications/mpm/app.json#L79)):
```
"notes": {
    "selectionMode": "directory" // can be "directory", "file" or "both"
 }
```

* System selection based on the value in input file is broken for certain paths, fix the regex to detect storage system. The regex was only considering paths like tapis://<storage_system>/path1 and failing on tapis://<storage_system>/path1/path2


## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2888](https://tacc-main.atlassian.net/browse/DES-2888)
* [DES-2819](https://tacc-main.atlassian.net/browse/DES-2819)

## Summary of Changes: ##

## Testing Steps: ##
1. Select Modal - selection mode
   * Try the file selection in these apps:
   * https://designsafe.dev/rw/workspace/mpm?appVersion=1.1.0 (directory)
   * https://designsafe.dev/rw/workspace/extract (file)
   * https://designsafe.dev/rw/workspace/compress (both)
   * https://designsafeci-next.tacc.utexas.edu/rw/workspace/opensees-mp-s3?appVersion=3.6.0 (nothing is set, so both).
2. Detecting the storage system based on existing path
   * Go to https://designsafe.dev/rw/workspace/openfoam
   * Put this in the file path: tapis://designsafe.storage.community/app_examples/extract
   * Click select button and it should open in community. Adjust the path to tapis://designsafe.storage.community/app_examples/ or tapis://designsafe.storage.community/app_examples

## UI Photos:
![Screenshot 2024-06-21 at 10 51 15 AM](https://github.com/DesignSafe-CI/portal/assets/2568355/c7a34833-937f-4ffb-8e27-25f9c68ed41e)

## Notes: ##
