### PR TITLE
Bug: Use Zod.refine for regex fields

### DIFF
--- a/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
+++ b/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
@@ -358,9 +358,11 @@ const FormSchema = (
         if (param.notes?.validator?.regex && param.notes?.validator?.message) {
           try {
             const regex = RegExp(param.notes.validator.regex);
-            parameterSetSchema[field.label] = (<z.ZodString>(
-              parameterSetSchema[field.label]
-            )).regex(regex, param.notes.validator.message);
+            parameterSetSchema[field.label] = parameterSetSchema[
+              field.label
+            ].refine((value) => regex.test(value), {
+              message: param.notes.validator.message,
+            });
           } catch (SyntaxError) {
             console.warn('Invalid regex pattern for app');
           }


### PR DESCRIPTION
## Overview: ##
regex parsing for fields is broken in app form.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

[WP-650](https://tacc-main.atlassian.net/browse/WP-650)

## Summary of Changes: ##
* Use Zod#Refine instead chained .regex for existing ZodEffects.

## Testing Steps: ##
For these two apps, test the following: 
https://designsafe.dev/rw/workspace/compress
https://designsafe.dev/rw/workspace/ls-dyna-stampede3?appVersion=2024R1

1. Open dev console.
2. Load the app, ensure there is app related info messages in dev tools console.
3. For compress, put a name for Archive (second step in form) which contains invalid characters like `&`
4. Similarly, for ls-dyna, in the second step, put a invalid name like test.pdf
5. Also use valid inputs and check if error message goes away in the form.

## UI Photos:

## Notes: ##
