### PR TITLE
Quick: Force collapse dropdowns to render before being activated

### DIFF
--- a/client/modules/datafiles/src/projects/ProjectCollapser/ProjectCollapser.tsx
+++ b/client/modules/datafiles/src/projects/ProjectCollapser/ProjectCollapser.tsx
@@ -33,6 +33,7 @@ export const ProjectCollapse: React.FC<
       style={{ flex: 1 }}
       items={[
         {
+          forceRender: true,
           label: (
             <span>
               {DISPLAY_NAMES[entityName]} | <strong>{title}</strong>

--- a/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
@@ -292,6 +292,7 @@ export const PublishedEntityDisplay: React.FC<{
         }}
         items={[
           {
+            forceRender: true,
             label: (
               <div style={{ textAlign: 'center' }}>
                 {' '}


### PR DESCRIPTION
## Overview: ##
This is a performance enhancement- rendering tabes conditionally while opening the collapser could cause the UI to get laggy/framey.
