### PR TITLE
Task/WC-96: Log views of non-Other type publications as listings on the root dir

### DIFF
--- a/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
+++ b/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
@@ -5,7 +5,11 @@ import {
   PublishedCitation,
   DownloadCitation,
 } from '@client/datafiles';
-import { usePublicationDetail, usePublicationVersions } from '@client/hooks';
+import {
+  apiClient,
+  usePublicationDetail,
+  usePublicationVersions,
+} from '@client/hooks';
 import React, { useEffect } from 'react';
 import { Alert, Button, Form, Input, Layout, Spin } from 'antd';
 import { Navigate, Outlet, useParams, useSearchParams } from 'react-router-dom';
@@ -53,6 +57,25 @@ export const PublishedDetailLayout: React.FC = () => {
       setSearchParams(newSearchParams);
     }
   }, [version, searchParams, setSearchParams]);
+
+  // List files in the project root for metrics/reporting purposes.
+  useEffect(() => {
+    if (!data) return;
+
+    const selectedVersion =
+      version ||
+      searchParams.get('version') ||
+      Math.max(...allVersions).toString();
+
+    data?.baseProject.projectType !== 'other' &&
+      apiClient.get(
+        `/api/datafiles/tapis/public/listing/designsafe.storage.published/${projectId}${
+          selectedVersion && parseInt(selectedVersion) > 1
+            ? `v${selectedVersion}`
+            : ''
+        }`
+      );
+  }, [data, searchParams, apiClient, version, projectId]);
 
   if (isError) {
     return (

--- a/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
+++ b/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
@@ -75,7 +75,7 @@ export const PublishedDetailLayout: React.FC = () => {
             : ''
         }`
       );
-  }, [data, searchParams, apiClient, version, projectId]);
+  }, [data, allVersions, searchParams, version, projectId]);
 
   if (isError) {
     return (


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-96](https://tacc-main.atlassian.net/browse/WC-96)

## Summary of Changes: ##

## Testing Steps: ##
1. Open a non-Other type publication
2. Confirm that an `op=listing` log is generated with the correct project ID and version.

## UI Photos:

## Notes: ##
