### PR TITLE
WP-707: Data Depot Toolbar updates

### DIFF
--- a/client/modules/datafiles/src/DatafilesToolbar/DatafilesToolbar.tsx
+++ b/client/modules/datafiles/src/DatafilesToolbar/DatafilesToolbar.tsx
@@ -83,6 +83,11 @@ export const DatafilesToolbar: React.FC<{ searchInput?: React.ReactNode }> = ({
 
   const rules = useMemo(
     function () {
+      // Check if none of the selected files end with `.hazmapper`.
+      const notContainingHazmapperFile = selectedFiles.every(
+        (file) => !file.path.endsWith('.hazmapper')
+      );
+
       // Rules for which toolbar buttons are active for a given selection.
       return {
         canPreview:
@@ -91,26 +96,24 @@ export const DatafilesToolbar: React.FC<{ searchInput?: React.ReactNode }> = ({
           user &&
           selectedFiles.length === 1 &&
           !isReadOnly &&
-          !selectedFiles[0].path.endsWith('.hazmapper'),
+          notContainingHazmapperFile,
         canCopy:
-          user &&
-          selectedFiles.length >= 1 &&
-          !selectedFiles[0].path.endsWith('.hazmapper'),
+          user && selectedFiles.length >= 1 && notContainingHazmapperFile,
         canMove:
           user &&
           selectedFiles.length >= 1 &&
           !isReadOnly &&
-          !selectedFiles[0].path.endsWith('.hazmapper'),
+          notContainingHazmapperFile,
         canTrash:
           user &&
           selectedFiles.length >= 1 &&
           !isReadOnly &&
-          !selectedFiles[0].path.endsWith('.hazmapper'),
+          notContainingHazmapperFile,
         // Disable downloads from frontera.work until we have a non-flaky mount on ds-download.
         canDownload:
           selectedFiles.length >= 1 &&
           system !== USER_WORK_SYSTEM &&
-          !selectedFiles[0].path.endsWith('.hazmapper'),
+          notContainingHazmapperFile,
       };
     },
     [selectedFiles, isReadOnly, user, system]

--- a/client/modules/datafiles/src/DatafilesToolbar/DatafilesToolbar.tsx
+++ b/client/modules/datafiles/src/DatafilesToolbar/DatafilesToolbar.tsx
@@ -98,7 +98,7 @@ export const DatafilesToolbar: React.FC<{ searchInput?: React.ReactNode }> = ({
           !selectedFiles[0].path.endsWith('.hazmapper'),
         canMove:
           user &&
-          selectedFiles.length>= 1 &&
+          selectedFiles.length >= 1 &&
           !isReadOnly &&
           !selectedFiles[0].path.endsWith('.hazmapper'),
         canTrash:

--- a/client/modules/datafiles/src/DatafilesToolbar/DatafilesToolbar.tsx
+++ b/client/modules/datafiles/src/DatafilesToolbar/DatafilesToolbar.tsx
@@ -96,6 +96,11 @@ export const DatafilesToolbar: React.FC<{ searchInput?: React.ReactNode }> = ({
           user &&
           selectedFiles.length >= 1 &&
           !selectedFiles[0].path.endsWith('.hazmapper'),
+        canMove:
+          user &&
+          selectedFiles.length>= 1 &&
+          !isReadOnly &&
+          !selectedFiles[0].path.endsWith('.hazmapper'),
         canTrash:
           user &&
           selectedFiles.length >= 1 &&
@@ -138,7 +143,7 @@ export const DatafilesToolbar: React.FC<{ searchInput?: React.ReactNode }> = ({
           {({ onClick }) => (
             <ToolbarButton
               onClick={onClick}
-              disabled={!rules.canRename}
+              disabled={!rules.canMove}
               className={styles.toolbarButton}
             >
               <i role="none" className="fa fa-arrows" />


### PR DESCRIPTION
## Overview: ##
The Move button needs to allow for selecting multiple files.
All buttons needs to handle if a .hazmapper file is anywhere in the selected files, not just the first file in the array.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-707](https://tacc-main.atlassian.net/browse/WP-707)

## Summary of Changes: ##

## Testing Steps: ##
1. Check that selecting multiple files in a project within the project.
2. Check that selecting multiple files in a publication does not enable the Move action.
3. Check that selecting a hazmapper file does not allow rename/move/copy/trash/download, no matter if it was the first or later file selected in a multiselect.

## UI Photos:

## Notes: ##
