### PR TITLE
task/DES-2935: Notifications fine tuning

### DIFF
--- a/client/modules/_hooks/src/notifications/useNotifications.ts
+++ b/client/modules/_hooks/src/notifications/useNotifications.ts
@@ -75,6 +75,9 @@ export function useReadNotifications() {
 const getNotificationsQuery = (params: TGetNotificationsParams) => ({
   queryKey: ['workspace', 'notifications', params],
   queryFn: () => getNotifications(params),
+  refetchOnReconnect: false,
+  refetchOnWindowFocus: false,
+  refetchonMount: false,
 });
 
 export function useGetNotifications(params: TGetNotificationsParams) {

--- a/client/modules/workspace/src/Toast/Toast.tsx
+++ b/client/modules/workspace/src/Toast/Toast.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import useWebSocket from 'react-use-websocket';
 import { useQueryClient } from '@tanstack/react-query';
 import { notification } from 'antd';
+import { useNavigate } from 'react-router-dom';
 import { Icon } from '@client/common-components';
 import { TJobStatusNotification } from '@client/hooks';
 import { getToastMessage } from '../utils';
@@ -15,6 +16,8 @@ const Notifications = () => {
   const [api, contextHolder] = notification.useNotification({ maxCount: 1 });
 
   const queryClient = useQueryClient();
+
+  const navigate = useNavigate();
 
   const handleNotification = (notification: TJobStatusNotification) => {
     if (
@@ -35,6 +38,11 @@ const Notifications = () => {
           notification.extra.status === 'FAILED' && styles['toast-is-error']
         }`,
         closeIcon: false,
+        duration: 5,
+        onClick: () => {
+          navigate('/history');
+        },
+        style: { cursor: 'pointer' },
       });
     }
   };


### PR DESCRIPTION
## Overview: ##

- Add class `hover: pointer` to toast notification
- Increase toast duration to 5s
- Clicking a notification navigates to Job Status
- Notifications will not be marked as read by refocusing window

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2935](https://tacc-main.atlassian.net/browse/DES-2935)

## Testing Steps: ##
1. Submit a job and confirm:
  a. notification toast has `hover: pointer` css class
  b. clicking a notification toast navigates to Job Status
  c. a notification lasts 5 seconds if another does not replace it
  d. navigating away from the tab, and back to it does not cause notifications to be read
