### PR TITLE
task/WC-62: respect line breaks in project/entity descriptions

### DIFF
--- a/client/modules/datafiles/src/projects/BaseProjectDetails.tsx
+++ b/client/modules/datafiles/src/projects/BaseProjectDetails.tsx
@@ -446,7 +446,7 @@ export const BaseProjectDetails: React.FC<{
       {projectValue.description && (
         <DescriptionExpander>
           <strong>Description: </strong>
-          {projectValue.description}
+          <p className="render-linebreaks">{projectValue.description}</p>
         </DescriptionExpander>
       )}
     </section>

--- a/client/modules/datafiles/src/projects/PublishedEntityDetails.tsx
+++ b/client/modules/datafiles/src/projects/PublishedEntityDetails.tsx
@@ -221,7 +221,7 @@ export const PublishedEntityDetails: React.FC<{
       </table>
       <DescriptionExpander>
         <strong>Description: </strong>
-        {entityValue.description}
+        <p className="render-linebreaks">{entityValue.description}</p>
       </DescriptionExpander>
     </section>
   );

--- a/client/modules/datafiles/src/projects/SubEntityDetails.tsx
+++ b/client/modules/datafiles/src/projects/SubEntityDetails.tsx
@@ -159,7 +159,9 @@ export const SubEntityDetails: React.FC<{
       </table>
       <DescriptionExpander>
         <strong>Description: </strong>
-        {entityValue.description || '(N/A)'}
+        <p className="render-linebreaks">
+          {entityValue.description || '(N/A)'}
+        </p>
       </DescriptionExpander>
     </section>
   );

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -107,6 +107,10 @@
   flex: 2;
 }
 
+.render-linebreaks {
+  white-space: pre-line;
+}
+
 .inner-form-item {
   margin-bottom: 0;
 }


### PR DESCRIPTION
## Overview: ##
Add a CSS class to render linebreaks in project descriptions.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-62](https://tacc-main.atlassian.net/browse/WC-62)

<img width="751" alt="image" src="https://github.com/user-attachments/assets/7397dc3d-b12a-4e6c-a655-5278c5ba03c6">

