### PR TITLE
Tasks/WP-655 Add support for User Projects in apps

### DIFF
--- a/client/modules/_hooks/src/workspace/types.ts
+++ b/client/modules/_hooks/src/workspace/types.ts
@@ -21,7 +21,7 @@ export type TJobKeyValuePair = {
   key: string;
   value: string;
   description?: string;
-  inputMode: string;
+  inputMode?: string;
   notes?: TParameterSetNotes;
 };
 

--- a/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
+++ b/client/modules/datafiles/src/projects/modals/MetricsModal.tsx
@@ -317,7 +317,7 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
     },
     {
       key: '2',
-      quarters: 'Apr-Jul',
+      quarters: 'Apr-Jun',
       uniqueInvestigations:
         (quarterSums.views as { [key: string]: number }).Q2 || '--',
       uniqueRequests:
@@ -327,7 +327,7 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
     },
     {
       key: '3',
-      quarters: 'Aug-Oct',
+      quarters: 'Jul-Sep',
       uniqueInvestigations:
         (quarterSums.views as { [key: string]: number }).Q3 || '--',
       uniqueRequests:
@@ -337,7 +337,7 @@ export const MetricsModalBody: React.FC<MetricsModalProps> = ({
     },
     {
       key: '4',
-      quarters: 'Nov-Dec',
+      quarters: 'Oct-Dec',
       uniqueInvestigations:
         (quarterSums.views as { [key: string]: number }).Q4 || '--',
       uniqueRequests:

--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -54,6 +54,7 @@ import {
   mergeConfigurationDefaultsWithJobData,
   mergeParameterSetDefaultsWithJobData,
   mergeInputDefaultsWithJobData,
+  getOnDemandEnvVariables,
 } from '../utils';
 
 export const AppsSubmissionForm: React.FC = () => {
@@ -452,6 +453,14 @@ export const AppsSubmissionForm: React.FC = () => {
         }
       )
     );
+    if (jobData.job.parameterSet['envVariables']) {
+      jobData.job.parameterSet['envVariables'] = jobData.job.parameterSet[
+        'envVariables'
+      ].concat(getOnDemandEnvVariables(definition));
+    } else {
+      jobData.job.parameterSet['envVariables'] =
+        getOnDemandEnvVariables(definition);
+    }
 
     // Add allocation scheduler option
     if (jobData.job.allocation) {

--- a/client/modules/workspace/src/utils/apps.ts
+++ b/client/modules/workspace/src/utils/apps.ts
@@ -7,6 +7,7 @@ import {
   TTapisApp,
   TTapisSystemQueue,
   TTasAllocations,
+  TJobKeyValuePair,
 } from '@client/hooks';
 import { TFormValues } from '../AppsWizard/AppsFormSchema';
 import { UseFormSetValue } from 'react-hook-form';
@@ -471,4 +472,39 @@ export const findAppById = (
     }
   }
   return null;
+};
+
+/**
+ * Get list of env variables that are on demand and hidden
+ * in App Form.
+ * This could be useful to populate these env variables before
+ * submission to tapis
+ * @param definition app definition
+ * @returns list of key, value
+ */
+export const getOnDemandEnvVariables = (
+  definition: TTapisApp
+): { key: string; value: string }[] => {
+  const includeOnDemandVars: { key: string; value: string }[] = [];
+
+  Object.entries(definition.jobAttributes.parameterSet).forEach(
+    ([parameterSetKey, parameterSetValue]) => {
+      if (!Array.isArray(parameterSetValue)) return;
+
+      if (parameterSetKey === 'envVariables') {
+        parameterSetValue.forEach((param) => {
+          if (
+            param.notes?.isHidden &&
+            param.inputMode === 'INCLUDE_ON_DEMAND'
+          ) {
+            includeOnDemandVars.push({
+              key: (<TJobKeyValuePair>param).key,
+              value: (<TJobKeyValuePair>param).value,
+            });
+          }
+        });
+      }
+    }
+  );
+  return includeOnDemandVars;
 };

--- a/designsafe/apps/workspace/api/views.py
+++ b/designsafe/apps/workspace/api/views.py
@@ -766,6 +766,23 @@ class JobsView(AuthenticatedApiView):
             f"portalName: {settings.PORTAL_NAMESPACE}"
         ]
 
+        parameter_set = job_post.get("parameterSet", {})
+        env_variables = parameter_set.get("envVariables", [])
+        # Add user projects based on env var in the parameters.
+        projects_updated = False
+        for entry in env_variables:
+            if entry.get("key") == "_UserProjects":
+                projects = request.user.projects.order_by("-last_updated")
+                entry["value"] = " ".join(
+                    f"{project.uuid},{project.value['projectId'] if project.value['projectId'] != 'None' else project.uuid}"
+                    for project in projects[:500]
+                )
+                projects_updated = True
+                break
+
+        if projects_updated:
+            job_post["parameterSet"]["envVariables"] = env_variables 
+
         # Add additional data for interactive apps
         if body.get("isInteractive"):
             # Add webhook URL environment variable for interactive apps

--- a/designsafe/apps/workspace/api/views.py
+++ b/designsafe/apps/workspace/api/views.py
@@ -786,7 +786,7 @@ class JobsView(AuthenticatedApiView):
                 projects = request.user.projects.order_by("-last_updated")
                 entry["value"] = " ".join(
                     f"{project.uuid},{project.value['projectId'] if project.value['projectId'] != 'None' else project.uuid}"
-                    for project in projects[:500]
+                    for project in projects[:settings.USER_PROJECTS_LIMIT]
                 )
                 projects_updated = True
                 break

--- a/designsafe/apps/workspace/api/views.py
+++ b/designsafe/apps/workspace/api/views.py
@@ -780,7 +780,6 @@ class JobsView(AuthenticatedApiView):
         parameter_set = job_post.get("parameterSet", {})
         env_variables = parameter_set.get("envVariables", [])
         # Add user projects based on env var in the parameters.
-        projects_updated = False
         for entry in env_variables:
             if entry.get("key") == "_UserProjects":
                 projects = request.user.projects.order_by("-last_updated")
@@ -788,11 +787,8 @@ class JobsView(AuthenticatedApiView):
                     f"{project.uuid},{project.value['projectId'] if project.value['projectId'] != 'None' else project.uuid}"
                     for project in projects[:settings.USER_PROJECTS_LIMIT]
                 )
-                projects_updated = True
+                job_post["parameterSet"]["envVariables"] = env_variables
                 break
-
-        if projects_updated:
-            job_post["parameterSet"]["envVariables"] = env_variables 
 
         # Add additional data for interactive apps
         if body.get("isInteractive"):

--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -708,3 +708,4 @@ CSRF_TRUSTED_ORIGINS = [f"https://{os.environ.get('SESSION_COOKIE_DOMAIN')}"]
 WEBHOOK_POST_URL = os.environ.get('WEBHOOK_POST_URL', '')
 
 STAFF_VPN_IP_PREFIX = os.environ.get("STAFF_VPN_IP_PREFIX", "129.114")
+USER_PROJECTS_LIMIT = os.environ.get("USER_PROJECTS_LIMIT", 500)


### PR DESCRIPTION
## Overview: ##
For Express apps, user would like to have all their projects mounted and available.
Follow the solution from v2, where if _UserProject env var is available, then the list of projects is appended in this format:
uuid1, projectid2 uuid1, projectid2
upto 500.

QGIS app is updated to handle mapping the values.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-655](https://tacc-main.atlassian.net/browse/WP-655)

## Summary of Changes: ##

## Testing Steps: ##
1. Go to https://designsafe.dev/rw/workspace/qgis_express?appVersion=3.36. Submit job and see if your projects are in MyProjects folder.
2. Go to https://designsafe.dev/rw/workspace/openfoam to test nothing is broken regression wise and job submission works. This app has env vars and making sure nothing in existing env var breaks

## UI Photos:
<img width="335" alt="Screenshot 2024-08-14 at 2 39 46 PM" src="https://github.com/user-attachments/assets/b1822e6b-c009-4df2-b869-6b2a23f2e786">

<img width="503" alt="Screenshot 2024-08-14 at 2 53 04 PM" src="https://github.com/user-attachments/assets/8f849f2c-c701-477a-a9dc-d679419d3c9b">


## Notes: ##
Followups:
* I move the script to create project mounts into a shared one - so it can be reused
