### PR TITLE
Quick: Update makefile and show execution dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,23 @@
 .PHONY: build
 build:
-	docker-compose -f ./conf/docker/docker-compose.yml build
+	docker compose -f ./conf/docker/docker-compose.yml build
 
 .PHONY: build-dev
 build-dev:
-	docker-compose -f ./conf/docker/docker-compose-dev.yml build
+	docker compose -f ./conf/docker/docker-compose-dev.yml build
 
 .PHONY: start
 start:
-	docker-compose -f ./conf/docker/docker-compose-dev.all.debug.yml up
+	docker compose -f ./conf/docker/docker-compose-dev.all.debug.yml up
 
 .PHONY: stop
 stop:
-	docker-compose -f ./conf/docker/docker-compose-dev.all.debug.yml down
+	docker compose -f ./conf/docker/docker-compose-dev.all.debug.yml down
 
 .PHONY: start-m1
 start-m1:
-	docker-compose -f ./conf/docker/docker-compose-dev.all.debug.m1.yml up
+	docker compose -f ./conf/docker/docker-compose-dev.all.debug.m1.yml up
 
 .PHONY: stop-m1
 stop-m1:
-	docker-compose -f ./conf/docker/docker-compose-dev.all.debug.m1.yml down
+	docker compose -f ./conf/docker/docker-compose-dev.all.debug.m1.yml down

--- a/client/modules/workspace/src/JobsDetailModal/JobsDetailModal.tsx
+++ b/client/modules/workspace/src/JobsDetailModal/JobsDetailModal.tsx
@@ -197,7 +197,7 @@ export const JobsDetailModalBody: React.FC<{
     <div className={styles['modal-body-container']}>
       <div className={`${styles['left-panel']}`}>
         <dl>
-          {isOutputState(jobData.status) && (
+          {!isOutputState(jobData.status) && (
             <>
               <dt>Execution:</dt>
               <dd>
@@ -208,31 +208,26 @@ export const JobsDetailModalBody: React.FC<{
                   }/${encodeURIComponent(jobData.execSystemExecDir)}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  disabled={!isOutputState(jobData.status)}
                 >
                   View in Execution Directory
                 </Button>
               </dd>
             </>
           )}
-          <>
-            <dt>Output:</dt>
-            <dd>
-              <Button
-                type="link"
-                href={`data/browser/tapis/${
-                  jobData.archiveSystemId
-                }/${encodeURIComponent(jobData.archiveSystemDir)}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                disabled={!isOutputState(jobData.status)}
-              >
-                {isOutputState(jobData.status)
-                  ? 'View Output'
-                  : 'Output Pending'}
-              </Button>
-            </dd>
-          </>
+          <dt>Output:</dt>
+          <dd>
+            <Button
+              type="link"
+              href={`data/browser/tapis/${
+                jobData.archiveSystemId
+              }/${encodeURIComponent(jobData.archiveSystemDir)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              disabled={!isOutputState(jobData.status)}
+            >
+              {isOutputState(jobData.status) ? 'View Output' : 'Output Pending'}
+            </Button>
+          </dd>
         </dl>
         {isTerminalState(jobData.status) && (
           <JobActionButton


### PR DESCRIPTION
## Overview: ##

- Update `Makefile` commands with `docker compose` instead of `docker-compose` after recent docker update.
- Show execution dir in Job Details while job is running

## PR Status: ##

* [X] Ready.

## Testing Steps: ##
1. Update docker desktop and run `make start`, confirm works
2. Run a job and confirm appears as below
<img width="211" alt="Screenshot 2024-07-12 at 12 54 54 PM" src="https://github.com/user-attachments/assets/8e82fbad-5aba-4e24-a5ae-4c538e7f86ab">

