### PR TITLE
fix/DES-2910: Set default ACLs on new My Data dirs for `tg`, `other`, and `mask`

### DIFF
--- a/designsafe/apps/auth/tasks.py
+++ b/designsafe/apps/auth/tasks.py
@@ -64,13 +64,17 @@ def check_or_configure_system_and_user_directory(username, system_id, path, crea
                             path)
 
                 tg458981_client.files.mkdir(systemId=system_id, path=path)
-                tg458981_client.files.setFacl(systemId=system_id,
-                                              path=path,
-                                              operation="ADD",
-                                              recursionMethod="PHYSICAL",
-                                              aclString=f"d:u:{username}:rwX,u:{username}:rwX")
-                agave_indexer.apply_async(kwargs={'systemId': system_id, 'filePath': path, 'recurse': False},
-                                          queue='indexing')
+                tg458981_client.files.setFacl(
+                    systemId=system_id,
+                    path=path,
+                    operation="ADD",
+                    recursionMethod="PHYSICAL",
+                    aclString=f"d:u:{username}:rwX,u:{username}:rwX,d:u:tg458981:rwX,u:tg458981:rwX,d:o::---,o::---,d:m::rwX,m::rwX",
+                )
+                agave_indexer.apply_async(
+                    kwargs={"systemId": system_id, "filePath": path, "recurse": False},
+                    queue="indexing",
+                )
 
         # create keys, push to key service and use as credential for Tapis system
         logger.info("Creating credentials for user=%s on system=%s", username, system_id)


### PR DESCRIPTION
## Overview: ##

Add full ACL declaration for the My Data dir created for a user upon initial login. In particular we needed to make sure the `other` ACLs were closed off.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2910](https://tacc-main.atlassian.net/browse/DES-2910)

## Testing Steps: ##
1. Create a new test account and login to the portal. Confirm correct ACLs applied at `cloud.data.tacc.utexas.edu:/data/designsafe/mydata`

OR
1. Run the `setfacl` command via an ipython session with tapipy and check ACLs for that path:
```
                client.files.setFacl(
                    systemId=system_id,
                    path=path,
                    operation="ADD",
                    recursionMethod="PHYSICAL",
                    aclString=f"d:u:{username}:rwX,u:{username}:rwX,d:u:tg458981:rwX,u:tg458981:rwX,d:o::---,o::---,d:m::rwX,m::rwX",
                )
```

