### PR TITLE
Task/WC-95: Clear file selection when changing publication version

### DIFF
--- a/client/modules/datafiles/src/DatafilesModal/DownloadModal/DownloadModal.tsx
+++ b/client/modules/datafiles/src/DatafilesModal/DownloadModal/DownloadModal.tsx
@@ -14,7 +14,7 @@ export const DownloadModal: React.FC<{
 
   const doiArray = selectedFiles.filter((f) => f.doi).map((f) => f.doi);
 
-  const doiString = [...new Set(doiArray)].join(',');
+  const doiString = doiArray.join(',');
 
   const showModal = () => {
     setIsModalOpen(true);

--- a/client/modules/datafiles/src/projects/BaseProjectDetails.tsx
+++ b/client/modules/datafiles/src/projects/BaseProjectDetails.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { TBaseProjectValue, TProjectUser } from '@client/hooks';
+import {
+  TBaseProjectValue,
+  TProjectUser,
+  useSelectedFiles,
+} from '@client/hooks';
 
 import styles from './BaseProjectDetails.module.css';
 import { Button, Col, Popover, Row, Select, Tooltip } from 'antd';
@@ -155,8 +159,14 @@ export const BaseProjectDetails: React.FC<{
   ].join(' | ');
 
   const [searchParams, setSearchParams] = useSearchParams();
+  const { unsetSelections } = useSelectedFiles(
+    'tapis',
+    'designsafe.storage.published',
+    ''
+  );
 
   const setSelectedVersion = (newVersion: number) => {
+    unsetSelections();
     setSearchParams((prevParams) => {
       prevParams.set('version', newVersion.toString());
       return prevParams;


### PR DESCRIPTION
## Overview: ##
Clear file selection when changing publication version. Fixes a bug where files from multiple versions of a publication could be selected at once. 

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-95](https://tacc-main.atlassian.net/browse/WC-95)
