### PR TITLE
Quick: List all app versions

### DIFF
--- a/designsafe/apps/workspace/api/views.py
+++ b/designsafe/apps/workspace/api/views.py
@@ -321,7 +321,7 @@ class AppsTrayView(AuthenticatedApiView):
         tapis = user.tapis_oauth.client
         apps_listing = tapis.apps.getApps(
             select="version,id,notes",
-            search="(enabled.eq.true)",
+            search="(enabled.eq.true)~(version.like.*)",
             listType="MINE",
             limit=-1,
         )
@@ -352,7 +352,7 @@ class AppsTrayView(AuthenticatedApiView):
         tapis = user.tapis_oauth.client
         apps_listing = tapis.apps.getApps(
             select="version,id,notes",
-            search="(enabled.eq.true)",
+            search="(enabled.eq.true)~(version.like.*)",
             listType="SHARED_PUBLIC",
             limit=-1,
         )


### PR DESCRIPTION
## Overview: ##

Retrieve all available active app versions from Tapis. This allows the portal to specify old versions to show in the workspace instead of being limited to the latest version.

## PR Status: ##

* [X] Ready.
