### PR TITLE
task/WA-324-order-by-simcenter

### DIFF
--- a/designsafe/apps/workspace/models/app_entries.py
+++ b/designsafe/apps/workspace/models/app_entries.py
@@ -152,7 +152,7 @@ class AppListingEntry(models.Model):
             )
         ]
 
-        ordering = ["-is_popular", Lower("label")]
+        ordering = ["-is_popular", "-is_simcenter", Lower("label")]
 
 
 class AppVariant(models.Model):


### PR DESCRIPTION
## Overview: ##
The goal is to list SimCenter apps alphabetically after the Popular Apps under Simulation.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WA-324](https://tacc-main.atlassian.net/browse/WA-324)

## Summary of Changes: ##
Changed the meta class of the apps model class to order by is_simcenter, after all the is_popular apps have been listed.

## Testing Steps: ##
1. Go to https://designsafe.dev/use-designsafe/tools-applications/
2. Make sure that apps are listed alphabetically, first listing the popular apps, and then the simcenter apps, then all other apps.
3. SimCenter apps should only appear under simulation.

## UI Photos:

## Notes: ##
