### PR TITLE
bug/WC-114: Fix DOI support in Publication search

### DIFF
--- a/client/modules/datafiles/src/publications/PublishedListing/PublishedListing.tsx
+++ b/client/modules/datafiles/src/publications/PublishedListing/PublishedListing.tsx
@@ -134,7 +134,7 @@ export const PublishedListing: React.FC = () => {
                 type="error"
                 description={
                   <span>
-                    An unexpected error occurred while retrieving publications."
+                    An unexpected error occurred while retrieving publications.
                   </span>
                 }
               />


### PR DESCRIPTION
## Overview: ##
Escape slashes in queries to prevent copy/pated DOIs from triggering errors.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-114](https://tacc-main.atlassian.net/browse/WC-114)

