### PR TITLE
task/WC-87: Preserve author order when updating metadata

### DIFF
--- a/client/modules/datafiles/src/projects/forms/BaseProjectForm.tsx
+++ b/client/modules/datafiles/src/projects/forms/BaseProjectForm.tsx
@@ -329,7 +329,10 @@ export const BaseProjectForm: React.FC<{
               ]}
               className="inner-form-item"
             >
-              <AuthorSelect projectUsers={watchedUsers} />
+              <AuthorSelect
+                projectUsers={watchedUsers}
+                currentAuthors={data?.baseProject.value.authors ?? []}
+              />
             </Form.Item>
           </Form.Item>
 

--- a/client/modules/datafiles/src/projects/forms/ProjectCategoryForm.tsx
+++ b/client/modules/datafiles/src/projects/forms/ProjectCategoryForm.tsx
@@ -124,7 +124,10 @@ export const ProjectCategoryForm: React.FC<{
               },
             ]}
           >
-            <AuthorSelect projectUsers={data.baseProject.value.users} />
+            <AuthorSelect
+              projectUsers={data.baseProject.value.users}
+              currentAuthors={category?.value.dataCollectors ?? []}
+            />
           </Form.Item>
         </Form.Item>
       )}
@@ -186,7 +189,10 @@ export const ProjectCategoryForm: React.FC<{
                 },
               ]}
             >
-              <AuthorSelect projectUsers={data.baseProject.value.users} />
+              <AuthorSelect
+                projectUsers={data.baseProject.value.users}
+                currentAuthors={category?.value.dataCollectors ?? []}
+              />
             </Form.Item>
           </Form.Item>
 
@@ -300,7 +306,10 @@ export const ProjectCategoryForm: React.FC<{
                 },
               ]}
             >
-              <AuthorSelect projectUsers={data.baseProject.value.users} />
+              <AuthorSelect
+                projectUsers={data.baseProject.value.users}
+                currentAuthors={category?.value.dataCollectors ?? []}
+              />
             </Form.Item>
           </Form.Item>
 

--- a/client/modules/datafiles/src/projects/forms/PublishableEntityForm.tsx
+++ b/client/modules/datafiles/src/projects/forms/PublishableEntityForm.tsx
@@ -27,7 +27,8 @@ import { AuthorSelect } from './_fields/AuthorSelect';
 const ExperimentFormFields: React.FC<{
   form: FormInstance;
   projectUsers: TProjectUser[];
-}> = ({ form, projectUsers }) => {
+  currentAuthors?: TProjectUser[];
+}> = ({ form, projectUsers, currentAuthors = [] }) => {
   const facilityValue = Form.useWatch(['value', 'facility'], form);
   return (
     <>
@@ -165,7 +166,10 @@ const ExperimentFormFields: React.FC<{
             },
           ]}
         >
-          <AuthorSelect projectUsers={projectUsers} />
+          <AuthorSelect
+            projectUsers={projectUsers}
+            currentAuthors={currentAuthors}
+          />
         </Form.Item>
       </Form.Item>
     </>
@@ -174,7 +178,8 @@ const ExperimentFormFields: React.FC<{
 
 const SimulationFormFields: React.FC<{
   projectUsers: TProjectUser[];
-}> = ({ projectUsers }) => {
+  currentAuthors?: TProjectUser[];
+}> = ({ projectUsers, currentAuthors = [] }) => {
   return (
     <>
       <Form.Item label="Simulation Title" required>
@@ -276,7 +281,10 @@ const SimulationFormFields: React.FC<{
             },
           ]}
         >
-          <AuthorSelect projectUsers={projectUsers} />
+          <AuthorSelect
+            projectUsers={projectUsers}
+            currentAuthors={currentAuthors}
+          />
         </Form.Item>
       </Form.Item>
     </>
@@ -285,7 +293,8 @@ const SimulationFormFields: React.FC<{
 
 const HybridSimFormFields: React.FC<{
   projectUsers: TProjectUser[];
-}> = ({ projectUsers }) => {
+  currentAuthors?: TProjectUser[];
+}> = ({ projectUsers, currentAuthors = [] }) => {
   return (
     <>
       <Form.Item label="Hybrid Simulation Title" required>
@@ -387,7 +396,10 @@ const HybridSimFormFields: React.FC<{
             },
           ]}
         >
-          <AuthorSelect projectUsers={projectUsers} />
+          <AuthorSelect
+            projectUsers={projectUsers}
+            currentAuthors={currentAuthors}
+          />
         </Form.Item>
       </Form.Item>
     </>
@@ -396,7 +408,8 @@ const HybridSimFormFields: React.FC<{
 
 const MissionFormFields: React.FC<{
   projectUsers: TProjectUser[];
-}> = ({ projectUsers }) => {
+  currentAuthors?: TProjectUser[];
+}> = ({ projectUsers, currentAuthors = [] }) => {
   return (
     <>
       <Form.Item label="Mission Title" required>
@@ -481,7 +494,10 @@ const MissionFormFields: React.FC<{
             },
           ]}
         >
-          <AuthorSelect projectUsers={projectUsers} />
+          <AuthorSelect
+            projectUsers={projectUsers}
+            currentAuthors={currentAuthors}
+          />
         </Form.Item>
       </Form.Item>
 
@@ -542,7 +558,8 @@ const MissionFormFields: React.FC<{
 
 const DocumentFormFields: React.FC<{
   projectUsers: TProjectUser[];
-}> = ({ projectUsers }) => {
+  currentAuthors?: TProjectUser[];
+}> = ({ projectUsers, currentAuthors = [] }) => {
   return (
     <>
       <Form.Item label="Document Title" required>
@@ -598,7 +615,10 @@ const DocumentFormFields: React.FC<{
             },
           ]}
         >
-          <AuthorSelect projectUsers={projectUsers} />
+          <AuthorSelect
+            projectUsers={projectUsers}
+            currentAuthors={currentAuthors}
+          />
         </Form.Item>
       </Form.Item>
 
@@ -685,19 +705,32 @@ export const PublishableEntityForm: React.FC<{
         <ExperimentFormFields
           form={form}
           projectUsers={data.baseProject.value.users}
+          currentAuthors={entity?.value.authors ?? []}
         />
       )}
       {projectType === 'simulation' && (
-        <SimulationFormFields projectUsers={data.baseProject.value.users} />
+        <SimulationFormFields
+          projectUsers={data.baseProject.value.users}
+          currentAuthors={entity?.value.authors ?? []}
+        />
       )}
       {projectType === 'hybrid_simulation' && (
-        <HybridSimFormFields projectUsers={data.baseProject.value.users} />
+        <HybridSimFormFields
+          projectUsers={data.baseProject.value.users}
+          currentAuthors={entity?.value.authors ?? []}
+        />
       )}
       {entityName === constants.FIELD_RECON_MISSION && (
-        <MissionFormFields projectUsers={data.baseProject.value.users} />
+        <MissionFormFields
+          projectUsers={data.baseProject.value.users}
+          currentAuthors={entity?.value.authors ?? []}
+        />
       )}
       {entityName === constants.FIELD_RECON_REPORT && (
-        <DocumentFormFields projectUsers={data.baseProject.value.users} />
+        <DocumentFormFields
+          projectUsers={data.baseProject.value.users}
+          currentAuthors={entity?.value.authors ?? []}
+        />
       )}
 
       {hasValidationErrors && (

--- a/client/modules/datafiles/src/projects/forms/_fields/AuthorSelect.tsx
+++ b/client/modules/datafiles/src/projects/forms/_fields/AuthorSelect.tsx
@@ -10,7 +10,7 @@ export const AuthorSelect: React.FC<{
 }> = ({ value, onChange, projectUsers, currentAuthors = [] }) => {
   const orderedUsers = useMemo(() => {
     // Ensure author order is not reset when adding/changing authors.
-    const authorUsers: TProjectUser[] = currentAuthors
+    const authorUsers = currentAuthors
       .map((a) =>
         projectUsers.find(
           (u) =>
@@ -21,7 +21,7 @@ export const AuthorSelect: React.FC<{
       )
       .filter((u) => !!u);
 
-    const nonAuthorUsers: TProjectUser[] = projectUsers
+    const nonAuthorUsers = projectUsers
       .filter(
         (u) =>
           !currentAuthors.find(
@@ -36,10 +36,12 @@ export const AuthorSelect: React.FC<{
     return [...authorUsers, ...nonAuthorUsers];
   }, [projectUsers, currentAuthors]);
 
-  const options = orderedUsers.map((author) => ({
-    value: JSON.stringify(author),
-    label: `${author.fname} ${author.lname} (${author.email})`,
-  }));
+  const options = orderedUsers
+    .filter((u) => !!u)
+    .map((author) => ({
+      value: JSON.stringify(author),
+      label: `${author?.fname} ${author?.lname} (${author?.email})`,
+    }));
 
   const onChangeCallback = useCallback(
     (value: string[]) => {
@@ -52,12 +54,13 @@ export const AuthorSelect: React.FC<{
     <Checkbox.Group
       style={{ flexDirection: 'column' }}
       value={orderedUsers
+        .filter((u) => !!u)
         .filter((user) =>
           value?.some(
             (v) =>
-              (user.email || '') === (v.email || '') &&
-              user.fname === v.fname &&
-              user.lname === v.lname
+              (user?.email || '') === (v.email || '') &&
+              user?.fname === v.fname &&
+              user?.lname === v.lname
           )
         )
         .map((v) => JSON.stringify(v) ?? [])}


### PR DESCRIPTION
## Overview: ##
Addresses an issue where the author order would be reset each time experiment/simulation metadata was saved.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-87](https://tacc-main.atlassian.net/browse/WC-87)

## Summary of Changes: ##
When updating project metadata, the user-defined author order is used to sort the set of selectable authors. This prevents the author order from being overwritten by the arbitrary order in the `users` array.

## Testing Steps: ##
1. In an Other-type project/Simulation/Experiment, set 3 or more authors.
2. In the Publication Pipeline, reverse the default author order
3. add a new author to the metadata from steps 1 and 2.
4. Confirm that the author order you set in step 2 is respected.

## UI Photos:

## Notes: ##
