### PR TITLE
Quick: Restore new_user_alert task on initial login

### DIFF
--- a/designsafe/apps/auth/tasks.py
+++ b/designsafe/apps/auth/tasks.py
@@ -102,14 +102,15 @@ def new_user_alert(username):
                                                     'Id: ' + str(user.id) + '\n',
               settings.DEFAULT_FROM_EMAIL, settings.NEW_ACCOUNT_ALERT_EMAILS.split(','),)
 
-    tram_headers = {"tram-services-key": settings.TRAM_SERVICES_KEY}
-    tram_body = {"project_id": settings.TRAM_PROJECT_ID,
-                 "email": user.email}
-    tram_resp = requests.post(f"{settings.TRAM_SERVICES_URL}/project_invitations/create",
-                                 headers=tram_headers,
-                                 json=tram_body,
-                                 timeout=15)
-    tram_resp.raise_for_status()
+    # Auto-add user to TRAM allocation
+    # tram_headers = {"tram-services-key": settings.TRAM_SERVICES_KEY}
+    # tram_body = {"project_id": settings.TRAM_PROJECT_ID,
+    #              "email": user.email}
+    # tram_resp = requests.post(f"{settings.TRAM_SERVICES_URL}/project_invitations/create",
+    #                              headers=tram_headers,
+    #                             json=tram_body,
+    #                              timeout=15)
+    # tram_resp.raise_for_status()
 
 
 @shared_task()

--- a/designsafe/apps/auth/views.py
+++ b/designsafe/apps/auth/views.py
@@ -17,6 +17,7 @@ from designsafe.apps.auth.tasks import (
     get_systems_to_configure,
 )
 from designsafe.apps.workspace.api.tasks import cache_allocations
+from designsafe.apps.auth.tasks import new_user_alert
 from .models import TapisOAuthToken
 
 logger = logging.getLogger(__name__)
@@ -131,7 +132,9 @@ def tapis_oauth_callback(request):
         user = authenticate(backend="tapis", token=token_data["access_token"])
 
         if user:
-            TapisOAuthToken.objects.update_or_create(user=user, defaults={**token_data})
+            _, created = TapisOAuthToken.objects.update_or_create(user=user, defaults={**token_data})
+            if created:
+                new_user_alert.apply_async(args=(user.username,))
 
             login(request, user)
             launch_setup_checks(user)


### PR DESCRIPTION
## Overview: ##
Dispatch the `new_user_alert` task when a user initially logs in. This was a part of the V2 OAuth flow that got omitted in V3.
