### PR TITLE
task/WC-91: Directories in Publication Preview should open in the Curation listing

### DIFF
--- a/client/modules/datafiles/src/projects/ProjectPipeline/PipelineOtherSelectFiles.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPipeline/PipelineOtherSelectFiles.tsx
@@ -152,6 +152,7 @@ export const PipelineOtherSelectFiles: React.FC<{
               api="tapis"
               system={`project-${data.baseProject.uuid}`}
               fileTags={data.baseProject.value.fileTags}
+              baseRoute={`/projects/${projectId}/curation`}
             />
           </>
         )}

--- a/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
@@ -49,7 +49,7 @@ export const EntityFileListingTable: React.FC<{
       ellipsis: true,
       render: (data, record) => {
         const fileNavPath = preview
-          ? `../${projectId}/curation/${encodeURIComponent(record.path)}`
+          ? `/projects/${projectId}/curation/${encodeURIComponent(record.path)}`
           : `./${encodeURIComponent(record.path)}${doi ? `?doi=${doi}` : ''}`;
         return (
           <div>

--- a/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
@@ -55,7 +55,6 @@ export const EntityFileListingTable: React.FC<{
           <div>
             {record.type === 'dir' ? (
               <Link
-                target={preview ? '_blank' : ''}
                 className="listing-nav-link"
                 to={fileNavPath}
                 replace={false}

--- a/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
@@ -40,62 +40,65 @@ export const EntityFileListingTable: React.FC<{
     path?: string;
     selectedFile?: TFileListing;
   }>({ isOpen: false });
-
+  const { projectId } = useParams();
   const doi = useDoiContext();
   const columns: TFileListingColumns = [
     {
       title: 'File Name',
       dataIndex: 'name',
       ellipsis: true,
-      render: (data, record) => (
-        <div>
-          {record.type === 'dir' ? (
-            <Link
-              className="listing-nav-link"
-              to={`./${encodeURIComponent(record.path)}${
-                doi ? `?doi=${doi}` : ''
-              }`}
-              style={{ pointerEvents: preview ? 'none' : 'all' }}
-              replace={false}
-            >
-              <i
-                role="none"
-                style={{ color: '#333333' }}
-                className="fa fa-folder"
-              >
-                &nbsp;&nbsp;
-              </i>
-              {data}
-            </Link>
-          ) : (
-            <>
-              <FileTypeIcon name={record.name} />
-              &nbsp;&nbsp;
-              <Button
-                type="link"
-                onClick={() =>
-                  setPreviewModalState({
-                    isOpen: true,
-                    path: record.path,
-                    selectedFile: { ...record, doi },
-                  })
-                }
-              >
-                {data}
-              </Button>
-            </>
-          )}
+      render: (data, record) => {
+        const fileNavPath = preview
+          ? `../${projectId}/curation/${encodeURIComponent(record.path)}`
+          : `./${encodeURIComponent(record.path)}${doi ? `?doi=${doi}` : ''}`;
+        return (
           <div>
-            {treeData.value.fileTags
-              .filter((t) => t.path === record.path)
-              .map((t) => (
-                <Tag color="#337ab7" key={t.tagName}>
-                  {t.tagName}
-                </Tag>
-              ))}
+            {record.type === 'dir' ? (
+              <Link
+                target={preview ? '_blank' : ''}
+                className="listing-nav-link"
+                to={fileNavPath}
+                replace={false}
+              >
+                <i
+                  role="none"
+                  style={{ color: '#333333' }}
+                  className="fa fa-folder"
+                >
+                  &nbsp;&nbsp;
+                </i>
+                {data}
+              </Link>
+            ) : (
+              <>
+                <FileTypeIcon name={record.name} />
+                &nbsp;&nbsp;
+                <Button
+                  type="link"
+                  onClick={() =>
+                    setPreviewModalState({
+                      isOpen: true,
+                      path: record.path,
+                      selectedFile: { ...record, doi },
+                    })
+                  }
+                >
+                  {data}
+                </Button>
+              </>
+            )}
+            <div>
+              {treeData.value.fileTags
+                .filter((t) => t.path === record.path)
+                .map((t) => (
+                  <Tag color="#337ab7" key={t.tagName}>
+                    {t.tagName}
+                  </Tag>
+                ))}
+            </div>
           </div>
-        </div>
-      ),
+        );
+      },
     },
   ];
   return (


### PR DESCRIPTION
## Overview: ##
When users click on directory links inside of the Publication Preview, they should be navigated to that directory in the Curation area.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-91](https://tacc-main.atlassian.net/browse/WC-91)

## Summary of Changes: ##

## Testing Steps: ##
1. Go to a project with folders associated to some entity, and click "Prepare to Publish.
2. Check that when you click on a directory name in Publication Preview, you are 

## UI Photos:

## Notes: ##
