### PR TITLE
task/WP-647: Remove portal name filter for jobs by default

### DIFF
--- a/designsafe/apps/api/projects_v2/operations/project_system_operations.py
+++ b/designsafe/apps/api/projects_v2/operations/project_system_operations.py
@@ -72,7 +72,7 @@ def submit_workspace_acls_job(
         "name": f"setfacl-project-{project_uuid.split('-')[0]}-{username}-{action}",
         "appId": "setfacl-corral-tg458981",
         "appVersion": "0.0.1",
-        "description": "test app setfacl-corral-tg458981",
+        "description": "Add/Remove ACLs on a directory",
         "fileInputs": [],
         "parameterSet": {
             "appArgs": [],


### PR DESCRIPTION
## Overview: ##

- Remove `portalName` filter in jobs listings by default to show all jobs for that user on the tenant.
- Unrelated: change the description of the setfacl job to no longer include "test"

## PR Status: ##

* [X] Ready.
## Related Jira tickets: ##

* [WP-647](https://tacc-main.atlassian.net/browse/WP-647)

## Testing Steps: ##
1. Submit a job from the command line / tapipy with no "portalName" tag. Alternatively, edit the workspace api code to not append the portalName tag upon job submission.
2. Go to the job listing page and confirm you see your job: https://designsafe.dev/rw/workspace/history
