### PR TITLE
Fix: wrong argument being sent to fedora ingester

### DIFF
--- a/designsafe/apps/api/projects_v2/operations/project_publish_operations.py
+++ b/designsafe/apps/api/projects_v2/operations/project_publish_operations.py
@@ -493,7 +493,7 @@ def publish_project(
             args=[project_id, version], queue="default"
         )
         ingest_pub_fedora_async.apply_async(
-            args=[project_id, version, True], queue="default"
+            args=[project_id, version, False], queue="default"
         )
 
     return pub_metadata


### PR DESCRIPTION
## Overview: ##
Need to send amend=False if the project is being versioned or initially published.
