### PR TITLE
Quick: Log DOIs when downloading project archives

### DIFF
--- a/client/modules/datafiles/src/publications/modals/DownloadDatasetModal.tsx
+++ b/client/modules/datafiles/src/publications/modals/DownloadDatasetModal.tsx
@@ -1,7 +1,11 @@
 import React, { useMemo, useState } from 'react';
 import { Alert, Button, Modal, Spin } from 'antd';
 import DatafilesModal from '../../DatafilesModal/DatafilesModal';
-import { useFileDetail, usePublicationVersions } from '@client/hooks';
+import {
+  useFileDetail,
+  usePublicationDetail,
+  usePublicationVersions,
+} from '@client/hooks';
 import { toBytes } from '@client/common-components';
 
 const gnuGeneralLicenseInfo = (
@@ -219,6 +223,11 @@ export const DownloadDatasetModal: React.FC<{
   };
 
   const { selectedVersion } = usePublicationVersions(projectId);
+  const { data: publicationData } = usePublicationDetail(projectId);
+  const doiString = publicationData?.tree.children
+    .map((c) => c.value.dois?.[0])
+    .filter((doi) => !!doi)
+    .join(',');
 
   const archivePath =
     selectedVersion > 1
@@ -311,7 +320,7 @@ export const DownloadDatasetModal: React.FC<{
                 api="tapis"
                 system="designsafe.storage.published"
                 scheme="public"
-                selectedFiles={[data]}
+                selectedFiles={[{ ...data, doi: doiString }]}
               >
                 {({ onClick }) => (
                   <Button


### PR DESCRIPTION
## Overview: ##
Log DOIs when downloading the archive of a project. If there are multiple DOIs, they will be formatted as a comma-separated list.

Sample log: 

```
des_django         | [METRICS] INFO views metrics.put:82: Data Depot user=jarosenb ip=172.19.0.1 agent=Mozilla/5.0 
(Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 
sessionId=h31uiskvoqy411zwd7bkzk16ga0zq1wb op=download info={'api': 'tapis', 'scheme': 'public', 'system':
'designsafe.storage.published', 'path': '/', 'body': {'paths': ['/archives/PRJ-3242_archive.zip']}, 'doi': '10.17603/ds2-x8rr-
yw04,10.17603/ds2-kzmf-ta46,10.17603/ds2-sa8v-0a73,10.17603/ds2-503c-ye80'}
```
