### PR TITLE
Add dropdown with help links

### DIFF
--- a/client/modules/datafiles/src/DatafilesHelpDropdown/DatafilesHelpDropdown.module.css
+++ b/client/modules/datafiles/src/DatafilesHelpDropdown/DatafilesHelpDropdown.module.css
@@ -1,0 +1,10 @@
+.datafilesHelp div {
+  text-align: center;
+  line-height: 20px;
+}
+
+.datafilesHelp a {
+  text-decoration: none;
+  color: unset;
+  white-space: nowrap;
+}

--- a/client/modules/datafiles/src/DatafilesHelpDropdown/DatafilesHelpDropdown.tsx
+++ b/client/modules/datafiles/src/DatafilesHelpDropdown/DatafilesHelpDropdown.tsx
@@ -1,0 +1,130 @@
+import { Button, Dropdown } from 'antd';
+import React from 'react';
+import styles from './DatafilesHelpDropdown.module.css';
+
+const items = [
+  {
+    label: (
+      <a
+        href="https://www.youtube.com/playlist?list=PL2GxvrdFrBlkwHBgQ47pZO-77ZLrJKYHV"
+        rel="noopener noreferrer"
+        target="_blank"
+        aria-describedby="msg-open-ext-site-new-window"
+      >
+        <div>Curation Tutorials</div>
+      </a>
+    ),
+    key: '1',
+  },
+  {
+    label: (
+      <a
+        href="/rw/user-guides/data-publication-guidelines/"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-describedby="msg-open-new-window"
+      >
+        <div>Curation Guidelines</div>
+      </a>
+    ),
+    key: '2',
+  },
+  {
+    label: (
+      <a
+        href="/rw/user-guide/data-depot"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-describedby="msg-open-new-window"
+      >
+        <div>
+          Learn About the <br />
+          Data Depot
+        </div>
+      </a>
+    ),
+    key: '3',
+  },
+  {
+    label: (
+      <a
+        href="/rw/user-guides/data-transfer-guide/"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-describedby="msg-open-new-window"
+      >
+        <div>Data Transfer Guide</div>
+      </a>
+    ),
+    key: '4',
+  },
+  {
+    label: (
+      <a
+        href="/faq/#!#faq-dcap"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-describedby="msg-open-new-window"
+      >
+        <div>Curation FAQ</div>
+      </a>
+    ),
+    key: '5',
+  },
+  {
+    label: (
+      <a
+        href="/faq/#!#faq-citation"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-describedby="msg-open-new-window"
+      >
+        <div>
+          How to Acknowledge <br />
+          DesignSafe-CI
+        </div>
+      </a>
+    ),
+    key: '6',
+  },
+  {
+    label: (
+      <a
+        href="/rw/user-guides/curating-publishing-projects/policies/publication/"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-describedby="msg-open-new-window"
+      >
+        <div>Data Usage Agreement</div>
+      </a>
+    ),
+    key: '7',
+  },
+  {
+    label: (
+      <a
+        href="/faq"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-describedby="msg-open-new-window"
+      >
+        <div>FAQ</div>
+      </a>
+    ),
+    key: '8',
+  },
+];
+
+export const DatafilesHelpDropdown: React.FC = () => {
+  return (
+    <Dropdown
+      menu={{ items }}
+      trigger={['click']}
+      overlayClassName={styles.datafilesHelp}
+    >
+      <Button type="primary">
+        Help <span className="caret" role="presentation" />
+      </Button>
+    </Dropdown>
+  );
+};

--- a/client/modules/datafiles/src/index.ts
+++ b/client/modules/datafiles/src/index.ts
@@ -1,6 +1,7 @@
 export * from './lib/datafiles';
 
 export * from './DatafilesSideNav/DatafilesSideNav';
+export * from './DatafilesHelpDropdown/DatafilesHelpDropdown';
 export * from './AddFileFolder/AddFileFolder';
 export * from './FileListing/FileListing';
 export { default as DatafilesModal } from './DatafilesModal/DatafilesModal';

--- a/client/src/datafiles/layouts/DataFilesBaseLayout.tsx
+++ b/client/src/datafiles/layouts/DataFilesBaseLayout.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { Layout, notification } from 'antd';
-import { AddFileFolder, DatafilesSideNav } from '@client/datafiles';
+import {
+  AddFileFolder,
+  DatafilesHelpDropdown,
+  DatafilesSideNav,
+} from '@client/datafiles';
 import { useAuthenticatedUser, notifyContext } from '@client/hooks';
 
 const { Sider } = Layout;
@@ -35,6 +39,7 @@ const DataFilesRoot: React.FC = () => {
           </h1>
           <AddFileFolder />
           <DatafilesSideNav />
+          <DatafilesHelpDropdown />
         </Sider>
         {pathname === '/' && <Navigate to={defaultPath} replace></Navigate>}
         <Outlet />


### PR DESCRIPTION
## Overview: ##
Add help dropdown with links to documentation.

<img width="241" alt="image" src="https://github.com/user-attachments/assets/9877f6cb-7006-406c-a39b-b7a8422dd2c2">

