### PR TITLE
Fix: Close open database connections in pipeline before copying files

### DIFF
--- a/designsafe/apps/api/projects_v2/operations/project_publish_operations.py
+++ b/designsafe/apps/api/projects_v2/operations/project_publish_operations.py
@@ -8,6 +8,7 @@ import datetime
 from pathlib import Path
 import logging
 from django.conf import settings
+from django.db import close_old_connections
 import networkx as nx
 from celery import shared_task
 from designsafe.apps.api.projects_v2 import constants
@@ -439,6 +440,10 @@ def publish_project(
     )
     if dry_run:
         return pub_tree, path_mapping
+
+    # If we don't explicitly close the db connection, it will remain open during the
+    # entire data-copying step, which can cause operations to fail.
+    close_old_connections()
 
     if not settings.DEBUG:
         # Copy files first so if it fails we don't create orphan metadata/datacite entries.


### PR DESCRIPTION
## Overview: ##
From [Django docs](https://docs.djangoproject.com/en/5.1/ref/databases/#caveats):

> If a connection is created in a long-running process, outside of Django’s request-response cycle, the connection will remain open until explicitly closed, or timeout occurs. You can use django.db.close_old_connections() to close all old or unusable connections.

For projects >100GB, there have been sporadic timeouts/errors from keeping a database connection open while copying files.
