### PR TITLE
task/DES-3028: Add category link to app form breadcrumb

### DIFF
--- a/client/modules/_hooks/src/workspace/useAppsListing.ts
+++ b/client/modules/_hooks/src/workspace/useAppsListing.ts
@@ -4,6 +4,7 @@ import apiClient from '../apiClient';
 export type TPortalApp = {
   app_id: string;
   app_type: string;
+  bundle_category: string;
   bundle_href: string;
   bundle_id: number;
   bundle_label: string;

--- a/client/modules/workspace/src/AppsBreadcrumb/AppsBreadcrumb.tsx
+++ b/client/modules/workspace/src/AppsBreadcrumb/AppsBreadcrumb.tsx
@@ -40,7 +40,14 @@ export const AppsBreadcrumb: React.FC = () => {
       href: '/use-designsafe/tools-applications/',
     },
   ];
-
+  if (currentAppFromCategories?.bundle_category) {
+    breadcrumbItems.push({
+      title: `${currentAppFromCategories.bundle_category}`,
+      href: `/use-designsafe/tools-applications/${currentAppFromCategories.bundle_category
+        .toLowerCase()
+        .replace(/ /g, '-')}`,
+    });
+  }
   if (currentAppFromCategories?.bundle_href) {
     breadcrumbItems.push({
       title: `${currentAppFromCategories.bundle_label} Overview`,

--- a/designsafe/apps/workspace/api/views.py
+++ b/designsafe/apps/workspace/api/views.py
@@ -359,6 +359,7 @@ class AppsTrayView(AuthenticatedApiView):
         all_values = [
             "app_id",
             "app_type",
+            "bundle_category",
             "bundle_description",
             "bundle_href",
             "bundle_id",
@@ -379,6 +380,7 @@ class AppsTrayView(AuthenticatedApiView):
         reduced_values = [
             "app_id",
             "app_type",
+            "bundle_category",
             "bundle_href",
             "bundle_id",
             "bundle_label",
@@ -408,6 +410,7 @@ class AppsTrayView(AuthenticatedApiView):
                 .annotate(
                     icon=F("bundle__icon"),
                     is_bundled=GreaterThan(Count("bundle__appvariant"), 1),
+                    bundle_category=F("bundle__category__category"),
                     bundle_description=F("bundle__description"),
                     bundle_href=F("bundle__href"),
                     bundle_is_popular=F("bundle__is_popular"),
@@ -428,6 +431,7 @@ class AppsTrayView(AuthenticatedApiView):
                 .annotate(
                     icon=F("bundle__icon"),
                     is_bundled=GreaterThan(Count("bundle__appvariant"), 1),
+                    bundle_category=F("bundle__category__category"),
                     bundle_description=F("bundle__description"),
                     bundle_href=F("bundle__href"),
                     bundle_is_popular=F("bundle__is_popular"),
@@ -471,6 +475,7 @@ class AppsTrayView(AuthenticatedApiView):
                         {
                             "app_id": "jupyter-lab-hpc",
                             "app_type": "tapis",
+                            "bundle_category": "Analysis",
                             "bundle_description: "Custom Jupyter notebooks.",
                             "bundle_href": "https://designsafe-ci.org/applications/overview/jupyter,
                             "bundle_id": 1,


### PR DESCRIPTION
## Overview: ##

Add category link to app form breadcrumb

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-3028](https://tacc-main.atlassian.net/browse/DES-3028)

## Testing Steps: ##
1. Go to any DS app and confirm it has a category link, e.g. https://designsafe.dev/rw/workspace/adcirc?appVersion=55.01
2. Go to a private app, or unregistered public app and confirm it does not have a category link

## UI Photos:

With
<img width="802" alt="Screenshot 2024-07-15 at 2 41 39 PM" src="https://github.com/user-attachments/assets/29679078-5f10-4ba1-b967-ed20be12794f">

Without
<img width="701" alt="Screenshot 2024-07-15 at 2 41 27 PM" src="https://github.com/user-attachments/assets/57e8ec84-73bf-414a-a935-bd6fa173b5ad">

