### PR TITLE
Quick: Fixes for guest users

### DIFF
--- a/client/modules/datafiles/src/projects/forms/_fields/AuthorSelect.tsx
+++ b/client/modules/datafiles/src/projects/forms/_fields/AuthorSelect.tsx
@@ -23,7 +23,14 @@ export const AuthorSelect: React.FC<{
     <Checkbox.Group
       style={{ flexDirection: 'column' }}
       value={projectUsers
-        .filter((user) => value?.some((v) => user.email === v.email))
+        .filter((user) =>
+          value?.some(
+            (v) =>
+              (user.email || '') === (v.email || '') &&
+              user.fname === v.fname &&
+              user.lname === v.lname
+          )
+        )
         .map((v) => JSON.stringify(v) ?? [])}
       options={options}
       onChange={onChangeCallback}


### PR DESCRIPTION
## Overview: ##
- Add a script to migrate legacy guest authors into the new `users` field
- Fix author selection to prevent errors when duplicate emails exist