### PR TITLE
DES-2761: [AppForm] Use bundle_icon field for app icon in App Form header

### DIFF
--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -6,6 +6,7 @@ import { useForm, FormProvider } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
+  useAppsListing,
   useGetAppsSuspense,
   usePostJobs,
   useGetSystems,
@@ -50,6 +51,7 @@ import {
   updateValuesForQueue,
   getDefaultExecSystem,
   getAllocationList,
+  findAppById,
 } from '../utils';
 
 export const AppsSubmissionForm: React.FC = () => {
@@ -65,6 +67,10 @@ export const AppsSubmissionForm: React.FC = () => {
   } = useAuthenticatedUser() as { user: TUser };
 
   const { definition, license, defaultSystemNeedsKeys } = app;
+  const { data: appListingData } = useAppsListing();
+  const icon =
+    findAppById(appListingData, definition.id)?.icon ??
+    (definition.notes.icon || 'Generic-App');
 
   const defaultStorageHost = defaultStorageSystem.host;
   const hasCorral = ['data.tacc.utexas.edu', 'corral.tacc.utexas.edu'].some(
@@ -481,7 +487,7 @@ export const AppsSubmissionForm: React.FC = () => {
           <Header style={headerStyle}>
             <Flex justify="space-between">
               <div>
-                <AppIcon name={definition.notes.icon || 'Generic-App'} />
+                <AppIcon name={icon} />
                 {definition.notes.label || definition.id}
               </div>
               {definition.notes.helpUrl && (

--- a/client/modules/workspace/src/utils/apps.ts
+++ b/client/modules/workspace/src/utils/apps.ts
@@ -1,6 +1,7 @@
 import { useParams, useLocation } from 'react-router-dom';
 import { z } from 'zod';
 import {
+  TAppCategories,
   TAppParamsType,
   TTapisSystem,
   TTapisApp,
@@ -446,4 +447,25 @@ export const useGetAppParams = () => {
     | undefined;
 
   return { appId, appVersion };
+};
+
+/**
+ * Find app in app tray categories and get the icon info.
+ * @param data TAppCategories or undefined
+ * @param appId string - id of an app.
+ * @returns icon name if available, otherwise null
+ */
+export const findAppById = (
+  data: TAppCategories | undefined,
+  appId: string
+) => {
+  if (!data) return null;
+  for (const category of data.categories) {
+    for (const app of category.apps) {
+      if (app.app_id === appId) {
+        return app;
+      }
+    }
+  }
+  return null;
 };


### PR DESCRIPTION
## Overview: ##
App entry models have an icon field, which comes across in an app variant object as bundle_icon, which is accessible from the client side. Use this field as the first choice option for the app icon in the app form header, reverting to the app’s notes.icon if bundle_icon doesn’t exist or the app doesn’t exist in the portal database.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2761](https://tacc-main.atlassian.net/browse/DES-2761)

## Summary of Changes: ##

## Testing Steps: ##
1. Go to apps in app left-nav and check if icons show up.
2. Navigate directly to an app: https://designsafe.dev/rw/workspace/qgis-s3?appVersion=3.34.4 and check icon

## UI Photos:

## Notes: ##
