### PR TITLE
enhance: WA-325 show disabled app variants in CMS

### DIFF
--- a/designsafe/apps/workspace/cms_plugins.py
+++ b/designsafe/apps/workspace/cms_plugins.py
@@ -41,7 +41,7 @@ class AppCategoryListing(CMSPluginBase):
                     "Open Source" if entry.license_type == "OS" else "Licensed"
                 ),
                 "href": entry.href,
-                "id": entry.app_id,
+                "version": entry.version,
             }
             for entry in listing_entries
         ]

--- a/designsafe/apps/workspace/cms_plugins.py
+++ b/designsafe/apps/workspace/cms_plugins.py
@@ -99,17 +99,7 @@ class AppVariants(CMSPluginBase):
     def render(self, context, instance: AppListingEntry, placeholder):
         context = super().render(context, instance, placeholder)
         app_variants = instance.app.appvariant_set.filter()
-        serialized_variants = [
-            {
-                "label": variant.label,
-                "version": variant.version,
-                "description": variant.description,
-                "is_enabled": variant.enabled,
-                "href": variant.href,
-            }
-            for variant in app_variants
-        ]
-        context["listing"] = serialized_variants
+        context["listing"] = app_variants
 
         return context
 

--- a/designsafe/apps/workspace/cms_plugins.py
+++ b/designsafe/apps/workspace/cms_plugins.py
@@ -41,7 +41,6 @@ class AppCategoryListing(CMSPluginBase):
                     "Open Source" if entry.license_type == "OS" else "Licensed"
                 ),
                 "href": entry.href,
-                "version": entry.version,
             }
             for entry in listing_entries
         ]
@@ -100,7 +99,17 @@ class AppVariants(CMSPluginBase):
     def render(self, context, instance: AppListingEntry, placeholder):
         context = super().render(context, instance, placeholder)
         app_variants = instance.app.appvariant_set.filter(enabled=True)
-        context["listing"] = app_variants
+        serialized_variants = [
+            {
+                "label": variant.label,
+                "version": variant.version,
+                "description": variant.description,
+                "is_comingsoon": variant.version.endswith("coming-soon"),
+                "href": variant.href,
+            }
+            for variant in app_variants
+        ]
+        context["listing"] = serialized_variants
 
         return context
 

--- a/designsafe/apps/workspace/cms_plugins.py
+++ b/designsafe/apps/workspace/cms_plugins.py
@@ -41,6 +41,7 @@ class AppCategoryListing(CMSPluginBase):
                     "Open Source" if entry.license_type == "OS" else "Licensed"
                 ),
                 "href": entry.href,
+                "id": entry.app_id,
             }
             for entry in listing_entries
         ]

--- a/designsafe/apps/workspace/cms_plugins.py
+++ b/designsafe/apps/workspace/cms_plugins.py
@@ -98,13 +98,13 @@ class AppVariants(CMSPluginBase):
 
     def render(self, context, instance: AppListingEntry, placeholder):
         context = super().render(context, instance, placeholder)
-        app_variants = instance.app.appvariant_set.filter(enabled=True)
+        app_variants = instance.app.appvariant_set.filter()
         serialized_variants = [
             {
                 "label": variant.label,
                 "version": variant.version,
                 "description": variant.description,
-                "is_comingsoon": variant.version.endswith("coming-soon"),
+                "is_enabled": variant.enabled,
                 "href": variant.href,
             }
             for variant in app_variants

--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin.html
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin.html
@@ -1,5 +1,5 @@
 {% if listing|length == 1 %}
-<section class="s-app-version-list">
+<section class="s-app-version-list" id="{{listing.0.id}}">
     <h2>Already know everything?</h2>
     {% for variant in listing %}
     <a class="btn btn-success" href="{{variant.href}}">Get Started</a>
@@ -9,7 +9,7 @@
 <section class="s-app-version-list">
     <h2>Select a Version</h2>
     {% for variant in listing %}
-    <article>
+    <article id="{{variant.id}}">
         <h3>{{variant.label}}</h3>
         <a class="btn btn-success" href="{{variant.href}}">Get Started</a>
         <p>{{variant.description}}</p>

--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin.html
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin.html
@@ -2,13 +2,7 @@
 <section class="s-app-version-list" id="{{listing.0.version}}">
     <h2>Already know everything?</h2>
     {% for variant in listing %}
-    <a class="btn btn-success" href="{{variant.href}}">
-        {% if ... %}
-            Coming Soon
-        {% else %}
-            Get Started
-        {% endif %}
-    </a>
+    {% include 'designsafe/apps/workspace/app_variant_plugin_button.html' %}
     {% endfor %}
 </section>
 {% else %}
@@ -17,13 +11,7 @@
     {% for variant in listing %}
     <article id="{{variant.version}}">
         <h3>{{variant.label}}</h3>
-        <a class="btn btn-success" href="{{variant.href}}">
-            {% if ... %}
-                Coming Soon
-            {% else %}
-                Get Started
-            {% endif %}
-        </a>
+        {% include 'designsafe/apps/workspace/app_variant_plugin_button.html' %}
         <p>{{variant.description}}</p>
     </article>
     {% endfor %}

--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin.html
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin.html
@@ -1,5 +1,5 @@
 {% if listing|length == 1 %}
-<section class="s-app-version-list" id="{{listing.0.version}}">
+<section class="s-app-version-list" id="app-var-{{listing.0.id}}-v{{listing.0.version}}">
     <h2>Already know everything?</h2>
     {% for variant in listing %}
     {% include 'designsafe/apps/workspace/app_variant_plugin_button.html' %}
@@ -9,7 +9,7 @@
 <section class="s-app-version-list">
     <h2>Select a Version</h2>
     {% for variant in listing %}
-    <article id="{{variant.version}}">
+    <article id="app-var-{{variant.id}}-v{{variant.version}}">
         <h3>{{variant.label}}</h3>
         {% include 'designsafe/apps/workspace/app_variant_plugin_button.html' %}
         <p>{{variant.description}}</p>

--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin.html
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin.html
@@ -2,7 +2,13 @@
 <section class="s-app-version-list" id="{{listing.0.version}}">
     <h2>Already know everything?</h2>
     {% for variant in listing %}
-    <a class="btn btn-success" href="{{variant.href}}">Get Started</a>
+    <a class="btn btn-success" href="{{variant.href}}">
+        {% if ... %}
+            Coming Soon
+        {% else %}
+            Get Started
+        {% endif %}
+    </a>
     {% endfor %}
 </section>
 {% else %}
@@ -11,7 +17,13 @@
     {% for variant in listing %}
     <article id="{{variant.version}}">
         <h3>{{variant.label}}</h3>
-        <a class="btn btn-success" href="{{variant.href}}">Get Started</a>
+        <a class="btn btn-success" href="{{variant.href}}">
+            {% if ... %}
+                Coming Soon
+            {% else %}
+                Get Started
+            {% endif %}
+        </a>
         <p>{{variant.description}}</p>
     </article>
     {% endfor %}

--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin.html
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin.html
@@ -1,5 +1,5 @@
 {% if listing|length == 1 %}
-<section class="s-app-version-list" id="{{listing.0.id}}">
+<section class="s-app-version-list" id="{{listing.0.version}}">
     <h2>Already know everything?</h2>
     {% for variant in listing %}
     <a class="btn btn-success" href="{{variant.href}}">Get Started</a>
@@ -9,7 +9,7 @@
 <section class="s-app-version-list">
     <h2>Select a Version</h2>
     {% for variant in listing %}
-    <article id="{{variant.id}}">
+    <article id="{{variant.version}}">
         <h3>{{variant.label}}</h3>
         <a class="btn btn-success" href="{{variant.href}}">Get Started</a>
         <p>{{variant.description}}</p>

--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin_button.html
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin_button.html
@@ -1,6 +1,6 @@
 {# @var variant #}
 
-        {% if variant.is_comingsoon %}
+        {% if variant.enabled %}
         <a class="btn btn-secondary disabled" href="{{variant.href}}">
             Unavailable
         </a>

--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin_button.html
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin_button.html
@@ -2,7 +2,7 @@
 
         {% if variant.is_comingsoon %}
         <a class="btn btn-secondary disabled" href="{{variant.href}}">
-            Coming Soon
+            Unavailable
         </a>
         {% else %}
         <a class="btn btn-success" href="{{variant.href}}">

--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin_button.html
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin_button.html
@@ -1,0 +1,11 @@
+{# @var variant #}
+
+        {% if variant.is_comingsoon %}
+        <a class="btn btn-secondary disabled" href="{{variant.href}}">
+            Coming Soon
+        </a>
+        {% else %}
+        <a class="btn btn-success" href="{{variant.href}}">
+            Get Started
+        </a>
+        {% endif %}

--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin_button.html
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin_button.html
@@ -1,11 +1,11 @@
 {# @var variant #}
 
         {% if variant.enabled %}
-        <a class="btn btn-secondary disabled" href="{{variant.href}}">
-            Unavailable
-        </a>
-        {% else %}
         <a class="btn btn-success" href="{{variant.href}}">
             Get Started
+        </a>
+        {% else %}
+        <a class="btn btn-secondary disabled" href="{{variant.href}}">
+            Unavailable
         </a>
         {% endif %}

--- a/designsafe/static/styles/app-version-list.css
+++ b/designsafe/static/styles/app-version-list.css
@@ -67,5 +67,6 @@
 
 /* Bootstrap */
 .s-app-version-list .btn {
+    min-width: 18ch;
     padding-inline: 24px; /* double Bootstrap .btn padding */
 }


### PR DESCRIPTION
## Overview / Changes: ##

- Show disabled apps with disabled "Unavailable" button.
- Try to render app variant buttons at same width.
- <details><summary>Add app variant `version` in HTML `id` attr.</summary>

    This lets JavaScript or CSS change specific buttons, e.g. make on read "Coming Soon".

    </details>

## PR Status: ##

* [X] Ready.
* Work in Progress.
* Hold.

## Related Jira tickets: ##

* [WA-325](https://tacc-main.atlassian.net/browse/WA-325)
* same template as #1396

## Summary of Changes: ##

- **added** property to template context
- **added** attribute to app variant in template

## Testing Steps: ##

1. Create/Have a CMS page that lists at least two app variants.
2. Uncheck "Enabled" on one variant.
3. Load the page.
4. **Verify** the disabled variant has disabled "Unavailable" button.
5. **Verify** each variant has unique `id` attribute.

## UI Photos:

| 4. setting | 4. render |
| - | - |
| <img width="392" alt="setting" src="https://github.com/user-attachments/assets/b582f29f-b1de-461d-8178-eaa911a783cc"> | <img width="392" alt="render" src="https://github.com/user-attachments/assets/7cfd325b-382e-4a69-b53b-1a6896025614"> |

| 5. has ID | 5. use ID |
| - | - |
| <img width="1024" alt="give ID" src="https://github.com/user-attachments/assets/3a82968f-d232-4d4e-8475-cfbf8f3e9275"> | <img width="1024" alt="use ID" src="https://github.com/user-attachments/assets/82f4a2c3-dc37-4ac5-a755-7921fed6e122"> | 