### PR TITLE
enhance: DES-3046 highlight other flag of app card

### DIFF
--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_card.html
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_card.html
@@ -15,11 +15,11 @@
 
     <ul class="c-app-card__flags">
         {% if app.is_popular %}
-        <li><strong>Popular</strong></li>
+        <li class="is-popular"><strong>Popular</strong></li>
         {% endif %}
 
         {% if not app.is_popular and app.is_simcenter %}
-        <li>SimCenter</li>
+        <li class="is-simcenter"><strong>SimCenter</strong></li>
         {% endif %}
 
 

--- a/designsafe/static/styles/app-card.css
+++ b/designsafe/static/styles/app-card.css
@@ -94,8 +94,11 @@ a.c-app-card:active {
 .c-app-card__flags {
     font-size: 1.2rem;
 }
-.c-app-card__flags > *:has(strong) {
+.c-app-card__flags > .is-popular {
     background-color: #ECE4BF;
+}
+.c-app-card__flags > .is-simcenter {
+    background-color: #AFD9EE;
 }
 
 .c-app-card__repo {

--- a/designsafe/static/styles/app-card.css
+++ b/designsafe/static/styles/app-card.css
@@ -98,7 +98,7 @@ a.c-app-card:active {
     background-color: #ECE4BF;
 }
 .c-app-card__flags > .is-simcenter {
-    background-color: #AFD9EE;
+    background-color: #d9edf7;
 }
 
 .c-app-card__repo {


### PR DESCRIPTION
## Overview

Highlight "SimCenter" flag on App Card.

## Status

* [x] Ready

<sup>Snippets — used on [prod](https://www.designsafe-ci.org/admin/djangocms_snippet/snippet/18/change) and [next](https://designsafeci-next.tacc.utexas.edu/admin/djangocms_snippet/snippet/18/change/) — are temporary because they rely on old markup.<sup>

## Related

* [DES-3046](https://tacc-main.atlassian.net/browse/DES-3046)

## Changes

- **changed** how markup distinguishes Popular vs. SimCenter
- **added** styles for SimCenter

## Testing
1. Load `/use-designsafe/tools-applications/` ([prod](https://www.designsafe-ci.org/use-designsafe/tools-applications/), [next](https://designsafeci-next.tacc.utexas.edu/use-designsafe/tools-applications/)).
2. Verify app that `is_popular` has **yellow** flag.
3. Verify app that `is_simcenter` has **light blue** flag.

## UI

### Testing Results

| SimCenter | Popular |
| - | - |
| <img width="1194" alt="simcenter" src="https://github.com/user-attachments/assets/73806eae-d162-4fdd-a3a7-b70dfd0a0a50"> | <img width="1194" alt="popular" src="https://github.com/user-attachments/assets/3ee9f201-9e96-46e3-af74-09f8846db417"> |

The blue will be lighter than this test, cuz 3f77e63 changes the color.

### Color Ideas

| `light-2x` | `light-3x` |
| - | - |
| <img width="1194" alt="DS Card SimCenter Highlight - light-2x" src="https://github.com/user-attachments/assets/7a9b1bb4-2fba-4fb3-8fc0-44e63807f604"> | <img width="1194" alt="DS Card SimCenter Highlight - light-3x" src="https://github.com/user-attachments/assets/60396915-a6b7-4dc5-8e7c-68b2d98a0500"> |

I'd prefer something in between, but these are existing palette colors.