### PR TITLE
Upper-case href types in project metadata

### DIFF
--- a/client/modules/datafiles/src/projects/BaseProjectDetails.tsx
+++ b/client/modules/datafiles/src/projects/BaseProjectDetails.tsx
@@ -331,7 +331,7 @@ export const BaseProjectDetails: React.FC<{
               <td style={{ fontWeight: 'bold' }}>
                 {projectValue.referencedData.map((ref) => (
                   <div key={JSON.stringify(ref)}>
-                    {ref.hrefType && `${ref.hrefType} | `}
+                    {ref.hrefType && `${ref.hrefType.toUpperCase()} | `}
                     <a href={ref.doi} rel="noopener noreferrer" target="_blank">
                       {ref.title}
                     </a>

--- a/client/modules/datafiles/src/projects/PublishedEntityDetails.tsx
+++ b/client/modules/datafiles/src/projects/PublishedEntityDetails.tsx
@@ -183,7 +183,7 @@ export const PublishedEntityDetails: React.FC<{
               <td style={{ fontWeight: 'bold' }}>
                 {entityValue.referencedData.map((ref) => (
                   <div key={JSON.stringify(ref)}>
-                    {ref.hrefType && `${ref.hrefType} | `}
+                    {ref.hrefType && `${ref.hrefType.toUpperCase()} | `}
                     <a href={ref.doi} rel="noopener noreferrer" target="_blank">
                       {ref.title}
                     </a>


### PR DESCRIPTION
## Overview: ##
href types should be uppercased (**DOI**/**URL** instead of **doi**/**url**) in the project metadata display.
