### PR TITLE
Task/DES-2601: DOI logging for file/publication operations

### DIFF
--- a/client/modules/_common_components/src/datafiles/FileListingTable/FileListingTable.tsx
+++ b/client/modules/_common_components/src/datafiles/FileListingTable/FileListingTable.tsx
@@ -1,7 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import styles from './FileListingTable.module.css';
 import { Alert, Table, TableColumnType, TableProps } from 'antd';
-import { useFileListing, TFileListing, useSelectedFiles } from '@client/hooks';
+import {
+  useFileListing,
+  TFileListing,
+  useSelectedFiles,
+  useDoiContext,
+} from '@client/hooks';
 import { FileListingTableCheckbox } from './FileListingTableCheckbox';
 import parse from 'html-react-parser';
 
@@ -81,14 +86,17 @@ export const FileListingTable: React.FC<
   }, [data, filterFn, currentDisplayPath]);
 
   /* HANDLE FILE SELECTION */
+  const doi = useDoiContext();
   const { selectedFiles, setSelectedFiles } = useSelectedFiles(
     api,
     system ?? '-',
     path
   );
   const onSelectionChange = useCallback(
-    (_: React.Key[], selection: TFileListing[]) => setSelectedFiles(selection),
-    [setSelectedFiles]
+    (_: React.Key[], selection: TFileListing[]) => {
+      setSelectedFiles(doi ? selection.map((s) => ({ ...s, doi })) : selection);
+    },
+    [setSelectedFiles, doi]
   );
   const selectedRowKeys = useMemo(
     () => selectedFiles.map((s) => s.path),

--- a/client/modules/_hooks/src/datafiles/publications/index.ts
+++ b/client/modules/_hooks/src/datafiles/publications/index.ts
@@ -9,3 +9,4 @@ export { usePublishProject } from './usePublishProject';
 export { useVersionProject } from './useVersionProject';
 export { useAmendProject } from './useAmendProject';
 export { useCreateFeedbackTicket } from './useCreateFeedbackTicket';
+export { useDoiContext, DoiContextProvider } from './useDoiContext';

--- a/client/modules/_hooks/src/datafiles/publications/useDoiContext.ts
+++ b/client/modules/_hooks/src/datafiles/publications/useDoiContext.ts
@@ -1,0 +1,20 @@
+import React, { useContext } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+const doiContext = React.createContext<string | undefined>(undefined);
+
+export function useDoiContext() {
+  const doiFromContext = useContext(doiContext);
+  const [searchParams] = useSearchParams();
+  if (doiFromContext) {
+    return doiFromContext;
+  }
+  const doiFromParams = searchParams.get('doi');
+
+  if (doiFromParams) {
+    return doiFromParams;
+  }
+  return undefined;
+}
+
+export const DoiContextProvider = doiContext.Provider;

--- a/client/modules/_hooks/src/datafiles/useFileDetail.ts
+++ b/client/modules/_hooks/src/datafiles/useFileDetail.ts
@@ -20,12 +20,13 @@ export function useFileDetail(
   api: string,
   system: string,
   scheme: string,
-  path: string
+  path: string,
+  enabled: boolean = true
 ) {
   return useQuery({
     queryKey: ['datafiles', 'fileListing', 'detail', api, scheme, system, path],
     queryFn: ({ signal }) =>
       getFileDetail(api, system, path, scheme, { signal }),
-    enabled: !!path,
+    enabled: !!path && enabled,
   });
 }

--- a/client/modules/_hooks/src/datafiles/useFileListing.ts
+++ b/client/modules/_hooks/src/datafiles/useFileListing.ts
@@ -13,6 +13,7 @@ export type TFileListing = {
   lastModified: string;
   length: number;
   permissions: string;
+  doi?: string;
 };
 
 export type FileListingResponse = {

--- a/client/modules/_hooks/src/datafiles/useFilePreview.ts
+++ b/client/modules/_hooks/src/datafiles/useFilePreview.ts
@@ -6,6 +6,7 @@ export type TPreviewParams = {
   api: string;
   system: string;
   scheme?: string;
+  doi?: string;
   path: string;
 };
 
@@ -31,11 +32,12 @@ async function getFilePreview({
   system,
   scheme,
   path,
+  doi,
   signal,
 }: TPreviewParams & { signal: AbortSignal }) {
   const res = await apiClient.get<TFilePreviewResponse>(
     `/api/datafiles/${api}/${scheme}/preview/${system}/${path}`,
-    { signal }
+    { params: { doi }, signal }
   );
   return res.data;
 }
@@ -45,6 +47,7 @@ export function useFilePreview({
   system,
   scheme = 'private',
   path,
+  doi,
   queryOptions,
 }: TPreviewParams & {
   queryOptions?: TQueryOptionExtras<TFilePreviewResponse>;
@@ -52,7 +55,7 @@ export function useFilePreview({
   return useQuery({
     queryKey: ['datafiles', 'preview', api, system, path],
     queryFn: ({ signal }) =>
-      getFilePreview({ api, system, scheme, path, signal }),
+      getFilePreview({ api, system, scheme, path, doi, signal }),
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     ...queryOptions,

--- a/client/modules/datafiles/src/DatafilesModal/CopyModal/CopyModal.tsx
+++ b/client/modules/datafiles/src/DatafilesModal/CopyModal/CopyModal.tsx
@@ -197,6 +197,7 @@ export const CopyModal: React.FC<{
         mutate({
           src: { api, system, path: encodeURIComponent(f.path) },
           dest: { api: destApi, system: destSystem, path: dPath },
+          doi: f.doi,
         })
       );
       handleClose();

--- a/client/modules/datafiles/src/DatafilesModal/DownloadModal/DownloadModal.tsx
+++ b/client/modules/datafiles/src/DatafilesModal/DownloadModal/DownloadModal.tsx
@@ -2,7 +2,6 @@ import { Modal } from 'antd';
 import React, { useState } from 'react';
 import { TModalChildren } from '../DatafilesModal';
 import { TFileListing, apiClient } from '@client/hooks';
-import { useSearchParams } from 'react-router-dom';
 
 export const DownloadModal: React.FC<{
   api: string;
@@ -13,7 +12,9 @@ export const DownloadModal: React.FC<{
 }> = ({ api, system, scheme, selectedFiles, children }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const [searchParams] = useSearchParams();
+  const doiArray = selectedFiles.filter((f) => f.doi).map((f) => f.doi);
+
+  const doiString = [...new Set(doiArray)].join(',');
 
   const showModal = () => {
     setIsModalOpen(true);
@@ -21,7 +22,7 @@ export const DownloadModal: React.FC<{
 
   const zipUrl = `/api/datafiles/${api}/${
     scheme ?? 'public'
-  }/download/${system}/?doi=${searchParams.get('doi')}`;
+  }/download/${system}/?doi=${doiString}`;
 
   const handleDownload = () => {
     apiClient

--- a/client/modules/datafiles/src/DatafilesModal/PreviewModal/PreviewModal.tsx
+++ b/client/modules/datafiles/src/DatafilesModal/PreviewModal/PreviewModal.tsx
@@ -33,6 +33,7 @@ export const PreviewModalBody: React.FC<{
     system: selectedFile.system,
     scheme,
     path: selectedFile.path,
+    doi: selectedFile.doi,
     queryOptions: { enabled: isOpen },
   });
 

--- a/client/modules/datafiles/src/FileListing/FileListing.tsx
+++ b/client/modules/datafiles/src/FileListing/FileListing.tsx
@@ -8,7 +8,7 @@ import {
 } from '@client/common-components';
 import { NavLink } from 'react-router-dom';
 import { PreviewModalBody } from '../DatafilesModal/PreviewModal';
-import { TFileListing, TFileTag } from '@client/hooks';
+import { TFileListing, TFileTag, useDoiContext } from '@client/hooks';
 
 export function toBytes(bytes?: number) {
   if (bytes === 0) return '0 bytes';
@@ -47,6 +47,7 @@ export const FileListing: React.FC<
     selectedFile?: TFileListing;
   }>({ isOpen: false });
 
+  const doi = useDoiContext();
   const columns: TFileListingColumns = useMemo(
     () => [
       {
@@ -59,7 +60,9 @@ export const FileListing: React.FC<
             {record.type === 'dir' ? (
               <NavLink
                 className="listing-nav-link"
-                to={`${baseRoute ?? '..'}/${encodeURIComponent(record.path)}`}
+                to={`${baseRoute ?? '..'}/${encodeURIComponent(record.path)}${
+                  doi ? `?doi=${doi}` : ''
+                }`}
                 replace={false}
               >
                 <i
@@ -82,7 +85,7 @@ export const FileListing: React.FC<
                     setPreviewModalState({
                       isOpen: true,
                       path: record.path,
-                      selectedFile: record,
+                      selectedFile: { ...record, doi },
                     })
                   }
                 >
@@ -113,7 +116,7 @@ export const FileListing: React.FC<
         render: (d) => new Date(d).toLocaleString(),
       },
     ],
-    [setPreviewModalState, baseRoute, fileTags]
+    [setPreviewModalState, baseRoute, fileTags, doi]
   );
 
   return (

--- a/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
+  apiClient,
   DoiContextProvider,
   TFileListing,
   TPreviewTreeData,
@@ -218,18 +219,18 @@ export const PublishedEntityDisplay: React.FC<{
     treeData.value.dois && treeData.value.dois.length > 0
       ? treeData.value.dois[0]
       : '';
-  const {
-    data: citationMetrics,
-    isLoading,
-    isError,
-    error,
-  } = useDataciteMetrics(dois, !preview);
+  const { data: citationMetrics } = useDataciteMetrics(dois, !preview);
 
   useEffect(() => {
-    if (isError) {
-      console.error('Error fetching citation metrics:', error);
+    if (active && !preview) {
+      const identifier = dois ?? treeData.uuid;
+      const path = `${projectId}/${treeData.name}/${identifier}`;
+      apiClient.get(
+        `/api/datafiles/agave/public/logentity/designsafe.storage.published/${path}`,
+        { params: { doi: dois } }
+      );
     }
-  }, [isLoading, isError, error]);
+  }, [active, preview, dois, projectId, treeData.name, treeData.uuid]);
 
   return (
     <section>

--- a/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
+  DoiContextProvider,
   TFileListing,
   TPreviewTreeData,
   useDataciteMetrics,
+  useDoiContext,
   useProjectPreview,
   usePublicationDetail,
   usePublicationVersions,
@@ -38,6 +40,7 @@ export const EntityFileListingTable: React.FC<{
     selectedFile?: TFileListing;
   }>({ isOpen: false });
 
+  const doi = useDoiContext();
   const columns: TFileListingColumns = [
     {
       title: 'File Name',
@@ -48,7 +51,9 @@ export const EntityFileListingTable: React.FC<{
           {record.type === 'dir' ? (
             <Link
               className="listing-nav-link"
-              to={`./${encodeURIComponent(record.path)}`}
+              to={`./${encodeURIComponent(record.path)}${
+                doi ? `?doi=${doi}` : ''
+              }`}
               style={{ pointerEvents: preview ? 'none' : 'all' }}
               replace={false}
             >
@@ -71,7 +76,7 @@ export const EntityFileListingTable: React.FC<{
                   setPreviewModalState({
                     isOpen: true,
                     path: record.path,
-                    selectedFile: record,
+                    selectedFile: { ...record, doi },
                   })
                 }
               >
@@ -400,13 +405,15 @@ export const PublicationView: React.FC<{
             child.name !== 'designsafe.project'
         )
         .map((child, idx) => (
-          <PublishedEntityDisplay
-            license={data.baseProject.license}
-            projectId={projectId}
-            treeData={child}
-            defaultOpen={idx === 0 && sortedChildren.length === 1}
-            key={child.id}
-          />
+          <DoiContextProvider key={child.id} value={child.value.dois?.[0]}>
+            <PublishedEntityDisplay
+              license={data.baseProject.license}
+              projectId={projectId}
+              treeData={child}
+              defaultOpen={idx === 0 && sortedChildren.length === 1}
+              key={child.id}
+            />
+          </DoiContextProvider>
         ))}
     </div>
   );

--- a/client/modules/datafiles/src/publications/modals/DownloadDatasetModal.tsx
+++ b/client/modules/datafiles/src/publications/modals/DownloadDatasetModal.tsx
@@ -229,7 +229,8 @@ export const DownloadDatasetModal: React.FC<{
     'tapis',
     'designsafe.storage.published',
     'public',
-    archivePath
+    archivePath,
+    isModalOpen
   );
   const FILE_SIZE_LIMIT = 2147483648;
   const exceedsLimit = useMemo(

--- a/client/src/datafiles/layouts/published/PublishedEntityListingLayout.tsx
+++ b/client/src/datafiles/layouts/published/PublishedEntityListingLayout.tsx
@@ -1,5 +1,9 @@
 import { FileListing, PublicationView } from '@client/datafiles';
-import { usePublicationDetail, usePublicationVersions } from '@client/hooks';
+import {
+  DoiContextProvider,
+  usePublicationDetail,
+  usePublicationVersions,
+} from '@client/hooks';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -15,17 +19,19 @@ export const PublishedEntityListingLayout: React.FC = () => {
       {['other', 'field_reconnaissance'].includes(
         data.baseProject.projectType
       ) && (
-        <FileListing
-          scroll={{ y: 500, x: 500 }}
-          api="tapis"
-          system="designsafe.storage.published"
-          path={encodeURIComponent(
-            data.tree.children.find((c) => c.version === selectedVersion)
-              ?.basePath ?? ''
-          )}
-          baseRoute="."
-          fileTags={data.fileTags}
-        />
+        <DoiContextProvider value={data.baseProject.dois?.[0]}>
+          <FileListing
+            scroll={{ y: 500, x: 500 }}
+            api="tapis"
+            system="designsafe.storage.published"
+            path={encodeURIComponent(
+              data.tree.children.find((c) => c.version === selectedVersion)
+                ?.basePath ?? ''
+            )}
+            baseRoute="."
+            fileTags={data.fileTags}
+          />
+        </DoiContextProvider>
       )}
     </div>
   );


### PR DESCRIPTION
## Overview: ##
Log the DOI when published files are copied/downloaded/previewed. Log the entity name and DOI when the publication collapse dropdown is opened.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2601](https://tacc-main.atlassian.net/browse/DES-2601)

## Summary of Changes: ##

## Testing Steps: ##
1. Download/copy/preview files in a publication in dev, and check that the DOI appears in the logs.
2. Download multiple files from separate DOIs on a publication's landing page. Check that each DOI shows up in the logs after `op=download`.
