### PR TITLE
task/DES-2880: add module and placeholder components

### DIFF
--- a/client/modules/reconportal/.babelrc
+++ b/client/modules/reconportal/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "@nx/react/babel",
+      {
+        "runtime": "automatic",
+        "useBuiltIns": "usage"
+      }
+    ]
+  ],
+  "plugins": []
+}

--- a/client/modules/reconportal/.eslintrc.json
+++ b/client/modules/reconportal/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["plugin:@nx/react", "../../.eslintrc.base.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/client/modules/reconportal/README.md
+++ b/client/modules/reconportal/README.md
@@ -1,0 +1,7 @@
+# reconportal
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test reconportal` to execute the unit tests via [Vitest](https://vitest.dev/).

--- a/client/modules/reconportal/project.json
+++ b/client/modules/reconportal/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "reconportal",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "modules/reconportal/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "@nx/vite:test",
+      "outputs": ["{options.reportsDirectory}"],
+      "options": {
+        "reportsDirectory": "../../coverage/modules/reconportal"
+      }
+    }
+  }
+}

--- a/client/modules/reconportal/src/ReconPortal/ReconPortal.module.css
+++ b/client/modules/reconportal/src/ReconPortal/ReconPortal.module.css
@@ -1,0 +1,4 @@
+.root {
+  color: #cc723e;
+  font-size: 16px;
+}

--- a/client/modules/reconportal/src/ReconPortal/ReconPortal.spec.tsx
+++ b/client/modules/reconportal/src/ReconPortal/ReconPortal.spec.tsx
@@ -3,11 +3,9 @@ import { render } from '@client/test-fixtures';
 import { ReconPortal } from './ReconPortal';
 
 describe('ReconPortal', () => {
-
   it('should render successfully', () => {
     const { getByText } = render(<ReconPortal />);
     expect(getByText(/Leaflet/gi)).toBeTruthy();
     expect(getByText(/Placeholder/gi)).toBeTruthy();
-
   });
 });

--- a/client/modules/reconportal/src/ReconPortal/ReconPortal.spec.tsx
+++ b/client/modules/reconportal/src/ReconPortal/ReconPortal.spec.tsx
@@ -1,0 +1,13 @@
+import { render } from '@client/test-fixtures';
+
+import { ReconPortal } from './ReconPortal';
+
+describe('ReconPortal', () => {
+
+  it('should render successfully', () => {
+    const { getByText } = render(<ReconPortal />);
+    expect(getByText(/Leaflet/gi)).toBeTruthy();
+    expect(getByText(/Placeholder/gi)).toBeTruthy();
+
+  });
+});

--- a/client/modules/reconportal/src/ReconPortal/ReconPortal.tsx
+++ b/client/modules/reconportal/src/ReconPortal/ReconPortal.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import styles from './ReconPortal.module.css';
 
 export const ReconPortal: React.FC = () => {
-
   return (
-    <div className={styles.root}>
-      Leaflet + Left-Sided Nav Placeholder
-    </div>
+    <div className={styles.root}>Leaflet + Left-Sided Nav Placeholder</div>
   );
 };

--- a/client/modules/reconportal/src/ReconPortal/ReconPortal.tsx
+++ b/client/modules/reconportal/src/ReconPortal/ReconPortal.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import styles from './ReconPortal.module.css';
+
+export const ReconPortal: React.FC = () => {
+
+  return (
+    <div className={styles.root}>
+      Leaflet + Left-Sided Nav Placeholder
+    </div>
+  );
+};

--- a/client/modules/reconportal/src/ReconPortalHeader/ReconPortalHeader.module.css
+++ b/client/modules/reconportal/src/ReconPortalHeader/ReconPortalHeader.module.css
@@ -1,0 +1,4 @@
+.root {
+  color: #cc443e;
+  font-size: 16px;
+}

--- a/client/modules/reconportal/src/ReconPortalHeader/ReconPortalHeader.spec.tsx
+++ b/client/modules/reconportal/src/ReconPortalHeader/ReconPortalHeader.spec.tsx
@@ -1,0 +1,11 @@
+import { render } from '@client/test-fixtures';
+
+import { ReconPortalHeader } from './ReconPortalHeader';
+
+describe('ReconPortalHeader', () => {
+
+  it('should render successfully', () => {
+    const { getByText } = render(<ReconPortalHeader />);
+    expect(getByText(/Header Placeholder/gi)).toBeTruthy();
+  });
+});

--- a/client/modules/reconportal/src/ReconPortalHeader/ReconPortalHeader.spec.tsx
+++ b/client/modules/reconportal/src/ReconPortalHeader/ReconPortalHeader.spec.tsx
@@ -3,7 +3,6 @@ import { render } from '@client/test-fixtures';
 import { ReconPortalHeader } from './ReconPortalHeader';
 
 describe('ReconPortalHeader', () => {
-
   it('should render successfully', () => {
     const { getByText } = render(<ReconPortalHeader />);
     expect(getByText(/Header Placeholder/gi)).toBeTruthy();

--- a/client/modules/reconportal/src/ReconPortalHeader/ReconPortalHeader.tsx
+++ b/client/modules/reconportal/src/ReconPortalHeader/ReconPortalHeader.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import styles from './ReconPortalHeader.module.css';
+
+export const ReconPortalHeader: React.FC = () => {
+
+  return (
+    <div className={styles.root}>
+      Header Placeholder
+    </div>
+  );
+};

--- a/client/modules/reconportal/src/ReconPortalHeader/ReconPortalHeader.tsx
+++ b/client/modules/reconportal/src/ReconPortalHeader/ReconPortalHeader.tsx
@@ -2,10 +2,5 @@ import React from 'react';
 import styles from './ReconPortalHeader.module.css';
 
 export const ReconPortalHeader: React.FC = () => {
-
-  return (
-    <div className={styles.root}>
-      Header Placeholder
-    </div>
-  );
+  return <div className={styles.root}>Header Placeholder</div>;
 };

--- a/client/modules/reconportal/src/index.ts
+++ b/client/modules/reconportal/src/index.ts
@@ -1,0 +1,2 @@
+export * from './ReconPortal/ReconPortal';
+export * from './ReconPortalHeader/ReconPortalHeader';

--- a/client/modules/reconportal/tsconfig.json
+++ b/client/modules/reconportal/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json"
+}

--- a/client/modules/reconportal/tsconfig.lib.json
+++ b/client/modules/reconportal/tsconfig.lib.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": [
+      "node",
+
+      "@nx/react/typings/cssmodule.d.ts",
+      "@nx/react/typings/image.d.ts"
+    ]
+  },
+  "exclude": [
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.spec.tsx",
+    "**/*.test.tsx",
+    "**/*.spec.js",
+    "**/*.test.js",
+    "**/*.spec.jsx",
+    "**/*.test.jsx"
+  ],
+  "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
+}

--- a/client/modules/reconportal/tsconfig.spec.json
+++ b/client/modules/reconportal/tsconfig.spec.json
@@ -1,0 +1,26 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ]
+  },
+  "include": [
+    "vite.config.ts",
+    "vitest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/client/modules/reconportal/vite.config.ts
+++ b/client/modules/reconportal/vite.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+export default defineConfig({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/modules/reconportal',
+
+  plugins: [react(), nxViteTsPaths()],
+
+  // Uncomment this if you are using workers.
+  // worker: {
+  //  plugins: [ nxViteTsPaths() ],
+  // },
+
+  test: {
+    globals: true,
+    cache: { dir: '../../node_modules/.vitest' },
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../../coverage/modules/reconportal',
+      provider: 'v8',
+    },
+  },
+});

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,6 +5,7 @@ import { RouterProvider } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import workspaceRouter from './workspace/workspaceRouter';
 import datafilesRouter from './datafiles/datafilesRouter';
+import reconportalRouter from './reconportal/reconportalRouter';
 import { ConfigProvider, ThemeConfig } from 'antd';
 
 const queryClient = new QueryClient();
@@ -81,7 +82,7 @@ if (rapidElement) {
     <StrictMode>
       <QueryClientProvider client={queryClient}>
         <ConfigProvider theme={themeConfig}>
-          <div>Recon Portal base element rendered by React</div>
+          <RouterProvider router={reconportalRouter} />
         </ConfigProvider>
       </QueryClientProvider>
     </StrictMode>

--- a/client/src/reconportal/layouts/ReconPortalBaseLayout.tsx
+++ b/client/src/reconportal/layouts/ReconPortalBaseLayout.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Layout } from 'antd';
+import {
+  ReconPortal,
+  ReconPortalHeader,
+} from '@client/reconportal';
+
+
+const ReconPortalBaseLayout: React.FC = () => {
+
+  return (
+      <Layout>
+        <ReconPortalHeader/>
+        <ReconPortal/>
+      </Layout>
+  );
+};
+
+export default ReconPortalBaseLayout;

--- a/client/src/reconportal/layouts/ReconPortalBaseLayout.tsx
+++ b/client/src/reconportal/layouts/ReconPortalBaseLayout.tsx
@@ -1,18 +1,13 @@
 import React from 'react';
 import { Layout } from 'antd';
-import {
-  ReconPortal,
-  ReconPortalHeader,
-} from '@client/reconportal';
-
+import { ReconPortal, ReconPortalHeader } from '@client/reconportal';
 
 const ReconPortalBaseLayout: React.FC = () => {
-
   return (
-      <Layout>
-        <ReconPortalHeader/>
-        <ReconPortal/>
-      </Layout>
+    <Layout>
+      <ReconPortalHeader />
+      <ReconPortal />
+    </Layout>
   );
 };
 

--- a/client/src/reconportal/reconportalRouter.tsx
+++ b/client/src/reconportal/reconportalRouter.tsx
@@ -1,0 +1,21 @@
+import { createBrowserRouter, Navigate } from 'react-router-dom';
+import  ReconPortalBaseLayout  from './layouts/ReconPortalBaseLayout';
+
+const reconportalRouter = createBrowserRouter(
+  [
+    {
+      id: 'root',
+      path: '/',
+      element: <ReconPortalBaseLayout />,
+      children: [
+        {
+          path: '*',
+          element: <Navigate to={'/'} replace={true} />,
+        },
+      ],
+    },
+  ],
+  { basename: '/recon-portal' }
+);
+
+export default reconportalRouter;

--- a/client/src/reconportal/reconportalRouter.tsx
+++ b/client/src/reconportal/reconportalRouter.tsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
-import  ReconPortalBaseLayout  from './layouts/ReconPortalBaseLayout';
+import ReconPortalBaseLayout from './layouts/ReconPortalBaseLayout';
 
 const reconportalRouter = createBrowserRouter(
   [

--- a/client/tsconfig.base.json
+++ b/client/tsconfig.base.json
@@ -18,6 +18,7 @@
       "@client/common-components": ["modules/_common_components/src/index.ts"],
       "@client/datafiles": ["modules/datafiles/src/index.ts"],
       "@client/hooks": ["modules/_hooks/src/index.ts"],
+      "@client/reconportal": ["modules/reconportal/src/index.ts"],
       "@client/test-fixtures": ["modules/_test-fixtures/src/index.ts"],
       "@client/workspace": ["modules/workspace/src/index.ts"]
     }


### PR DESCRIPTION
## Overview: ##

Add reactoportal react library with placeholder components.  This is to just illustrate where we should put things to follow the pattern that already exists in DesignSafe.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DES-2880](https://tacc-main.atlassian.net/browse/DES-2880)

## Testing Steps: ##
0. See discussion on slack https://tacc-team.slack.com/archives/C07168Y3XGS/p1721769585646989?thread_ts=1721769343.928439&cid=C07168Y3XGS
1. Run and see that its there at /recon-portal 

## UI Photos:
<img width="460" alt="Screenshot 2024-07-23 at 4 51 21 PM" src="https://github.com/user-attachments/assets/3dc0c9a7-178b-4120-8661-2d6fb216e5cf">

