### PR TITLE
Task/wg 375 recon portal UI changes

### DIFF
--- a/designsafe/apps/rapid/views.py
+++ b/designsafe/apps/rapid/views.py
@@ -96,7 +96,9 @@ def opentopo_data(request):
         logger.debug("Requesting opentopo data")
         response = requests.get(OPEN_TOPO_REQUEST_FOR_WHOLE_WORLD)
         response.raise_for_status()
-        response_data = response.json()
+        # response has some tabs char in the strings values that need to be replaced with string '\t'
+        response_content = response.text.replace('\t', '\\t')
+        response_data = json.loads(response_content)
         return JsonResponse(response_data, safe=False, status=response.status_code)
     except requests.RequestException as e:
         logger.error(f"Error fetching URL {OPEN_TOPO_REQUEST_FOR_WHOLE_WORLD}: {str(e)}")

--- a/designsafe/apps/rapid/views.py
+++ b/designsafe/apps/rapid/views.py
@@ -96,9 +96,7 @@ def opentopo_data(request):
         logger.debug("Requesting opentopo data")
         response = requests.get(OPEN_TOPO_REQUEST_FOR_WHOLE_WORLD)
         response.raise_for_status()
-        # response has some tabs char in the strings values that need to be replaced with string '\t'
-        response_content = response.text.replace('\t', '\\t')
-        response_data = json.loads(response_content)
+        response_data = response.json()
         return JsonResponse(response_data, safe=False, status=response.status_code)
     except requests.RequestException as e:
         logger.error(f"Error fetching URL {OPEN_TOPO_REQUEST_FOR_WHOLE_WORLD}: {str(e)}")

--- a/designsafe/static/scripts/rapid/controllers/rapid-main-ctrl.js
+++ b/designsafe/static/scripts/rapid/controllers/rapid-main-ctrl.js
@@ -248,9 +248,11 @@ export default class RapidMainCtrl {
     }
 
     search() {
-        if (!this.events || !this.openTopoData) return;
-        this.filtered_events = this.RapidDataService.searchEvents(this.events, this.filter_options);
-        this.filtered_openTopoData = this.RapidDataService.searchOpenTopo(this.openTopoData, this.opentopo_filter_options, this.filter_options);
+        if (!this.events && !this.openTopoData) return;
+        if (this.data_source)
+            this.filtered_events = this.RapidDataService.searchEvents(this.events, this.filter_options);
+        if (this.ot_data_source)
+            this.filtered_openTopoData = this.RapidDataService.searchOpenTopo(this.openTopoData, this.opentopo_filter_options, this.filter_options);
         
         // Handle Recon Portal Layer
         this.updateLayer(this.data_source, this.reconLayer, this.filtered_events);

--- a/designsafe/static/scripts/rapid/html/index.html
+++ b/designsafe/static/scripts/rapid/html/index.html
@@ -9,7 +9,7 @@
             <input type="checkbox"
               ng-change="vm.search()"
               ng-model="vm.data_source"/>
-            <label> Recon Portal Data </label>
+            <label> DesignSafe Data </label>
           </div>
         <div class="filter-options">
           <label> Event Type </label>
@@ -30,7 +30,6 @@
               ng-model="vm.filter_options.end_date"
               ng-disabled="!vm.data_source"
               title="Select the data source to enable filters"/>
-              <button class="btn btn-xs btn-default hide-btn" ng-click="vm.debouncedSearch()" ng-disabled="!vm.data_source"> Search </button>
         </div>
         </ul>
       <ul>
@@ -59,12 +58,12 @@
             ng-model="vm.opentopo_filter_options.ot_end_date"
             ng-disabled="!vm.ot_data_source"
             title="Select the data source to enable filters">
-          <button class="btn btn-xs btn-default hide-btn" ng-click="vm.debouncedSearch()" ng-disabled="!vm.ot_data_source"> Search </button>
         </div>
         </ul>
-      <div class="filter-options">
-        <button class="btn btn-xs btn-default hide-btn" ng-click="vm.show_filter_options=false"> Hide Filters </button>
-        <button class="btn btn-xs btn-info clear-btn" ng-click="vm.clear_filters()"> Clear Filters </button>
+      <div class="filter-button-row">
+        <button class="btn btn-xs btn-default filter-btn" ng-click="vm.show_filter_options=false"> Hide Filters </button>
+        <button class="btn btn-xs btn-default filter-btn" ng-click="vm.clear_filters()"> Clear Filters </button>
+        <button class="btn btn-xs btn-info filter-btn" ng-click="vm.debouncedSearch()" ng-disabled="(!vm.data_source && !vm.ot_data_source)"> Search </button>
       </div>
     </div>
   </div>
@@ -103,9 +102,25 @@
         </div> 
       </div>
       <div ng-show="!vm.active_rapid_event" class="event-results sb-row">
-        <div ng-show="vm.filtered_events" class="">
-          <event-listing ng-show="vm.data_source" ng-repeat="event in vm.filtered_events" event=event ng-click="vm.select_event(event)"></event-listing>
-          <event-listing ng-show="vm.ot_data_source" ng-repeat="event in vm.filtered_openTopoData" event=event ng-click="vm.select_event(event)"></event-listing>
+        <div class="event-listing designSafeData error" ng-if="vm.data_source && vm.filtered_events.length === 0">
+          <p>No DesignSafe datasets match your selected filters.</p>
+        </div>
+        <div class="event-listing openTopoData error" ng-if="vm.ot_data_source && vm.filtered_openTopoData.length === 0">
+          <p>No OpenTopography datasets match your selected filters.</p>
+        </div>
+        <div ng-if="vm.filtered_events">
+            <event-listing 
+                ng-repeat="event in vm.filtered_events" 
+                event="event" 
+                ng-click="vm.select_event(event)">
+            </event-listing>
+        </div>
+        <div ng-if="vm.filtered_openTopoData">
+          <event-listing 
+              ng-repeat="event in vm.filtered_openTopoData" 
+              event="event" 
+              ng-click="vm.select_event(event)">
+          </event-listing>
         </div>
         <div ng-show="!vm.filtered_events" class="">
           <event-listing ng-show="vm.data_source" ng-repeat="event in vm.events" event=event ng-click="vm.select_event(event)"></event-listing>

--- a/designsafe/static/scripts/rapid/html/index.html
+++ b/designsafe/static/scripts/rapid/html/index.html
@@ -63,7 +63,7 @@
       <div class="filter-button-row">
         <button class="btn btn-xs btn-default filter-btn" ng-click="vm.show_filter_options=false"> Hide Filters </button>
         <button class="btn btn-xs btn-default filter-btn" ng-click="vm.clear_filters()"> Clear Filters </button>
-        <button class="btn btn-xs btn-info filter-btn" ng-click="vm.debouncedSearch()" ng-disabled="(!vm.data_source && !vm.ot_data_source)"> Search </button>
+        <button class="btn btn-xs btn-info filter-btn" ng-click="vm.search()" ng-disabled="(!vm.data_source && !vm.ot_data_source)"> Search </button>
       </div>
     </div>
   </div>

--- a/designsafe/static/scripts/rapid/html/index.html
+++ b/designsafe/static/scripts/rapid/html/index.html
@@ -4,119 +4,69 @@
   </div>
   <div class="filter-options slide-in" ng-show="vm.show_filter_options">
     <div class="filter-container">
-        <div class="filter-options">
-        <label> Event Type </label>
-        <select class="form-control"
-                ng-options="et.display_name for et in vm.event_types track by et.name"
-                ng-change="vm.search()"
-                ng-model="vm.filter_options.event_type"
-                ng-disabled="!vm.data_source"
-                title="Select the data source to enable filters"></select>
-        <label> Start date </label>
-        <input type="date"
-              class="form-control"
-              ng-model="vm.filter_options.start_date"
+        <ul>
+          <div class="data_source">
+            <input type="checkbox"
               ng-change="vm.search()"
+              ng-model="vm.data_source"/>
+            <label> Recon Portal Data </label>
+          </div>
+        <div class="filter-options">
+          <label> Event Type </label>
+          <select class="form-control"
+              ng-options="et.display_name for et in vm.event_types track by et.name"
+              ng-model="vm.filter_options.event_type"
               ng-disabled="!vm.data_source"
-              title="Select the data source to enable filters">
-        <label> End date </label>
-        <input type="date"
+              title="Select the data source to enable filters"></select>
+          <label> Start date </label>
+          <input type="date"
+            class="form-control"
+            ng-model="vm.filter_options.start_date"
+            ng-disabled="!vm.data_source"
+            title="Select the data source to enable filters"/>
+          <label> End date </label>
+          <input type="date"
               class="form-control"
               ng-model="vm.filter_options.end_date"
-              ng-change="vm.search()"
               ng-disabled="!vm.data_source"
-              title="Select the data source to enable filters">
-              </div>
-          <div class="external-data-checkbox"  ng-show="!vm.show_external_filters">
-            <input type="checkbox" id="showExternalCheckbox" ng-click="vm.show_external_filters = true; vm.ot_data_source = false;"
-            ng-model="vm.show_external_filters">
-            <label for="showExternalCheckbox">
-              <i class="ds-icon-Expand unchecked-icon"></i>
-              <h4>
-                <u>
-              View External Dataset Filters
-            </u>
-            </h4>
-            </label>
-          </div>
-        <div ng-show="vm.show_external_filters">
-          <div class="external-data-checkbox"  ng-show="vm.show_external_filters">
-            <input type="checkbox" id="hideExternalCheckbox" ng-click="vm.show_external_filters = false; vm.ot_data_source = false; vm.clear_filters();"
-            ng-model="vm.show_external_filters">
-            <label for="hideExternalCheckbox">
-              <h4>
-                <u>
-              Hide External Dataset Filters
-            </u>
-            </h4>
-            </label>
-          </div>
-        <ul>
+              title="Select the data source to enable filters"/>
+              <button class="btn btn-xs btn-default hide-btn" ng-click="vm.debouncedSearch()" ng-disabled="!vm.data_source"> Search </button>
+        </div>
+        </ul>
+      <ul>
         <div class="data_source">
-      <input type="checkbox"
+          <input type="checkbox"
             ng-change="vm.search()"
-            ng-model="vm.ot_data_source">
-      <label class="external_datasource_listing"> OpenTopography Data </label>
-    </div>
-    <div class="filter-options">
-        <label> Keyword search<span class="info-icon" data-tooltip="Keywords typically include: title terms, location details, type of events, index terms associated with the datasets"> (i)</span></label> </label>
-        <input type="text" 
-              class="form-control" 
-              ng-model="vm.opentopo_filter_options.keyword" 
-              ng-change="vm.debouncedSearch()"
-              ng-disabled="!vm.ot_data_source"
-              title="Select the data source to enable filters"></input>
-        <label> Start date </label>
-        <input type="date"
-              class="form-control"
-              ng-model="vm.opentopo_filter_options.ot_start_date"
-              ng-change="vm.search()"
-              ng-disabled="!vm.ot_data_source"
-              title="Select the data source to enable filters">
-        <label> End date </label>
-        <input type="date"
-              class="form-control"
-              ng-model="vm.opentopo_filter_options.ot_end_date"
-              ng-change="vm.search()"
-              ng-disabled="!vm.ot_data_source"
-              title="Select the data source to enable filters">
-      </div>
-      <div class="data_source">
-    <input type="checkbox"
-          ng-change="vm.search()"
-          ng-model="vm.ot_data_source">
-    <label class="external_datasource_listing"> External Data Source 2 </label>
-  </div>
-  <div class="filter-options">
-      <label> Keyword search<span class="info-icon" data-tooltip="Keywords typically include: title terms, location details, type of events, index terms associated with the datasets"> (i)</span></label> </label>
-      <input type="text" 
+            ng-model="vm.ot_data_source"/>
+          <label> OpenTopography Data </label>
+        </div>
+        <div class="filter-options">
+          <label> Keyword search<span class="info-icon" data-tooltip="Keywords typically include: title terms, location details, type of events, index terms associated with the datasets"> (i)</span></label> </label>
+          <input type="text" 
             class="form-control" 
             ng-model="vm.opentopo_filter_options.keyword" 
-            ng-change="vm.debouncedSearch()"
             ng-disabled="!vm.ot_data_source"
             title="Select the data source to enable filters"></input>
-      <label> Start date </label>
-      <input type="date"
+          <label> Start date </label>
+          <input type="date"
             class="form-control"
             ng-model="vm.opentopo_filter_options.ot_start_date"
-            ng-change="vm.search()"
             ng-disabled="!vm.ot_data_source"
             title="Select the data source to enable filters">
-      <label> End date </label>
-      <input type="date"
+          <label> End date </label>
+          <input type="date"
             class="form-control"
             ng-model="vm.opentopo_filter_options.ot_end_date"
-            ng-change="vm.search()"
             ng-disabled="!vm.ot_data_source"
             title="Select the data source to enable filters">
-  </div>
-  </div>
+          <button class="btn btn-xs btn-default hide-btn" ng-click="vm.debouncedSearch()" ng-disabled="!vm.ot_data_source"> Search </button>
+        </div>
+        </ul>
       <div class="filter-options">
-    <button class="btn btn-xs btn-info clear-btn" ng-click="vm.clear_filters()"> Clear </button>
-    <button class="btn btn-xs btn-default hide-btn" ng-click="vm.show_filter_options=false"> Hide </button>
-  </div>
-  </div>
-</ul>
+        <button class="btn btn-xs btn-default hide-btn" ng-click="vm.show_filter_options=false"> Hide Filters </button>
+        <button class="btn btn-xs btn-info clear-btn" ng-click="vm.clear_filters()"> Clear Filters </button>
+      </div>
+    </div>
   </div>
   <div id="show_sidebar_handle" ng-show="!vm.show_sidebar" ng-click="vm.show_sidebar = !vm.show_sidebar">
     <div class="sidebar-handle"
@@ -165,5 +115,4 @@
     </div>
   </div> <!-- ends sidebar -->
   <div id="map"></div>
-</div>
 </div>

--- a/designsafe/static/scripts/rapid/styles/rapid.css
+++ b/designsafe/static/scripts/rapid/styles/rapid.css
@@ -316,58 +316,11 @@ body {
   margin-bottom: 10px;
 }
 
-.data_source{
+.data-source{
   display:flex;
   flex-direction: row;
   width: 100%;
   align-items: center;
-}
-
-.external_datasource_listing {
-  padding-left: 10px;
-  padding-right: 10px;
-  padding-top: 12px;
-  padding-bottom: 5px;
-
-}
-
-.external-data-checkbox {
-  position: relative;
-  display: inline-block;
-}
-
-.external-data-checkbox input[type="checkbox"] {
-  position: absolute;
-  opacity: 0;
-  cursor: pointer;
-  height: 0;
-  width: 0;
-}
-
-.external-data-checkbox label {
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-}
-
-.external-data-checkbox .unchecked-icon {
-  display: inline-block;
-  font-size: 20px;
-  margin-right: 8px;
-}
-
-.external-data-checkbox .checked-icon {
-  display: none;
-  font-size: 20px;
-  margin-right: 8px;
-}
-
-.external-data-checkbox input[type="checkbox"]:checked ~ label .unchecked-icon {
-  display: none;
-}
-
-.external-data-checkbox input[type="checkbox"]:checked ~ label .checked-icon {
-  display: inline-block;
 }
 
 .clear-btn,

--- a/designsafe/static/scripts/rapid/styles/rapid.css
+++ b/designsafe/static/scripts/rapid/styles/rapid.css
@@ -219,6 +219,9 @@ body {
 .event-listing.openTopoData {
   border-left: 5px solid #a8bb2f;
 }
+.event-listing.designSafeData {
+  border-left: 5px solid #548cc8;
+}
 
 .event-listing .event-type.earthquake {
   background-color: #e46e28;
@@ -241,7 +244,11 @@ body {
 .event-listing  .event-type.openTopoData {
   background-color: #a8bb2f;
 }
-
+.error {
+  background: #efd5d8;
+  color: #bb2f3f;
+  font-weight: bold;
+}
 
 .event-listing .event-date, .event-listing .event-type {
   background: #777777;
@@ -294,6 +301,13 @@ body {
   gap: 10px;
 }
 
+.filter-button-row {
+  display: flex;
+  justify-content:center;
+  white-space: nowrap;
+  align-items: center;
+}
+
 .filter-options-button {
   margin: 10px;
 }
@@ -323,8 +337,7 @@ body {
   align-items: center;
 }
 
-.clear-btn,
-.hide-btn{
+.filter-btn{
   width: 25%;
   height :40px;
 }


### PR DESCRIPTION
## Overview: ##

Requested UI changes from Tracy before 4Kitchens and CMD design review

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-376](https://tacc-main.atlassian.net/browse/WG-375)

## Summary of Changes: ##
- Removes external dataset header and toggle and associated styles
- Changes order of Clear and Hide buttons, adds filter
to the wording in the button
- Adds search bar on button row
- Adds checkbox to hide and add DesignSafe data
- Adds message in sidebar if no results are returned for a filter search

## Testing Steps: ##
1. Go to https://designsafe.dev/recon-portal/ and check search functionality
2. Use search bar in sidebar to ensure it still works with the filters

## UI Photos:

Main screen with filters showing
![Screenshot 2024-09-24 at 2 11 05 PM](https://github.com/user-attachments/assets/084614ad-9aab-4091-b5b3-5364ebfca108)
![Screenshot 2024-09-24 at 2 11 22 PM](https://github.com/user-attachments/assets/4179315c-144b-4d0d-bdbf-1dfb636b0579)
![Screenshot 2024-09-24 at 2 11 48 PM](https://github.com/user-attachments/assets/9220593e-f7ac-4b29-8016-f11064a6bf66)
![Screenshot 2024-09-24 at 2 12 09 PM](https://github.com/user-attachments/assets/71b5dbad-c9c8-4eeb-b468-1832dab8c345)
![Screenshot 2024-09-24 at 2 12 32 PM](https://github.com/user-attachments/assets/84eb1a9f-9eea-4f25-b849-b55fa5055157)
No dataset match for filters
![Screenshot 2024-09-24 at 2 12 46 PM](https://github.com/user-attachments/assets/126703cf-7bfb-4bd1-971b-1d129f60d1a0)


## Notes: ##
