### PR TITLE
[Job Listing] Translate timeout errors to finished for interactive apps

### DIFF
--- a/designsafe/apps/workspace/api/views.py
+++ b/designsafe/apps/workspace/api/views.py
@@ -625,6 +625,12 @@ class JobsView(AuthenticatedApiView):
             _tapis_query_parameters={"tags.contains": f"portalName: {portal_name}"},
             select="allAttributes",
         )
+        if isinstance(data, list):
+            for index, job in enumerate(data):
+                data[index] = check_job_for_timeout(job)
+        else:
+            data = check_job_for_timeout(data)
+
         return {"listing": data, "reachedEnd": len(data) < int(limit)}
 
     def search(self, client, request):


### PR DESCRIPTION
## Overview: ##
Job listing is not showing 'finished' as status when interactive apps timeout.
There is existing logic to handle this, but this is not done for listing endpoint.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-3023](https://tacc-main.atlassian.net/browse/DES-3023)

## Summary of Changes: ##
* Update listing endpoint to also adapt to status changes. 

## Testing Steps: ##
go to listing, find an existing interactive app that failed with timeout.  Just before vs after.

Before:
<img width="1374" alt="Screenshot 2024-07-15 at 11 31 00 AM" src="https://github.com/user-attachments/assets/9d60f990-3917-47dd-8ed2-0974b91475dc">
<img width="1245" alt="Screenshot 2024-07-15 at 11 30 52 AM" src="https://github.com/user-attachments/assets/f55f9aee-213f-4c77-9a11-d0b554ac2008">


After:
<img width="845" alt="Screenshot 2024-07-15 at 11 55 33 AM" src="https://github.com/user-attachments/assets/069dacc2-4da2-41a5-9777-7b810c7a8c84">


## UI Photos:

## Notes: ##

This is broken in core also, created jira [WP-597](https://tacc-main.atlassian.net/browse/WP-597) to fix.