### PR TITLE
Security: Remediate client-side injection in error pages

### DIFF
--- a/designsafe/templates/403.html
+++ b/designsafe/templates/403.html
@@ -5,7 +5,7 @@
         <h1>You do not have permission to access the requested resource.</h1>
         <p>
             You do not have permission to access the requested resource. If you feel this
-            is in error, please <a href="{% url 'djangoRT:ticketcreate' %}?error_page={{ request.path }}&http_referer={{ request.META.HTTP_REFERER }}">submit a ticket</a>
+            is in error, please <a href="{% url 'djangoRT:ticketcreate' %}?http_referer={{ request.META.HTTP_REFERER }}">submit a ticket</a>
             and we will investigate how to get this resolved.
         </p>
     </div>

--- a/designsafe/templates/404.html
+++ b/designsafe/templates/404.html
@@ -5,7 +5,7 @@
         <h1>The resource you requested isn't here.</h1>
         <p>
             If you followed a link from another DesignSafe-CI page, please
-            <a href="{% url 'djangoRT:ticketcreate' %}?error_page={{ request.path }}&http_referer={{ request.META.HTTP_REFERER }}">submit a ticket</a>
+            <a href="{% url 'djangoRT:ticketcreate' %}?http_referer={{ request.META.HTTP_REFERER }}">submit a ticket</a>
             to let us know so we can get the link corrected! If you followed a link from elsewhere on
             the web, we would also like to know so we can get that link redirected
             properly!

--- a/designsafe/templates/500.html
+++ b/designsafe/templates/500.html
@@ -8,7 +8,7 @@
         </p>
         <p>
             If you continue to receive this error, please
-            <a href="{% url 'djangoRT:ticketcreate' %}?error_page={{ request.path }}&http_referer={{ request.META.HTTP_REFERER }}">submit a ticket</a>.
+            <a href="{% url 'djangoRT:ticketcreate' %}?http_referer={{ request.META.HTTP_REFERER }}">submit a ticket</a>.
         </p>
     </div>
 {% endblock content %}


### PR DESCRIPTION
## Overview: ##
Addresses the following items in the security audit:
1. Client-side template injection
2. Client-side HTTP parameter pollution

These issues were flagged because we were passing `request.path` as a query param to the ticket creation page, so the solution is to remove them and rely on other methods (e.g. splunk) to determine which paths raise exceptions.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Notes: ##
