### PR TITLE
task/WP-685: user work workspace file select

### DIFF
--- a/client/modules/_hooks/src/systems/types.ts
+++ b/client/modules/_hooks/src/systems/types.ts
@@ -61,6 +61,7 @@ export type TTapisSystem = {
     label?: string;
     keyservice?: boolean;
     isMyData?: boolean;
+    hasWork?: boolean;
     portalNames: string[];
   };
   importRefId?: string;

--- a/client/modules/workspace/src/SelectModal/SelectModal.tsx
+++ b/client/modules/workspace/src/SelectModal/SelectModal.tsx
@@ -103,9 +103,13 @@ const getSystemRootPath = (
   storageSystem: TTapisSystem | undefined,
   user: TUser | undefined
 ): string => {
-  return storageSystem?.notes?.isMyData
-    ? encodeURIComponent('/' + user?.username)
-    : '';
+  if (storageSystem?.notes?.isMyData) {
+    return encodeURIComponent('/' + user?.username);
+  }
+  if (storageSystem?.notes?.hasWork) {
+    return encodeURIComponent('/work/' + user?.homedir);
+  }
+  return '';
 };
 
 const getBackPath = (
@@ -298,7 +302,7 @@ export const SelectModal: React.FC<{
       return (a.notes?.isMyData ? 0 : 1) - (b.notes?.isMyData ? 0 : 1);
     })
     .map((system) => ({
-      label: system.notes.label,
+      label: system.notes?.hasWork ? 'Work' : system.notes.label ?? system.id,
       value: system.id,
     }));
   systemOptions.push({ label: 'My Projects', value: 'myprojects' });
@@ -363,7 +367,9 @@ export const SelectModal: React.FC<{
       selectedPath: getSystemRootPath(system, user),
       scheme: getScheme(system),
     });
-    setSystemLabel(system.notes.label ?? system.id);
+    setSystemLabel(
+      system.notes?.hasWork ? 'Work' : system.notes.label ?? system.id
+    );
   };
 
   const onProjectSelect = (uuid: string, projectId: string) => {

--- a/designsafe/apps/auth/backends.py
+++ b/designsafe/apps/auth/backends.py
@@ -36,7 +36,8 @@ def on_user_logged_out(sender, request, user, **kwargs):
         login_provider = "TACC"
 
     logger.info(
-        "Revoking tapis token: %s", TapisOAuthToken().get_masked_token(user.tapis_oauth.access_token)
+        "Revoking tapis token: %s",
+        TapisOAuthToken().get_masked_token(user.tapis_oauth.access_token),
     )
     backend = TapisOAuthBackend()
     TapisOAuthBackend.revoke(backend, user.tapis_oauth.access_token)
@@ -139,7 +140,8 @@ class TapisOAuthBackend(ModelBackend):
             token = kwargs["token"]
 
             logger.info(
-                'Attempting login via Tapis with token "%s"' % TapisOAuthToken().get_masked_token(token)
+                'Attempting login via Tapis with token "%s"'
+                % TapisOAuthToken().get_masked_token(token)
             )
             client = Tapis(base_url=settings.TAPIS_TENANT_BASEURL, access_token=token)
 
@@ -188,9 +190,13 @@ class TapisOAuthBackend(ModelBackend):
 
     def revoke(self, token):
         logger.info(
-            "Attempting to revoke Tapis token %s" % TapisOAuthToken().get_masked_token(token)
+            "Attempting to revoke Tapis token %s"
+            % TapisOAuthToken().get_masked_token(token)
         )
 
-        client = Tapis(base_url=settings.TAPIS_TENANT_BASEURL, access_token=token)
-        response = client.authenticator.revoke_token(token=token)
-        logger.info("revoke response is %s" % response)
+        try:
+            client = Tapis(base_url=settings.TAPIS_TENANT_BASEURL, access_token=token)
+            response = client.authenticator.revoke_token(token=token)
+            logger.info("revoke response is %s" % response)
+        except BaseTapyException as e:
+            logger.error("Error revoking token: %s", e.message)


### PR DESCRIPTION
## Overview: ##

- Adds support for `cloud.data:/work` system in workspace File Select modal
- handles errors in the `revoke()` method in the auth backend

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WP-685](https://tacc-main.atlassian.net/browse/WP-685)

## Testing Steps: ##
1. In [client/modules/workspace/src/SelectModal/SelectModal.tsx:line 36](https://github.com/DesignSafe-CI/portal/blob/c659f4c412715a9cd7a72c2540f7a4e3052d1062/client/modules/workspace/src/SelectModal/SelectModal.tsx#L36) set `portalName` to `DesignSafeTest`
2. Go to https://designsafe.dev/rw/workspace/openfoam and open the select modal
3. Confirm that "Work" appears in the dropdown, and it points to the user's $STOCKYARD (`/work/numbers/username`)


## Notes:
- On release day of this feature and #1423 , we will need to update the `cloud.data` system `notes.portalNames[]` field to use `DesignSafe` instead of `DesignSafeTest`
