### PR TITLE
task/WC-79: Only show up to 3 keywords in the publication listing

### DIFF
--- a/client/modules/datafiles/src/publications/PublishedListing/PublishedListing.tsx
+++ b/client/modules/datafiles/src/publications/PublishedListing/PublishedListing.tsx
@@ -84,7 +84,13 @@ const columns: TableColumnsType<TPublicationListingItem> = [
   },
   {
     render: (_, record) => {
-      return <span>{`${record.keywords.join(', ')}`}</span>;
+      return (
+        <span>{`${record.keywords
+          .map((k) => k.split(';')) // Some old projects are semicolon-delimited
+          .flat()
+          .slice(0, 3)
+          .join(', ')}`}</span>
+      );
     },
     width: '15%',
     title: 'Keywords',


### PR DESCRIPTION
## Overview: ##
If a publication has >3 keywords, only show the first 3 in the main listing.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-79](https://tacc-main.atlassian.net/browse/WC-79)
