### PR TITLE
Quick: Maintenance toggle with staff bypass

### DIFF
--- a/designsafe/middleware.py
+++ b/designsafe/middleware.py
@@ -17,6 +17,7 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.deprecation import MiddlewareMixin
 from designsafe.apps.notifications.models import SiteMessage
+from designsafe.apps.api.utils import get_client_ip
 
 logger = logging.getLogger(__name__)
 
@@ -82,11 +83,12 @@ class MaintenanceMiddleware:
         # Code to be executed for each request before
         # the view (and later middleware) are called.
         show_maintenance = getattr(settings, "DJANGO_MAINTENANCE", False)
+        client_ip = get_client_ip(request)
         if not show_maintenance:
             return self.get_response(request)
 
-        # Allow access behind the maint page for staff members
-        if getattr(request.user, "is_staff"):
+        # Allow access behind the maint page for staff members or behind TACC VPN
+        if getattr(request.user, "is_staff") or client_ip.startswith("129.114"):
             return self.get_response(request)
 
         # Non-staff users see the maint page instead of the page they requested

--- a/designsafe/middleware.py
+++ b/designsafe/middleware.py
@@ -89,9 +89,9 @@ class MaintenanceMiddleware:
         if getattr(request.user, "is_staff"):
             return self.get_response(request)
 
-        if show_maintenance:
-            if not request.path.startswith('/static'):
-                return render(request, 'maintenance.html')
+        # Non-staff users see the maint page instead of the page they requested
+        if not request.path.startswith('/static'):
+            return render(request, 'maintenance.html')
 
         return self.get_response(request)
 

--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -36,6 +36,7 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get('DJANGO_DEBUG', 'False') == 'True'
+DJANGO_MAINTENANCE = os.environ.get("DJANGO_MAINTENANCE", 'False') == 'True'
 RENDER_REACT = os.environ.get('RENDER_REACT', 'False') == 'True'
 
 ALLOWED_HOSTS = ['*']
@@ -152,6 +153,7 @@ MIDDLEWARE = (
     'designsafe.middleware.DesignSafeTermsMiddleware',
     'designsafe.middleware.DesignsafeProfileUpdateMiddleware',
     'designsafe.middleware.SiteMessageMiddleware',
+    'designsafe.middleware.MaintenanceMiddleware'
 )
 
 ROOT_URLCONF = 'designsafe.urls'

--- a/designsafe/templates/maintenance.html
+++ b/designsafe/templates/maintenance.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block title %}Maintenance{% endblock %}
+{% block content %}
+<div class="container">
+    <!-- Jumbotron -->
+    <div class="jumbotron">
+        <div class="text-center">
+            <img src="/static/images/ds-logo-horiz.png" alt="DesignSafe-CI: Temporarily Unavailable">
+        </div>
+        <p class="lead">
+            DesignSafe-CI is temporarily unavailable due to maintenance.
+            We apologize for the inconvenience. Please try again later.
+        </p>
+        <a href="javascript:document.location.reload(true);" class="btn btn-default btn-lg text-center"><span
+                class="green">Try This Page Again</span></a>
+    </div>
+</div>
+{% endblock content %}


### PR DESCRIPTION
## Overview: ##
Allows toggling a maintenance page via the `DJANGO_MAINTENANCE` flag in designsafe.env. users who are already authenticated with staff-level permissions will be able to view pages behind the maintenance wall.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Summary of Changes: ##

## Testing Steps: ##
1. Temporarily set `DJANGO_MAINTENANCE = True` in common_settings.py
2. Confirm that maintenance page displays only when not authenticated as a staff-level user.

## UI Photos:
<img width="1169" alt="image" src="https://github.com/user-attachments/assets/04a600a5-98b9-4ba2-85b5-b8026ddef2ea">


## Notes: ##
