### PR TITLE
Bugs/DES-3033 [Job Details Modal] Do not show hidden fields and show fields with empty strings

### DIFF
--- a/client/modules/workspace/src/JobsDetailModal/JobsDetailModal.tsx
+++ b/client/modules/workspace/src/JobsDetailModal/JobsDetailModal.tsx
@@ -164,7 +164,7 @@ export const JobsDetailModalBody: React.FC<{
     data: Record<string, string | undefined>
   ): DescriptionsProps['items'] =>
     Object.entries(data)
-      .filter(([_, value]) => value)
+      .filter(([_, value]) => value !== undefined) // allow empty strings
       .map(([key, value]) => ({
         label: key,
         children: <span style={valueStyle}>{value}</span>,

--- a/client/modules/workspace/src/utils/jobs.ts
+++ b/client/modules/workspace/src/utils/jobs.ts
@@ -147,19 +147,24 @@ export function getJobDisplayInformation(
   app: TAppResponse | undefined
 ): TJobDisplayInfo {
   const filterAppArgs = (objects: TJobArgSpecs) =>
-    objects.filter((obj) => !obj.notes || !obj.notes.isHidden);
+    objects.filter((obj) => {
+      const notes = obj.notes ? JSON.parse(obj.notes as string) : null;
+      return !notes || !notes.isHidden;
+    });
 
   const filterInputs = (objects: TAppFileInput[]) =>
-    objects.filter(
-      (obj) =>
-        (!obj.notes || !obj.notes.isHidden) &&
-        !(obj.name || obj.sourceUrl || '').startsWith('_')
-    );
+    objects
+      .filter((obj) => {
+        const notes = obj.notes ? JSON.parse(obj.notes as string) : null;
+        return !notes || !notes.isHidden;
+      })
+      .filter((obj) => !(obj.name || obj.sourceUrl || '').startsWith('_'));
 
   const filterParameters = (objects: TJobKeyValuePair[]) =>
-    objects.filter(
-      (obj) => (!obj.notes || !obj.notes.isHidden) && !obj.key.startsWith('_')
-    );
+    objects.filter((obj) => {
+      const notes = obj.notes ? JSON.parse(obj.notes as string) : null;
+      return (!notes || !notes.isHidden) && !obj.key.startsWith('_');
+    });
 
   const fileInputs = filterInputs(
     JSON.parse(job.fileInputs) as TAppFileInput[]

--- a/client/modules/workspace/src/utils/jobs.ts
+++ b/client/modules/workspace/src/utils/jobs.ts
@@ -139,6 +139,24 @@ function getParameterSetNotesLabel(obj: unknown): string | undefined {
   return undefined;
 }
 
+function isNotHidden(
+  obj: TJobArgSpec | TAppFileInput | TJobKeyValuePair
+): boolean {
+  return !obj.notes || !obj.notes.isHidden;
+}
+
+// Notes Reviver for JSON.parse
+function reviver(key: string, value: unknown) {
+  if (key === 'notes' && typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch (e) {
+      return value;
+    }
+  }
+  return value;
+}
+
 /**
  * Get display values from job, app, and execution system info.
  */
@@ -146,30 +164,20 @@ export function getJobDisplayInformation(
   job: TTapisJob,
   app: TAppResponse | undefined
 ): TJobDisplayInfo {
-  const filterAppArgs = (objects: TJobArgSpecs) =>
-    objects.filter((obj) => {
-      const notes = obj.notes ? JSON.parse(obj.notes as string) : null;
-      return !notes || !notes.isHidden;
-    });
+  const filterAppArgs = (objects: TJobArgSpecs) => objects.filter(isNotHidden);
 
   const filterInputs = (objects: TAppFileInput[]) =>
     objects
-      .filter((obj) => {
-        const notes = obj.notes ? JSON.parse(obj.notes as string) : null;
-        return !notes || !notes.isHidden;
-      })
+      .filter(isNotHidden)
       .filter((obj) => !(obj.name || obj.sourceUrl || '').startsWith('_'));
 
   const filterParameters = (objects: TJobKeyValuePair[]) =>
-    objects.filter((obj) => {
-      const notes = obj.notes ? JSON.parse(obj.notes as string) : null;
-      return (!notes || !notes.isHidden) && !obj.key.startsWith('_');
-    });
+    objects.filter(isNotHidden).filter((obj) => !obj.key.startsWith('_'));
 
   const fileInputs = filterInputs(
-    JSON.parse(job.fileInputs) as TAppFileInput[]
+    JSON.parse(job.fileInputs, reviver) as TAppFileInput[]
   );
-  const parameterSet = JSON.parse(job.parameterSet);
+  const parameterSet = JSON.parse(job.parameterSet, reviver);
   const parameters = filterAppArgs(parameterSet.appArgs) as TJobArgSpecs;
 
   const displayEnvVariables = filterParameters(parameterSet.envVariables);
@@ -192,7 +200,7 @@ export function getJobDisplayInformation(
       value: parameter.arg,
     })),
     envVars: displayEnvVariables.map((d) => ({
-      label: getParameterSetNotesLabel(d.notes) ?? d.key,
+      label: d.notes?.label ?? d.key,
       id: d.key,
       value: d.value,
     })),


### PR DESCRIPTION
## Overview: ##
* Notes section is still in json and not parsed. Parse the notes json and correctly hide the fields.
* Show empty input or parameters - only ignore undefined input, but empty values are useful in debugging job results.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-3033](https://tacc-main.atlassian.net/browse/DES-3033)

## Summary of Changes: ##

## Testing Steps: ##
1. Test paraview before and after fix.
2. Test empty optional fields and ensure they show up in details to allow user to see that optional data is not passed in.

Para view job details before:
<img width="1753" alt="Screenshot 2024-07-16 at 9 48 27 AM" src="https://github.com/user-attachments/assets/9596b120-9ba1-4820-9026-e9fdffcf9b9b">

Para view job details after:
<img width="1223" alt="Screenshot 2024-07-16 at 9 46 44 AM" src="https://github.com/user-attachments/assets/ce2e9448-2764-4c1f-9c6f-738adf755b65">

Empty string for a parameter: (additional parameters for converter)
<img width="1185" alt="Screenshot 2024-07-16 at 9 46 25 AM" src="https://github.com/user-attachments/assets/bb9cb55d-c72e-484b-9a53-2ed9ac843c07">


## UI Photos:

## Notes: ##
