### PR TITLE
Bug/DES-2835,2855: Ribbon Buttons and Amend text

### DIFF
--- a/client/modules/datafiles/src/DatafilesModal/RenameModal/RenameModal.tsx
+++ b/client/modules/datafiles/src/DatafilesModal/RenameModal/RenameModal.tsx
@@ -31,7 +31,16 @@ export const RenameModalBody: React.FC<{
   );
 
   const handleRenameFinish = async (values: { newName: string }) => {
+    const originalName = selectedFiles[0].name;
     const newName = values.newName;
+
+    const extension = originalName.includes('.')
+      ? originalName.substring(originalName.lastIndexOf('.'))
+      : '';
+
+    const fullName = newName.endsWith(extension)
+      ? newName
+      : newName + extension;
 
     try {
       await mutate({
@@ -39,8 +48,8 @@ export const RenameModalBody: React.FC<{
           api,
           system,
           path,
-          name: selectedFiles[0].name,
-          newName: newName,
+          name: originalName,
+          newName: fullName,
         },
       });
 

--- a/client/src/datafiles/layouts/projects/ProjectPipelineSelectLayout.tsx
+++ b/client/src/datafiles/layouts/projects/ProjectPipelineSelectLayout.tsx
@@ -73,6 +73,10 @@ export const ProjectPipelineSelectLayout: React.FC = () => {
                   keywords, author order, descriptions, natural hazard type, and
                   natural hazard event.
                 </li>
+                <li>
+                  Change the metadata in the curation directory before this
+                  step.
+                </li>
               </ul>
               <NavLink
                 to={`/projects/${projectId}/prepare-to-publish/pipeline?operation=amend`}


### PR DESCRIPTION
## Overview: ##
(1) Rename (DES-2835/2921): when renaming a file, the file extension was getting lost. (My Data, HPC Work, My Projects)
(2) Amend bullet (DES-2855): add bullet point to tell user to make changes in Curation Directory

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2835](https://tacc-main.atlassian.net/browse/DES-2835)
* [DES-2921](https://tacc-main.atlassian.net/browse/DES-2921)
* [DES-2855](https://tacc-main.atlassian.net/browse/DES-2855)

## Summary of Changes: ##

## Testing Steps: ##
1. Test the Rename file works for different file extension. 
2. Verify Amend Metadata text includes bullet point that instructs user to make changes in Curation Directory.

## UI Photos:
Rename with file extension: 
<img width="159" alt="Screen Shot 2024-06-24 at 10 48 53 AM" src="https://github.com/DesignSafe-CI/portal/assets/35277477/742bca88-c4d9-4d2d-acc1-23d0be65e9df">

Amend text (similar to Version):
<img width="913" alt="Screen Shot 2024-06-24 at 10 45 43 AM" src="https://github.com/DesignSafe-CI/portal/assets/35277477/90455844-f884-440d-8e28-34c7d1ea80ae">

## Notes: ##
