### PR TITLE
Hotfix: Fix display bug for generic FR collections from 2019

### DIFF
--- a/client/modules/datafiles/src/projects/ProjectCollapser/ProjectCollapser.tsx
+++ b/client/modules/datafiles/src/projects/ProjectCollapser/ProjectCollapser.tsx
@@ -17,8 +17,8 @@ export const ProjectCollapse: React.FC<
         if (header.length > 0) {
           const headerElement = header[0] as HTMLElement;
           headerElement.style.backgroundColor =
-            PROJECT_COLORS[entityName]['fill'];
-          headerElement.style.border = `1px solid ${PROJECT_COLORS[entityName]['outline']}`;
+            PROJECT_COLORS[entityName]?.['fill'];
+          headerElement.style.border = `1px solid ${PROJECT_COLORS[entityName]?.['outline']}`;
         }
       }
     },
@@ -36,7 +36,8 @@ export const ProjectCollapse: React.FC<
           forceRender: true,
           label: (
             <span>
-              {DISPLAY_NAMES[entityName]} | <strong>{title}</strong>
+              {DISPLAY_NAMES[entityName] ?? 'Collection'} |{' '}
+              <strong>{title}</strong>
             </span>
           ),
           children,

--- a/client/modules/datafiles/src/projects/ProjectTree/ProjectTree.tsx
+++ b/client/modules/datafiles/src/projects/ProjectTree/ProjectTree.tsx
@@ -137,8 +137,8 @@ const RecursiveTree: React.FC<{
         <div
           className={styles['tree-list-badge']}
           style={{
-            backgroundColor: PROJECT_COLORS[treeData.name].fill,
-            outline: `1px solid ${PROJECT_COLORS[treeData.name].outline}`,
+            backgroundColor: PROJECT_COLORS[treeData.name]?.fill,
+            outline: `1px solid ${PROJECT_COLORS[treeData.name]?.outline}`,
           }}
         >
           {DISPLAY_NAMES[treeData.name]}

--- a/client/modules/datafiles/src/projects/constants.ts
+++ b/client/modules/datafiles/src/projects/constants.ts
@@ -17,6 +17,8 @@ export const SIMULATION_MODEL = 'designsafe.project.simulation.model';
 export const SIMULATION_INPUT = 'designsafe.project.simulation.input';
 export const SIMULATION_OUTPUT = 'designsafe.project.simulation.output';
 // Field Research
+export const FIELD_RECON_COLLECTION =
+  'designsafe.project.field_recon.collection';
 export const FIELD_RECON_MISSION = 'designsafe.project.field_recon.mission';
 export const FIELD_RECON_REPORT = 'designsafe.project.field_recon.report';
 export const FIELD_RECON_SOCIAL_SCIENCE =
@@ -72,6 +74,7 @@ export const PROJECT_COLORS: Record<string, { outline: string; fill: string }> =
     [HYBRID_SIM_SIM_SUBSTRUCTURE]: { outline: '#BD5717', fill: '#EBCCB9' },
     [HYBRID_SIM_SIM_OUTPUT]: { outline: '#B59300', fill: '#ECE4BF' },
 
+    [FIELD_RECON_COLLECTION]: { outline: '#43A59D', fill: '#CAE9E6' },
     [FIELD_RECON_REPORT]: { outline: '#cccccc', fill: '#f5f5f5' },
     [FIELD_RECON_MISSION]: { outline: '#000000', fill: '#ffffff' },
     [FIELD_RECON_GEOSCIENCE]: { outline: '#43A59D', fill: '#CAE9E6' },
@@ -191,6 +194,7 @@ export const DISPLAY_NAMES: Record<string, string> = {
   [HYBRID_SIM_SIM_OUTPUT]: 'Simulation Output',
   // Field Recon
   [FIELD_RECON_MISSION]: 'Mission',
+  [FIELD_RECON_COLLECTION]: 'Collection',
   [FIELD_RECON_GEOSCIENCE]: 'Geoscience Collection',
   [FIELD_RECON_SOCIAL_SCIENCE]: 'Social Science Collection',
   [FIELD_RECON_REPORT]: 'Document Collection',


### PR DESCRIPTION
## Overview: ##
The `designsafe.project.field_recon.collection` entity type wasn't supported in the frontend and would cause an exception when trying to look up its display attributes.