### PR TITLE
Bug/WC-33: Fix NEES DOI links by appending project root to paths

### DIFF
--- a/client/modules/datafiles/src/nees/NeesDetails.tsx
+++ b/client/modules/datafiles/src/nees/NeesDetails.tsx
@@ -58,7 +58,9 @@ export const NeesDetails: React.FC<{ neesId: string }> = ({ neesId }) => {
   const neesExperiments = data?.metadata.experiments;
   const numDOIs = neesExperiments?.filter((exp) => !!exp.doi).length || 0;
   const routeParams = useParams();
-  const path = routeParams.path ?? data?.path;
+  let path = routeParams.path ?? data?.path;
+  // Fix for legacy URLs. /Experiment-1 -> /NEES-001.groups/Experiment-1
+  if (path) path = path.includes(neesId) ? path : `/${neesId}.groups/${path}`;
 
   const [activeTab, setActiveTab] = useState<string>('files');
   useEffect(() => setActiveTab('files'), [path]);
@@ -269,7 +271,7 @@ export const NeesDetails: React.FC<{ neesId: string }> = ({ neesId }) => {
         scheme="public"
         system="nees.public"
         baseRoute="."
-        path={path ?? ''}
+        path={`${path}` ?? ''}
         scroll={{ y: 500 }}
       />
     </>

--- a/client/modules/datafiles/src/nees/NeesDetails.tsx
+++ b/client/modules/datafiles/src/nees/NeesDetails.tsx
@@ -271,7 +271,7 @@ export const NeesDetails: React.FC<{ neesId: string }> = ({ neesId }) => {
         scheme="public"
         system="nees.public"
         baseRoute="."
-        path={`${path}` ?? ''}
+        path={path ?? ''}
         scroll={{ y: 500 }}
       />
     </>


### PR DESCRIPTION
## Overview: ##
Some DOIs have links to NEES projects that aren't compatible with the routing in the relaunched portal. This diff reformats the paths so that the listing will display.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-33](https://tacc-main.atlassian.net/browse/WC-33)

## Summary of Changes: ##

## Testing Steps: ##
1. Visit https://designsafe.dev/data/browser/public/nees.public/NEES-2010-0921.groups/Experiment-3 and confirm that you get a listing and not an error.
