### PR TITLE
[DES-3022] Handle memoryMB greater than queue maximum

### DIFF
--- a/client/modules/_hooks/src/workspace/usePostJobs.ts
+++ b/client/modules/_hooks/src/workspace/usePostJobs.ts
@@ -24,6 +24,7 @@ export type TConfigurationValues = {
   nodeCount?: number;
   coresPerNode?: number;
   allocation?: string;
+  memoryMB?: number;
 };
 
 export type TOutputValues = {

--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -454,6 +454,19 @@ export const AppsSubmissionForm: React.FC = () => {
       delete jobData.job.allocation;
     }
 
+    // Before job submission, ensure the memory limit is not above queue limit.
+    if (definition.jobType === 'BATCH') {
+      const queue = getExecSystemFromId(
+        execSystems,
+        definition.jobAttributes.execSystemId
+      )?.batchLogicalQueues.find(
+        (q) => q.name === jobData.job.execSystemLogicalQueue
+      );
+      if (queue && app.definition.jobAttributes.memoryMB > queue.maxMemoryMB) {
+        jobData.job.memoryMB = queue.maxMemoryMB;
+      }
+    }
+
     submitJob(jobData);
   };
 


### PR DESCRIPTION
## Overview: ##
memoryMB is not a UI field, and is generally defined in app definition. There are scenarios where a queue has lower max memoryMB than what is defined in app definition. In those cases adjust the max before submitting a job

Only applicable to batch jobs, since queue is only available on batch

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-3022](https://tacc-main.atlassian.net/browse/DES-3022)

## Summary of Changes: ##
* Adjust job submission logic to keep max memory within limits. 
## Testing Steps: ##
1. rtx-dev has lower memory than small queue in frontera. submit a frontera job (https://designsafe.dev/rw/workspace/FigureGen-Serial?appVersion=51.0.0) with rtx-dev queue.
2. Submit a job on S3 to check for regression.
![Screenshot 2024-07-12 at 9 20 01 AM](https://github.com/user-attachments/assets/54b1342d-5a97-403a-afe2-b874c41f01ba)

job payload shows memoryMB


## UI Photos:

## Notes: ##
