### PR TITLE
Quick: Fix move/copy buttons in preview modal

### DIFF
--- a/client/modules/datafiles/src/DatafilesModal/PreviewModal/PreviewModal.tsx
+++ b/client/modules/datafiles/src/DatafilesModal/PreviewModal/PreviewModal.tsx
@@ -1,6 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import {
   TFileListing,
+  useAuthenticatedUser,
   useFileListingRouteParams,
   useFilePreview,
 } from '@client/hooks';
@@ -44,6 +45,13 @@ export const PreviewModalBody: React.FC<{
     handleCancel();
   }, [handleCancel, queryClient]);
 
+  const { user } = useAuthenticatedUser();
+  const isReadOnly = [
+    'designsafe.storage.published',
+    'designsafe.storage.community',
+    'nees.public',
+  ].includes(selectedFile.system);
+
   if (!isOpen) return null;
 
   return (
@@ -72,7 +80,7 @@ export const PreviewModalBody: React.FC<{
       >
         {!selectedFile.path.endsWith('.hazmapper') && (
           <>
-            {scheme === 'private' && api === 'tapis' && (
+            {!isReadOnly && api === 'tapis' && (
               <MoveModal
                 api={api}
                 system={selectedFile.system}
@@ -89,19 +97,21 @@ export const PreviewModalBody: React.FC<{
               </MoveModal>
             )}
 
-            <CopyModal
-              api={api}
-              system={selectedFile.system}
-              path={listingPath}
-              selectedFiles={[selectedFile]}
-            >
-              {({ onClick }) => (
-                <Button onClick={onClick}>
-                  <i role="none" className="fa fa-copy" />
-                  <span>&nbsp;Copy</span>
-                </Button>
-              )}
-            </CopyModal>
+            {user && (
+              <CopyModal
+                api={api}
+                system={selectedFile.system}
+                path={listingPath}
+                selectedFiles={[selectedFile]}
+              >
+                {({ onClick }) => (
+                  <Button onClick={onClick}>
+                    <i role="none" className="fa fa-copy" />
+                    <span>&nbsp;Copy</span>
+                  </Button>
+                )}
+              </CopyModal>
+            )}
             <DownloadModal
               api={api}
               system={selectedFile.system}


### PR DESCRIPTION
## Overview: ##
Hide the move and copy buttons in the preview modal when the user does not have permission for these operations.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-XXXX](https://tacc-main.atlassian.net/browse/DES-XXXX)

## Summary of Changes: ##

## Testing Steps: ##
1. Check when previewing a file in a publication or NEES archive, the Move button is not displayed
2. Check that when previewing a file while logged out, the Copy button is not displayed.
