### PR TITLE
bug/DES-3000: Handle DOI not provided in useCitationMetrics

### DIFF
--- a/client/modules/_hooks/src/datafiles/publications/useCitationMetrics.ts
+++ b/client/modules/_hooks/src/datafiles/publications/useCitationMetrics.ts
@@ -55,10 +55,13 @@ export async function getCitationMetrics({
 
 export function useCitationMetrics(doi: string) {
   return useQuery({
-    queryKey: ['citationMetrics', doi], // This should be an object
+    queryKey: ['citationMetrics', doi],
     queryFn: async ({ signal }) => {
+      if (!doi) {
+        // Return a default value or handle the case when DOI is not provided
+        return null;
+      }
       return getCitationMetrics({ doi, signal });
     },
-    // Add any additional options you need, like refetch, stale time, etc.
   });
 }

--- a/designsafe/apps/api/publications/views.py
+++ b/designsafe/apps/api/publications/views.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from requests.exceptions import HTTPError
 from designsafe.apps.api.publications import operations
 from designsafe.apps.projects.managers import datacite as DataciteManager
+from django.views.decorators.cache import cache_page
 import json
 import logging
 import requests
@@ -29,6 +30,7 @@ class PublicationListingView(BaseApiView):
 View for getting details (description, full definition) from a specific publication.
 """
 class PublicationDetailView(BaseApiView):
+    @cache_page(60 * 15)
     def get(self, request, operation, project_id, revision=None):
         client = get_service_account_client()
         try:
@@ -42,6 +44,7 @@ class PublicationDetailView(BaseApiView):
 View for getting DataCite DOI details from publications.
 """
 class PublicationDataCiteView(BaseApiView):
+    @cache_page(60 * 15)
     def get(self, request, doi):
         url = f'https://api.datacite.org/dois/{doi}' 
 

--- a/designsafe/apps/api/publications/views.py
+++ b/designsafe/apps/api/publications/views.py
@@ -6,6 +6,7 @@ from requests.exceptions import HTTPError
 from designsafe.apps.api.publications import operations
 from designsafe.apps.projects.managers import datacite as DataciteManager
 from django.views.decorators.cache import cache_page
+from django.utils.decorators import method_decorator
 import json
 import logging
 import requests
@@ -30,7 +31,7 @@ class PublicationListingView(BaseApiView):
 View for getting details (description, full definition) from a specific publication.
 """
 class PublicationDetailView(BaseApiView):
-    @cache_page(60 * 15)
+    @method_decorator(cache_page(60 * 15))
     def get(self, request, operation, project_id, revision=None):
         client = get_service_account_client()
         try:
@@ -44,7 +45,7 @@ class PublicationDetailView(BaseApiView):
 View for getting DataCite DOI details from publications.
 """
 class PublicationDataCiteView(BaseApiView):
-    @cache_page(60 * 15)
+    @method_decorator(cache_page(60 * 15))
     def get(self, request, doi):
         url = f'https://api.datacite.org/dois/{doi}' 
 


### PR DESCRIPTION
## Overview: ##
In Publications, when you open a publication, the browser makes a few calls to https://designsafeci-next.tacc.utexas.edu/api/publications/data-cite//  (ie no DOI is being sent over), and those calls hang for 30 seconds until they time out. These calls might be tying up the server and causing performance issues.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-3000](https://tacc-main.atlassian.net/browse/DES-3000)

## Summary of Changes: ##
In useCitationMetrics, I added a check that only returns getCitationMetrics if there is a DOI.
 
## Testing Steps: ##
1. With Inspect open, go to Network. 
2. In publications, click on a publication. Check that useCitationMetrics is never called without a DOI

## UI Photos:

## Notes: ##
