### PR TITLE
BUG/WC-92: Deep-copy entity values before inserting them into the project tree

### DIFF
--- a/designsafe/apps/api/projects_v2/operations/project_publish_operations.py
+++ b/designsafe/apps/api/projects_v2/operations/project_publish_operations.py
@@ -4,6 +4,7 @@ from typing import Optional, Literal
 import subprocess
 import os
 import shutil
+import copy
 import datetime
 from pathlib import Path
 import logging
@@ -204,7 +205,9 @@ def add_values_to_tree(project_id: str) -> nx.DiGraph:
     for node_id in publication_tree:
         uuid = publication_tree.nodes[node_id]["uuid"]
         if uuid is not None:
-            publication_tree.nodes[node_id]["value"] = entity_map[uuid].value
+            publication_tree.nodes[node_id]["value"] = copy.deepcopy(
+                entity_map[uuid].value
+            )
 
     return publication_tree
 


### PR DESCRIPTION
## Overview: ##
Fixes a bug where even though each node in the project tree is supposed to be independent, we were assigning values in such a way that multiple nodes could contain the *same* value dictionary.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-92](https://tacc-main.atlassian.net/browse/WC-92)

