### PR TITLE
Bug/des 2528 update datacite metrics

### DIFF
--- a/client/modules/_hooks/src/datafiles/publications/useDataciteEvents.ts
+++ b/client/modules/_hooks/src/datafiles/publications/useDataciteEvents.ts
@@ -21,7 +21,7 @@ export async function getDataciteEvents({
 }) {
   const dataciteEvents = `/api/publications/data-cite/events?source-id=datacite-usage&doi=${encodeURIComponent(
     doi
-  )}`;
+  )}&page[size]=1000`;
 
   // Fetch data from both endpoints simultaneously
   const respDataciteEvents = await apiClient.get<DataciteEventsResponse>(

--- a/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
+++ b/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
@@ -58,19 +58,16 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
   }
 
   // Table 1: Usage Breakdown
-  const uniqueInvestigations = eventMetricsData.data.filter(
-    (entry: DataEntry) =>
-      entry.attributes['relation-type-id'] ===
-      'unique-dataset-investigations-regular'
-  );
-  const uniqueRequests = eventMetricsData.data.filter(
-    (entry: DataEntry) =>
-      entry.attributes['relation-type-id'] === 'unique-dataset-requests-regular'
-  );
-  const totalRequests = eventMetricsData.data.filter(
-    (entry: DataEntry) =>
-      entry.attributes['relation-type-id'] === 'total-dataset-requests-regular'
-  );
+  const sumTotals = (data: DataEntry[], relationTypeId: string) => {
+    return data
+      .filter(entry => entry.attributes['relation-type-id'] === relationTypeId)
+      .reduce((sum, entry) => sum + entry.attributes.total, 0);
+  };
+  
+  const uniqueInvestigations = sumTotals(eventMetricsData.data, 'unique-dataset-investigations-regular');
+  const uniqueRequests = sumTotals(eventMetricsData.data, 'unique-dataset-requests-regular');
+  const totalRequests = sumTotals(eventMetricsData.data, 'total-dataset-requests-regular');
+  
 
   const dataSource = [
     {
@@ -90,8 +87,8 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
         </span>
       ),
       data:
-        uniqueInvestigations.length > 0
-          ? uniqueInvestigations[0].attributes.total
+        uniqueInvestigations > 0
+          ? uniqueInvestigations
           : '--',
     },
     {
@@ -112,7 +109,7 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
         </span>
       ),
       data:
-        uniqueRequests.length > 0 ? uniqueRequests[0].attributes.total : '--',
+        uniqueRequests > 0 ? uniqueRequests : '--',
     },
     {
       key: '3',
@@ -128,7 +125,7 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
           </Popover>
         </span>
       ),
-      data: totalRequests.length > 0 ? totalRequests[0].attributes.total : '--',
+      data: totalRequests > 0 ? totalRequests : '--',
     },
   ];
 

--- a/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
+++ b/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
@@ -89,7 +89,7 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
       data:
         uniqueInvestigations > 0
           ? uniqueInvestigations
-          : '--',
+          : '- -',
     },
     {
       key: '2',

--- a/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
+++ b/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
@@ -58,19 +58,15 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
   }
 
   // Table 1: Usage Breakdown
-  const uniqueInvestigations = eventMetricsData.data.filter(
-    (entry: DataEntry) =>
-      entry.attributes['relation-type-id'] ===
-      'unique-dataset-investigations-regular'
-  );
-  const uniqueRequests = eventMetricsData.data.filter(
-    (entry: DataEntry) =>
-      entry.attributes['relation-type-id'] === 'unique-dataset-requests-regular'
-  );
-  const totalRequests = eventMetricsData.data.filter(
-    (entry: DataEntry) =>
-      entry.attributes['relation-type-id'] === 'total-dataset-requests-regular'
-  );
+  const sumTotals = (data: DataEntry[], relationTypeId: string) => {
+    return data
+      .filter(entry => entry.attributes['relation-type-id'] === relationTypeId)
+      .reduce((sum, entry) => sum + entry.attributes.total, 0);
+  };
+
+  const uniqueInvestigations = sumTotals(eventMetricsData.data, 'unique-dataset-investigations-regular');
+  const uniqueRequests = sumTotals(eventMetricsData.data, 'unique-dataset-requests-regular');
+  const totalRequests = sumTotals(eventMetricsData.data, 'total-dataset-requests-regular');
 
   const dataSource = [
     {
@@ -90,8 +86,8 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
         </span>
       ),
       data:
-        uniqueInvestigations.length > 0
-          ? uniqueInvestigations[0].attributes.total
+        uniqueInvestigations > 0
+          ? uniqueInvestigations
           : '--',
     },
     {
@@ -112,7 +108,7 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
         </span>
       ),
       data:
-        uniqueRequests.length > 0 ? uniqueRequests[0].attributes.total : '--',
+        uniqueRequests > 0 ? uniqueRequests : '--',
     },
     {
       key: '3',
@@ -128,7 +124,7 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
           </Popover>
         </span>
       ),
-      data: totalRequests.length > 0 ? totalRequests[0].attributes.total : '--',
+      data: totalRequests > 0 ? totalRequests : '--',
     },
   ];
 

--- a/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
+++ b/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
@@ -181,7 +181,7 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
       .map((entry) => entry.yearMonth.split('-')[0]) // Get only the years
       .filter((year, index, array) => array.indexOf(year) === index) // Unique years
       .sort((a, b) => b.localeCompare(a)); // Sort descending
-  
+
     return orderedYears.length > 0 ? orderedYears[0] : null; // Return the most recent year
   }, [usageMetricsData.data.attributes.viewsOverTime]);
 
@@ -343,7 +343,7 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
         (quarterSums.totals as { [key: string]: number })?.Q4 || '--',
     },
   ];
-  
+
   const quartersColumns = [
     {
       title: (

--- a/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
+++ b/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
@@ -89,7 +89,7 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
       data:
         uniqueInvestigations > 0
           ? uniqueInvestigations
-          : '- -',
+          : '--',
     },
     {
       key: '2',

--- a/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
+++ b/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
@@ -176,16 +176,24 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
     return sumsByQuarter;
   }
 
-  const orderedYears = useMemo(() => {
-    return usageMetricsData.data.attributes.viewsOverTime
+  const mostRecentYear = useMemo(() => {
+    const orderedYears = usageMetricsData.data.attributes.viewsOverTime
       .map((entry) => entry.yearMonth.split('-')[0]) // Get only the years
       .filter((year, index, array) => array.indexOf(year) === index) // Unique years
       .sort((a, b) => b.localeCompare(a)); // Sort descending
+  
+    return orderedYears.length > 0 ? orderedYears[0] : null; // Return the most recent year
   }, [usageMetricsData.data.attributes.viewsOverTime]);
 
-  const defaultYear = orderedYears[0];
+  const defaultYear = mostRecentYear || '';
 
   const [selectedYear, setSelectedYear] = useState(defaultYear);
+
+  useEffect(() => {
+    if (defaultYear) {
+      setSelectedYear(defaultYear);
+    }
+  }, [defaultYear]);
 
   const [quarterSums, setQuarterSums] = useState<{
     [key: string]: number | { [key: string]: number };
@@ -251,20 +259,6 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
       setQuarterSums({ views, downloads, totals });
     }
   }, [selectedYear, eventMetricsData, usageMetricsData.data.attributes]);
-
-  useEffect(() => {
-    if (
-      usageMetricsData.data.attributes.viewsOverTime &&
-      usageMetricsData.data.attributes.viewsOverTime.length > 0
-    ) {
-      const lastItem =
-        usageMetricsData.data.attributes.viewsOverTime[
-          usageMetricsData.data.attributes.viewsOverTime.length - 1
-        ];
-      const latestYear = lastItem.yearMonth.substring(0, 4);
-      setSelectedYear(latestYear);
-    }
-  }, [usageMetricsData.data.attributes.viewsOverTime]);
 
   const handleYearChange = (value: string) => {
     setSelectedYear(value);
@@ -349,7 +343,7 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
         (quarterSums.totals as { [key: string]: number })?.Q4 || '--',
     },
   ];
-
+  
   const quartersColumns = [
     {
       title: (

--- a/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
+++ b/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
@@ -58,16 +58,19 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
   }
 
   // Table 1: Usage Breakdown
-  const sumTotals = (data: DataEntry[], relationTypeId: string) => {
-    return data
-      .filter(entry => entry.attributes['relation-type-id'] === relationTypeId)
-      .reduce((sum, entry) => sum + entry.attributes.total, 0);
-  };
-  
-  const uniqueInvestigations = sumTotals(eventMetricsData.data, 'unique-dataset-investigations-regular');
-  const uniqueRequests = sumTotals(eventMetricsData.data, 'unique-dataset-requests-regular');
-  const totalRequests = sumTotals(eventMetricsData.data, 'total-dataset-requests-regular');
-  
+  const uniqueInvestigations = eventMetricsData.data.filter(
+    (entry: DataEntry) =>
+      entry.attributes['relation-type-id'] ===
+      'unique-dataset-investigations-regular'
+  );
+  const uniqueRequests = eventMetricsData.data.filter(
+    (entry: DataEntry) =>
+      entry.attributes['relation-type-id'] === 'unique-dataset-requests-regular'
+  );
+  const totalRequests = eventMetricsData.data.filter(
+    (entry: DataEntry) =>
+      entry.attributes['relation-type-id'] === 'total-dataset-requests-regular'
+  );
 
   const dataSource = [
     {
@@ -87,8 +90,8 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
         </span>
       ),
       data:
-        uniqueInvestigations > 0
-          ? uniqueInvestigations
+        uniqueInvestigations.length > 0
+          ? uniqueInvestigations[0].attributes.total
           : '--',
     },
     {
@@ -109,7 +112,7 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
         </span>
       ),
       data:
-        uniqueRequests > 0 ? uniqueRequests : '--',
+        uniqueRequests.length > 0 ? uniqueRequests[0].attributes.total : '--',
     },
     {
       key: '3',
@@ -125,7 +128,7 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
           </Popover>
         </span>
       ),
-      data: totalRequests > 0 ? totalRequests : '--',
+      data: totalRequests.length > 0 ? totalRequests[0].attributes.total : '--',
     },
   ];
 

--- a/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
+++ b/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
@@ -60,13 +60,24 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
   // Table 1: Usage Breakdown
   const sumTotals = (data: DataEntry[], relationTypeId: string) => {
     return data
-      .filter(entry => entry.attributes['relation-type-id'] === relationTypeId)
+      .filter(
+        (entry) => entry.attributes['relation-type-id'] === relationTypeId
+      )
       .reduce((sum, entry) => sum + entry.attributes.total, 0);
   };
 
-  const uniqueInvestigations = sumTotals(eventMetricsData.data, 'unique-dataset-investigations-regular');
-  const uniqueRequests = sumTotals(eventMetricsData.data, 'unique-dataset-requests-regular');
-  const totalRequests = sumTotals(eventMetricsData.data, 'total-dataset-requests-regular');
+  const uniqueInvestigations = sumTotals(
+    eventMetricsData.data,
+    'unique-dataset-investigations-regular'
+  );
+  const uniqueRequests = sumTotals(
+    eventMetricsData.data,
+    'unique-dataset-requests-regular'
+  );
+  const totalRequests = sumTotals(
+    eventMetricsData.data,
+    'total-dataset-requests-regular'
+  );
 
   const dataSource = [
     {
@@ -85,10 +96,7 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
           </Popover>
         </span>
       ),
-      data:
-        uniqueInvestigations > 0
-          ? uniqueInvestigations
-          : '--',
+      data: uniqueInvestigations > 0 ? uniqueInvestigations : '--',
     },
     {
       key: '2',
@@ -107,8 +115,7 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
           </Popover>
         </span>
       ),
-      data:
-        uniqueRequests > 0 ? uniqueRequests : '--',
+      data: uniqueRequests > 0 ? uniqueRequests : '--',
     },
     {
       key: '3',

--- a/designsafe/apps/api/publications/views.py
+++ b/designsafe/apps/api/publications/views.py
@@ -62,8 +62,9 @@ class PublicationDataCiteEventsView(BaseApiView):
     def get(self, request):
         doi = request.GET.get('doi', '')
         source_id = request.GET.get('source-id', 'datacite-usage')
+        page_size = 1000
 
-        url = f'https://api.datacite.org/events?source-id={source_id}&doi={doi}'
+        url = f'https://api.datacite.org/events?source-id={source_id}&doi={doi}&page[size]={page_size}'
 
         try:
             response = requests.get(url)

--- a/designsafe/apps/api/publications/views.py
+++ b/designsafe/apps/api/publications/views.py
@@ -62,9 +62,8 @@ class PublicationDataCiteEventsView(BaseApiView):
     def get(self, request):
         doi = request.GET.get('doi', '')
         source_id = request.GET.get('source-id', 'datacite-usage')
-        page_size = 1000
 
-        url = f'https://api.datacite.org/events?source-id={source_id}&doi={doi}&page[size]={page_size}'
+        url = f'https://api.datacite.org/events?source-id={source_id}&doi={doi}'
 
         try:
             response = requests.get(url)


### PR DESCRIPTION
## Overview: ##
Update the Usage Breakdown of the Metrics Modal to display the sum of these fields. 
Update the call to datacite to retrieve all records. 
In Metrics Modal, make sure default Year in dropdown is most current year. 

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-2528](https://tacc-main.atlassian.net/browse/DES-2528)

## Summary of Changes: ##
add page_size to the api call to retrieve all records
get the sum of uniqueInv, uniqueReq, and totalReq. (previously, was only grabbing the first occurrence)

## Testing Steps: ##
1. 

## UI Photos:

## Notes: ##
