### PR TITLE
bug/DES-2922: word/spelling/typo issues

### DIFF
--- a/client/modules/datafiles/src/projects/ProjectPipeline/PipelineSelectForPublish.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPipeline/PipelineSelectForPublish.tsx
@@ -171,7 +171,9 @@ export const PipelineSelectForPublish: React.FC<{
             <span>
               Amending or revising a project will impact all previously
               published works. New datasets cannot be published through this
-              process. If you need to publish subsequent dataset(s), please{' '}
+              process. 
+              <br />
+              If you need to publish subsequent dataset(s), please{' '}
               <a
                 href={`/help/new-ticket/?category=DATA_CURATION_PUBLICATION&amp;subject=Request+to+Update+or+Remove+Authors+for+${projectId}`}
                 target="_blank"
@@ -180,7 +182,7 @@ export const PipelineSelectForPublish: React.FC<{
               >
                 submit a ticket
               </a>{' '}
-              with your project number and the name of the dataset(s)
+              with your project number, the name of the dataset(s), and the author order of the dataset(s).
             </span>
           }
         />

--- a/client/modules/datafiles/src/projects/ProjectPipeline/PipelineSelectForPublish.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPipeline/PipelineSelectForPublish.tsx
@@ -171,7 +171,7 @@ export const PipelineSelectForPublish: React.FC<{
             <span>
               Amending or revising a project will impact all previously
               published works. New datasets cannot be published through this
-              process. 
+              process.
               <br />
               If you need to publish subsequent dataset(s), please{' '}
               <a
@@ -182,7 +182,8 @@ export const PipelineSelectForPublish: React.FC<{
               >
                 submit a ticket
               </a>{' '}
-              with your project number, the name of the dataset(s), and the author order of the dataset(s).
+              with your project number, the name of the dataset(s), and the
+              author order of the dataset(s).
             </span>
           }
         />

--- a/client/modules/datafiles/src/projects/forms/BaseProjectForm.tsx
+++ b/client/modules/datafiles/src/projects/forms/BaseProjectForm.tsx
@@ -355,7 +355,6 @@ export const BaseProjectForm: React.FC<{
 
       <Form.Item label="Keywords" required>
         Choose informative words that indicate the content of the project.
-        Keywords should be comma-separated.
         <Form.Item
           name="keywords"
           rules={[{ required: true }]}

--- a/client/modules/datafiles/src/projects/modals/ProjectInfoStepper/FieldReconSteps.tsx
+++ b/client/modules/datafiles/src/projects/modals/ProjectInfoStepper/FieldReconSteps.tsx
@@ -11,7 +11,7 @@ const FieldReconOverview1 = (
       and publish together or independently.
     </p>
     <p>
-      Curation is important so your data can be 
+      Curation is important so your data can be
       <strong> organized</strong>, <strong>discovered</strong>, and{' '}
       <strong>understood </strong>
       for years to come.

--- a/client/modules/datafiles/src/projects/modals/ProjectInfoStepper/FieldReconSteps.tsx
+++ b/client/modules/datafiles/src/projects/modals/ProjectInfoStepper/FieldReconSteps.tsx
@@ -11,9 +11,9 @@ const FieldReconOverview1 = (
       and publish together or independently.
     </p>
     <p>
-      Curation is important so your data can be
-      <strong>organized</strong>, <strong>discovered</strong>, and{' '}
-      <strong>understood</strong>
+      Curation is important so your data can be 
+      <strong> organized</strong>, <strong>discovered</strong>, and{' '}
+      <strong>understood </strong>
       for years to come.
     </p>
     <p>The four components of curating field research projects:</p>


### PR DESCRIPTION
## Overview: ##
- Add line break for clarity in the process description
- Include instructions for submitting a ticket with project number, dataset name(s), and author order
- Remove text that instructs user that Keywords should be comma-separated.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2922](https://tacc-main.atlassian.net/browse/DES-2922)

## Summary of Changes: ##

## Testing Steps: ##
1. In an FR project, verify the text appears correctly.
2. In the Amends pipeline make verify the text is updated to include author order. 
3. When you click 'Edit Project', make sure keywords no longer includes "...comma-seperated."

## UI Photos:
<img width="787" alt="Screen Shot 2024-06-25 at 12 53 16 PM" src="https://github.com/DesignSafe-CI/portal/assets/35277477/4d3d5907-f988-400f-820c-65421b2f2d35">

<img width="398" alt="Screen Shot 2024-06-25 at 1 10 47 PM" src="https://github.com/DesignSafe-CI/portal/assets/35277477/b07a17a1-d40a-4f8e-a802-c6fffabeebfa">

## Notes: ##
