### PR TITLE
fix: DES-3027 remove CMS app category breadcrumb

### DIFF
--- a/designsafe/templates/menu/breadcrumb.html
+++ b/designsafe/templates/menu/breadcrumb.html
@@ -1,5 +1,9 @@
 {# https://github.com/django-cms/django-cms/blob/release/3.11.x/menus/templates/menu/breadcrumb.html #}
+{% load cms_tags %}
+
 {% for ance in ancestors %}
+{% page_attribute "slug" ance.parent_id as parent_slug %}
+{% if not parent_slug == "tools-applications" %}
 
   <li itemscope itemprop="itemListElement"
       itemtype="https://schema.org/ListItem"
@@ -21,4 +25,5 @@
     <meta itemprop="position" content="{{ forloop.counter }}" />
   </li>
 
+{% endif %}
 {% endfor %}

--- a/designsafe/templates/menu/breadcrumb.html
+++ b/designsafe/templates/menu/breadcrumb.html
@@ -4,7 +4,7 @@
 {% for ance in ancestors %}
 {% page_attribute "slug" ance.id as current_slug %}
 {% page_attribute "slug" ance.parent_id as parent_slug %}
-{% if not parent_slug == "tools-applications" or current_slug == "tools-applications-new" %}
+{% if not parent_slug|truncatechars:18 == "tools-application…" or current_slug == "tools-applications-new" %}
 
   <li itemscope itemprop="itemListElement"
       itemtype="https://schema.org/ListItem"

--- a/designsafe/templates/menu/breadcrumb.html
+++ b/designsafe/templates/menu/breadcrumb.html
@@ -10,8 +10,7 @@
       itemtype="https://schema.org/ListItem"
       {% if not forloop.last %}
       class="active"
-      {% endif %}
-      data-parent_slug-truncate="{{ parent_slug|truncatechars:17 }}">
+      {% endif %}>
   {% if not forloop.last %}
 
     <a href="{{ ance.get_absolute_url }}" itemprop="item">

--- a/designsafe/templates/menu/breadcrumb.html
+++ b/designsafe/templates/menu/breadcrumb.html
@@ -4,13 +4,14 @@
 {% for ance in ancestors %}
 {% page_attribute "slug" ance.id as current_slug %}
 {% page_attribute "slug" ance.parent_id as parent_slug %}
-{% if not parent_slug|truncatechars:18 == "tools-application…" or current_slug == "tools-applications-new" %}
+{% if not parent_slug|truncatechars:17 == "tools-applicatio…" or current_slug == "tools-applications-new" %}
 
   <li itemscope itemprop="itemListElement"
       itemtype="https://schema.org/ListItem"
       {% if not forloop.last %}
       class="active"
-      {% endif %}>
+      {% endif %}
+      data-parent_slug-truncate="{{ parent_slug|truncatechars:17 }}">
   {% if not forloop.last %}
 
     <a href="{{ ance.get_absolute_url }}" itemprop="item">

--- a/designsafe/templates/menu/breadcrumb.html
+++ b/designsafe/templates/menu/breadcrumb.html
@@ -2,14 +2,17 @@
 {% load cms_tags %}
 
 {% for ance in ancestors %}
+{% page_attribute "slug" ance.id as current_slug %}
 {% page_attribute "slug" ance.parent_id as parent_slug %}
-{% if not parent_slug == "tools-applications" %}
+{% if not parent_slug == "tools-applications" or current_slug == "tools-applications-new" %}
 
   <li itemscope itemprop="itemListElement"
       itemtype="https://schema.org/ListItem"
       {% if not forloop.last %}
       class="active"
-      {% endif %}>
+      {% endif %}
+      data-current_slug="{{ current_slug }}"
+      data-parent_slug="{{ parent_slug }}">
   {% if not forloop.last %}
 
     <a href="{{ ance.get_absolute_url }}" itemprop="item">

--- a/designsafe/templates/menu/breadcrumb.html
+++ b/designsafe/templates/menu/breadcrumb.html
@@ -10,9 +10,7 @@
       itemtype="https://schema.org/ListItem"
       {% if not forloop.last %}
       class="active"
-      {% endif %}
-      data-current_slug="{{ current_slug }}"
-      data-parent_slug="{{ parent_slug }}">
+      {% endif %}>
   {% if not forloop.last %}
 
     <a href="{{ ance.get_absolute_url }}" itemprop="item">


### PR DESCRIPTION
## Overview

Remove App category breadcrumb in CMS (cuz it is not in Workspace yet).

> [!IMPORTANT]
> Not necessary if https://github.com/DesignSafe-CI/portal/pull/1360 is merged.

## Related

* [DES-3027](https://tacc-main.atlassian.net/browse/DES-3027)

## Changes

* **added** condition to hide breadcrumb

## Testing

> [!NOTE]
> If testing off "Prod", check out
> ```
> fix/DES-3027-remove-cms-app-category-breadcrumb
> ```
> If testing off "Next", check out
> ```
> feat/Tapis-v3-redesign--DES-3027-remove-cms-app-category-breadcrumb
> ```

1. Have an App Category model "Simulation".
2. Have a CMS page "Tools & Applications".
3. In "Basic Settings", verify "Slug" is `tools-applications`.
4. Have a child page "Simulation".
5. Have a child page "ADCIRC Overview".
6. Open child page.
7. Verify breadcrumb:\
    <sub>**is** Tools & Applications > ADCIRC Overview</sub>\
    <sub>**not** Tools & Applications > Simulation > ADCIRC Overview</sub>
8. Add new page "Tools & Applications (New)" under "Tools & Applications".
9. Move old page "Simulation" under new page "Tools & Applications (New)".
10. Verify breadcrumb:\
    <sub>**is** Tools & Applications > Tools & Applications (New) > ADCIRC Overview</sub>\
    <sub>**not** Tools & Applications > Tools & Applications (New) > Simulation > ADCIRC Overview</sub>

## UI

| off `main` branch<br><sup>w/ `tools-applications-new`</sup> | off `feat/Tapis-v3-…` branch<br><sup>w/ `tools-applications`</sup> |
| - | - |
| <img width="960" alt="DES-3027 Main tools-applications-new" src="https://github.com/user-attachments/assets/faab509b-5eee-4f33-abea-348ba2188a38"> | <img width="960" alt="DES-3027 Next tools-applications" src="https://github.com/user-attachments/assets/2c35cb7e-ff3b-4cb5-b7f1-9d8ff4032e97"> |