### PR TITLE
enhance: update maintenance page logo

### DIFF
--- a/conf/nginx/error.html
+++ b/conf/nginx/error.html
@@ -57,13 +57,13 @@
     <!-- Jumbotron -->
     <div class="jumbotron">
         <div class="text-center">
-            <img src="/static/images/ds-logo-horiz.png" alt="DesignSafe-CI Temporarily Unavailable">
+            <img src="/static/images/org_logos/NSF_NHERI-DS.svg" alt="DesignSafe-CI Temporarily Unavailable">
+            <p class="lead">
+                DesignSafe-CI is temporarily unavailable due to maintenance.
+                We apologize for the inconvenience. Please try again later.
+            </p>
+            <a href="javascript:document.location.reload(true);" class="btn btn-default btn-lg text-center">Try This Page Again</a>
         </div>
-        <p class="lead">
-            DesignSafe-CI is temporarily unavailable due to maintenance.
-            We apologize for the inconvenience. Please try again later.
-        </p>
-        <a href="javascript:document.location.reload(true);" class="btn btn-default btn-lg text-center"><span class="green">Try This Page Again</span></a>
     </div>
 </div>
 <!-- End Error Page Content -->

--- a/conf/nginx/error.html
+++ b/conf/nginx/error.html
@@ -40,7 +40,6 @@
             padding: 14px 24px;
         }
         /* Colors */
-        .green {color:#5cb85c;}
         .orange {color:#f0ad4e;}
         .red {color:#d9534f;}
     </style>

--- a/conf/nginx/error.html
+++ b/conf/nginx/error.html
@@ -59,7 +59,7 @@
         <div class="text-center">
             <img src="/static/images/org_logos/NSF_NHERI-DS.svg" alt="DesignSafe-CI Temporarily Unavailable">
         </div>
-        <p>
+        <p class="lead">
             DesignSafe-CI is temporarily unavailable due to maintenance.
             We apologize for the inconvenience. Please try again later.
         </p>

--- a/conf/nginx/error.html
+++ b/conf/nginx/error.html
@@ -58,12 +58,12 @@
     <div class="jumbotron">
         <div class="text-center">
             <img src="/static/images/org_logos/NSF_NHERI-DS.svg" alt="DesignSafe-CI Temporarily Unavailable">
-            <p class="lead">
-                DesignSafe-CI is temporarily unavailable due to maintenance.
-                We apologize for the inconvenience. Please try again later.
-            </p>
-            <a href="javascript:document.location.reload(true);" class="btn btn-default btn-lg text-center">Try This Page Again</a>
         </div>
+        <p>
+            DesignSafe-CI is temporarily unavailable due to maintenance.
+            We apologize for the inconvenience. Please try again later.
+        </p>
+        <a href="javascript:document.location.reload(true);" class="btn btn-default btn-lg text-center">Try This Page Again</a>
     </div>
 </div>
 <!-- End Error Page Content -->

--- a/designsafe/static/scripts/geo/html/map.html
+++ b/designsafe/static/scripts/geo/html/map.html
@@ -3,7 +3,7 @@
 <!-- <ul class="list-group">
   <li class="list-group-item menu" style="background:#eaeaea;margin-top:0px">
     <a href="/">
-      <img src="/static/images/ds-logo-horiz.png" width="180"></img>
+      <img src="/static/images/org_logos/NSF_NHERI-DS.svg" width="180"></img>
     </a>
   </li>
 </ul> -->


### PR DESCRIPTION
## Overview

Update maintenance page logo to new NSF+NHERI+DesignSafe one.

## Status

* [X] Ready.

## Related

* similar to like [DES-3012](https://tacc-main.atlassian.net/browse/DES-3012), [DES-2883](https://tacc-main.atlassian.net/browse/DES-2883), [DES-2824](https://tacc-main.atlassian.net/browse/DES-2824)

## Changes

maintenance page:
- **changed** url of logo
- **deleted** ineffectual markup and class

some other page:
- **changed** url of commented code to old logo

## Testing

1. Open maintenance page.
2. Verify logo has NSF and NHERI.

## UI

| before | after |
| - | - |
| <img width="1280" alt="before" src="https://github.com/user-attachments/assets/58261782-dce9-4551-a7f4-773381d27f4b"> | <img width="1280" alt="after" src="https://github.com/user-attachments/assets/2e2695e1-332c-4854-8111-6cc844564cbe"> |