### PR TITLE
Quick: Redirect unauthenticated users to publications by default

### DIFF
--- a/client/src/datafiles/layouts/DataFilesBaseLayout.tsx
+++ b/client/src/datafiles/layouts/DataFilesBaseLayout.tsx
@@ -14,7 +14,7 @@ const DataFilesRoot: React.FC = () => {
   const { user } = useAuthenticatedUser();
   const defaultPath = user?.username
     ? '/tapis/designsafe.storage.default'
-    : '/tapis/designsafe.storage.community';
+    : '/public/designsafe.storage.published';
   const { pathname } = useLocation();
 
   const [notifyApi, contextHolder] = notification.useNotification();


### PR DESCRIPTION
## Overview: ##
Redirect to the publication listing instead of Community Data. when the user selects "Data Depot" from the top navbar.
