### PR TITLE
Bugs/DES-2872: [AppForm] Handle axios request errors without crashing client

### DIFF
--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -419,14 +419,15 @@ export const AppsSubmissionForm: React.FC = () => {
             [sParameterSet]: Object.entries(sParameterValue)
               .map(([k, v]) => {
                 if (!v) return;
+                const field = parameterSet.fields?.[sParameterSet]?.[k];
                 // filter read only parameters. 'FIXED' parameters are tracked as readOnly
-                if (parameterSet.fields?.[k]?.readOnly) return;
+                if (field?.readOnly) return;
                 // Convert the value to a string, if necessary
                 const transformedValue =
                   typeof v === 'number' ? v.toString() : v;
                 return sParameterSet === 'envVariables'
-                  ? { key: k, value: transformedValue }
-                  : { name: k, arg: transformedValue };
+                  ? { key: field?.key ?? k, value: transformedValue }
+                  : { name: field?.key ?? k, arg: transformedValue };
               })
               .filter((v) => v), // filter out any empty values
           };

--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -108,7 +108,7 @@ export const AppsSubmissionForm: React.FC = () => {
     [definition]
   );
 
-  let missingAllocation;
+  let missingAllocation: string | undefined;
   if (!hasDefaultAllocation && hasStorageSystems) {
     // User does not have default storage allocation
     missingAllocation = getSystemName(defaultStorageHost);

--- a/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
+++ b/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
@@ -298,18 +298,20 @@ const FormSchema = (
           return;
         }
         const paramId =
+          (<TJobArgSpec>param).name ?? (<TJobKeyValuePair>param).key;
+        const label =
           param.notes?.label ??
           (<TJobArgSpec>param).name ??
           (<TJobKeyValuePair>param).key;
 
         const field: TField = {
-          label: paramId,
+          label: label,
           description: param.description,
           required: param.inputMode === 'REQUIRED',
           readOnly: param.inputMode === 'FIXED',
           parameterSet: parameterSet,
-          name: `parameters.${parameterSet}.${paramId}`,
-          key: `parameters.${parameterSet}.${paramId}`,
+          name: `parameters.${parameterSet}.${label}`,
+          key: paramId,
           type: 'text',
         };
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,6 +18,7 @@
         "html-react-parser": "^5.1.10",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-error-boundary": "^4.0.13",
         "react-hook-form": "^7.51.3",
         "react-hook-form-antd": "^1.1.0",
         "react-router-dom": "^6.21.1",
@@ -11934,6 +11935,17 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.13.tgz",
+      "integrity": "sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-hook-form": {

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "html-react-parser": "^5.1.10",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-error-boundary": "^4.0.13",
     "react-hook-form": "^7.51.3",
     "react-hook-form-antd": "^1.1.0",
     "react-router-dom": "^6.21.1",

--- a/client/src/workspace/layouts/AppsViewLayout.tsx
+++ b/client/src/workspace/layouts/AppsViewLayout.tsx
@@ -20,16 +20,19 @@ export const AppsViewLayout: React.FC = () => {
         </div>
       ) : (
         <ErrorBoundary
-          fallbackRender={({ error }) => (
-            <div id="appDetail-wrapper">
-              <Alert
-                message={error?.response?.data?.message ?? error.message}
-                type="error"
-                showIcon
-                style={{ marginTop: 10 }}
-              />
-            </div>
-          )}
+          key={key}
+          fallbackRender={({ error }) =>
+            error && (
+              <div id="appDetail-wrapper">
+                <Alert
+                  message={error?.response?.data?.message ?? error.message}
+                  type="error"
+                  showIcon
+                  style={{ marginTop: 10 }}
+                />
+              </div>
+            )
+          }
         >
           <Suspense
             fallback={

--- a/client/src/workspace/layouts/AppsViewLayout.tsx
+++ b/client/src/workspace/layouts/AppsViewLayout.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Outlet } from 'react-router-dom';
-import { Layout } from 'antd';
+import { Alert, Layout } from 'antd';
 import { Spinner } from '@client/common-components';
 import { AppsSubmissionForm, useGetAppParams } from '@client/workspace';
 import { useAppsListing } from '@client/hooks';
@@ -18,17 +19,30 @@ export const AppsViewLayout: React.FC = () => {
           {parse(htmlApp.html as string)}
         </div>
       ) : (
-        <Suspense
-          fallback={
-            <Layout>
-              <Spinner />
-            </Layout>
-          }
+        <ErrorBoundary
+          fallbackRender={({ error }) => (
+            <div id="appDetail-wrapper">
+              <Alert
+                message={error?.response?.data?.message ?? error.message}
+                type="error"
+                showIcon
+                style={{ marginTop: 10 }}
+              />
+            </div>
+          )}
         >
-          {/* <AppFormProvider> */}
-          <AppsSubmissionForm key={key} />
-          {/* </AppFormProvider> */}
-        </Suspense>
+          <Suspense
+            fallback={
+              <Layout>
+                <Spinner />
+              </Layout>
+            }
+          >
+            {/* <AppFormProvider> */}
+            <AppsSubmissionForm key={key} />
+            {/* </AppFormProvider> */}
+          </Suspense>
+        </ErrorBoundary>
       )}
       <Outlet />
     </>


### PR DESCRIPTION
## Overview: ##
Add error boundary over the suspense for app form. This should handle both allocation and getApps suspenses.


## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2872](https://tacc-main.atlassian.net/browse/DES-2872)

## Summary of Changes: ##
Use ErrorBoundary over suspense, following documentation [here](https://tanstack.com/query/latest/docs/framework/react/guides/suspense/#resetting-error-boundaries)
using react-error-boundary as mentioned above. 

## Testing Steps: ##
1. Go to https://designsafe.dev/rw/workspace/opensees-does-not-exist
2. Once error is seen, hit a valid app in left nav and see that the error disappears. 
3. Any job submission related error are already handled by app form and do not fall into this (tested this by forcing bad data in client code).


## UI Photos:
<img width="1596" alt="Screenshot 2024-07-01 at 1 26 53 PM" src="https://github.com/DesignSafe-CI/portal/assets/2568355/81ff4830-b51c-4534-8e08-6013625d45bb">

## Notes: ##
