### PR TITLE
[SelectModal] New features added - back button and first row

### DIFF
--- a/client/modules/_common_components/src/datafiles/FileListingTable/FileListingTable.tsx
+++ b/client/modules/_common_components/src/datafiles/FileListingTable/FileListingTable.tsx
@@ -14,6 +14,14 @@ export type TFileListingColumns = (TableColumnType<TFileListing> & {
   dataIndex: keyof TFileListing;
 })[];
 
+function getLastPathComponent(path: string = '', relativeTo: string = '') {
+  const pathComponents = path
+    .replace(relativeTo, '')
+    .split('/')
+    .filter((p) => !!p);
+  return pathComponents[pathComponents.length - 1];
+}
+
 export const FileListingTable: React.FC<
   {
     api: string;
@@ -26,6 +34,7 @@ export const FileListingTable: React.FC<
     className?: string;
     emptyListingDisplay?: React.ReactNode;
     searchTerm?: string | null;
+    currentDisplayPath?: TFileListing | undefined;
   } & Omit<TableProps, 'columns' | 'className'>
 > = ({
   api,
@@ -38,6 +47,7 @@ export const FileListingTable: React.FC<
   className,
   emptyListingDisplay,
   searchTerm = '',
+  currentDisplayPath = null,
   ...props
 }) => {
   const limit = 100;
@@ -69,8 +79,12 @@ export const FileListingTable: React.FC<
     if (filterFn) {
       return filterFn(cl);
     }
+    if (currentDisplayPath) {
+      return [currentDisplayPath, ...cl];
+    }
+
     return cl;
-  }, [data, filterFn]);
+  }, [data, filterFn, path, system]);
 
   /* HANDLE FILE SELECTION */
   const { selectedFiles, setSelectedFiles } = useSelectedFiles(

--- a/client/modules/_common_components/src/datafiles/FileListingTable/FileListingTable.tsx
+++ b/client/modules/_common_components/src/datafiles/FileListingTable/FileListingTable.tsx
@@ -14,14 +14,6 @@ export type TFileListingColumns = (TableColumnType<TFileListing> & {
   dataIndex: keyof TFileListing;
 })[];
 
-function getLastPathComponent(path: string = '', relativeTo: string = '') {
-  const pathComponents = path
-    .replace(relativeTo, '')
-    .split('/')
-    .filter((p) => !!p);
-  return pathComponents[pathComponents.length - 1];
-}
-
 export const FileListingTable: React.FC<
   {
     api: string;
@@ -86,7 +78,7 @@ export const FileListingTable: React.FC<
     }
 
     return cl;
-  }, [data, filterFn, path, system]);
+  }, [data, filterFn, currentDisplayPath]);
 
   /* HANDLE FILE SELECTION */
   const { selectedFiles, setSelectedFiles } = useSelectedFiles(

--- a/client/modules/workspace/src/SelectModal/SelectModal.tsx
+++ b/client/modules/workspace/src/SelectModal/SelectModal.tsx
@@ -225,11 +225,14 @@ function getFilesColumns(
       dataIndex: 'path',
       align: 'end',
       title: '',
-      render: (_, record) => {
-        const shouldRenderSelectButton =
+      render: (_, record, index) => {
+        const selectionModeAllowed =
           (record.type === 'dir' && selectionMode === 'directory') ||
           (record.type === 'file' && selectionMode === 'file') ||
           selectionMode === 'both';
+        const isNotRoot =
+          index > 0 || path !== getSystemRootPath(selectedSystem, user);
+        const shouldRenderSelectButton = isNotRoot && selectionModeAllowed;
 
         return shouldRenderSelectButton ? (
           <SecondaryButton

--- a/client/modules/workspace/src/SelectModal/SelectModal.tsx
+++ b/client/modules/workspace/src/SelectModal/SelectModal.tsx
@@ -34,6 +34,7 @@ import { SelectModalProjectListing } from './SelectModalProjectListing';
 
 const api = 'tapis';
 const portalName = 'DesignSafe';
+const projectPrefix = 'project-';
 
 const SystemSuffixIcon = () => {
   return (
@@ -161,6 +162,7 @@ function getFilesColumns(
         <div>
           <Button
             type="link"
+            disabled={path === getSystemRootPath(selectedSystem, user)}
             onClick={() =>
               navCallback(
                 getBackPath(
@@ -231,7 +233,9 @@ function getFilesColumns(
           (record.type === 'file' && selectionMode === 'file') ||
           selectionMode === 'both';
         const isNotRoot =
-          index > 0 || path !== getSystemRootPath(selectedSystem, user);
+          index > 0 ||
+          record.system.startsWith(projectPrefix) ||
+          path !== getSystemRootPath(selectedSystem, user);
         const shouldRenderSelectButton = isNotRoot && selectionModeAllowed;
 
         return shouldRenderSelectButton ? (
@@ -378,7 +382,7 @@ export const SelectModal: React.FC<{
   useEffect(() => {
     if (isModalOpen) {
       let systemValue = system ?? defaultStorageSystem.id;
-      if (systemValue.startsWith('project-')) {
+      if (systemValue.startsWith(projectPrefix)) {
         systemValue = 'myprojects';
       }
       dropdownCallback(systemValue);
@@ -466,7 +470,7 @@ export const SelectModal: React.FC<{
                 path={decodeURIComponent(selectedPath)}
                 systemRootAlias={selection.projectId}
                 initialBreadcrumbs={
-                  selectedSystemId.startsWith('project-')
+                  selectedSystemId.startsWith(projectPrefix)
                     ? [{ title: 'My Projects', path: 'PROJECT_LISTING' }]
                     : []
                 }


### PR DESCRIPTION
## Overview: ##
See [Referenced Design](https://xd.adobe.com/view/bab9a62d-3f2a-45f8-be0f-5680c474d9c1-efea/screen/4f5c890c-a48d-4a55-8d5d-4d400dd9222e/specs/)
New features added - back button and first row:
* First row match the last part of the breadcrumb.
* First row is selectable
* Back button moves up.
* In search mode, back button go to root of the system.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2819](https://tacc-main.atlassian.net/browse/DES-2819)

## Summary of Changes: ##
* Updated file listing common component to take first row as optional parameter. This seems to be a good reliable way to handle the indent and go along with listing UX.
* Remove existing header component and add back button.
* Back button handler


## Testing Steps: ##
Use an app like https://designsafe.dev/rw/workspace/mpm?appVersion=1.1.0
1. Go to my data, navigate into folder and see the first row adjusted. Select the first row, ensure the text selection is right
2. Repeat the previous test case, use back button, observe the bread crumb and file listing updated.
3. Switch to community data (community data is public based and has different root, which makes it another test scenario). Repeat previous tests on community data.
4. Switch between My data and community and see if first row and back button states reset.

## UI Photos:

Highlighted portions show the relevant changes.

<img width="973" alt="Screenshot 2024-07-10 at 9 38 22 AM" src="https://github.com/DesignSafe-CI/portal/assets/2568355/68c68165-4224-4c14-9e62-98d2c344a949">

## Notes: ##
