### PR TITLE
Quick: fix case when `job.tags` is null

### DIFF
--- a/client/modules/_hooks/src/workspace/types.ts
+++ b/client/modules/_hooks/src/workspace/types.ts
@@ -192,7 +192,7 @@ export type TTapisJob = {
   stageAppTransactionId?: string;
   status: string;
   subscriptions: string;
-  tags: string[];
+  tags: string[] | null;
   tapisQueue: string;
   tenant: string;
   uuid: string;

--- a/client/modules/workspace/src/utils/jobs.ts
+++ b/client/modules/workspace/src/utils/jobs.ts
@@ -68,7 +68,7 @@ export function getOutputPath(job: TTapisJob) {
 }
 
 export function isInteractiveJob(job: TTapisJob) {
-  return job.tags.includes('isInteractive');
+  return job.tags?.includes('isInteractive');
 }
 
 export function getJobInteractiveSessionInfo(


### PR DESCRIPTION
## Overview: ##

Handle case where `job.tags` is `null`.

## PR Status: ##

* [X] Ready.

## Testing Steps:
1. Comment out https://github.com/DesignSafe-CI/portal/blob/6f5520c7f5bb0aa0c3489d0438a60ff1fbac4207/designsafe/apps/workspace/api/views.py#L781-L784
2. Submit a non-interactive job
3. Confirm that "View Details" modal works properly