### PR TITLE
Hotfix: Onboarding acls and notifications

### DIFF
--- a/client/modules/workspace/src/AppsSubmissionDetails/AppsSubmissionDetails.tsx
+++ b/client/modules/workspace/src/AppsSubmissionDetails/AppsSubmissionDetails.tsx
@@ -259,7 +259,7 @@ export const AppsSubmissionDetails: React.FC<{
             htmlType="submit"
             disabled={!isValid}
             loading={isSubmitting}
-            style={{ width: 140 }}
+            style={{ width: 150 }}
           >
             {definition.notes.isInteractive ? 'Launch Session' : 'Submit Job'}
           </PrimaryButton>

--- a/client/modules/workspace/src/AppsSubmissionDetails/AppsSubmissionDetails.tsx
+++ b/client/modules/workspace/src/AppsSubmissionDetails/AppsSubmissionDetails.tsx
@@ -259,7 +259,7 @@ export const AppsSubmissionDetails: React.FC<{
             htmlType="submit"
             disabled={!isValid}
             loading={isSubmitting}
-            style={{ width: 130 }}
+            style={{ width: 140 }}
           >
             {definition.notes.isInteractive ? 'Launch Session' : 'Submit Job'}
           </PrimaryButton>

--- a/client/modules/workspace/src/Toast/Toast.tsx
+++ b/client/modules/workspace/src/Toast/Toast.tsx
@@ -30,11 +30,13 @@ const Notifications = () => {
   const handleNotification = (notification: TJobStatusNotification) => {
     switch (notification.event_type) {
       case 'interactive_session_ready':
-        setInteractiveModalDetails({
-          ...interactiveModalDetails,
-          interactiveSessionLink: notification.action_link,
-          message: notification.message,
-        });
+        if (interactiveModalDetails.show) {
+          setInteractiveModalDetails({
+            ...interactiveModalDetails,
+            interactiveSessionLink: notification.action_link,
+            message: notification.message,
+          });
+        }
       /* falls through */
       case 'job':
         queryClient.invalidateQueries({
@@ -47,7 +49,7 @@ const Notifications = () => {
           message: (
             <Flex justify="space-between">
               {getToastMessage(notification)}
-              <RightOutlined style={{ marginRight: -5 }} />
+              <RightOutlined style={{ marginRight: -5, marginLeft: 10 }} />
             </Flex>
           ),
           placement: 'bottomLeft',
@@ -90,7 +92,7 @@ const Notifications = () => {
     if (lastMessage !== null) {
       handleNotification(JSON.parse(lastMessage.data));
     }
-  }, [lastMessage, handleNotification]);
+  }, [lastMessage]);
 
   return contextHolder;
 };

--- a/designsafe/static/scripts/ng-designsafe/components/notification-badge/notification-badge.component.html
+++ b/designsafe/static/scripts/ng-designsafe/components/notification-badge/notification-badge.component.html
@@ -27,7 +27,7 @@
                       {{x.datetime| date:'h:mm a'}}
                   </dt>
                   <dd class="item-info">
-                    <span>{{x.message}}</span>
+                    <span>{{x.message || "Interactive session ready to view."}}</span>
                     <div ng-if="x.extra.path" uib-tooltip="{{x.extra.path}}" tooltip-trigger="{{{true: 'mouseenter', false: 'never'}[x.extra.path.length > 44]}}">
                       <div id="notif-path">
                         <bdi>{{x.extra.path}}</bdi>


### PR DESCRIPTION
## Overview: ##

- Fixes an issue where an `interactive_session_ready` notification would result in an infinite loop
  - Cosmetic adjustments for interactive session ready jobs
- Fixes an issue where credentials were not being made for `designsafe.storage.default` for new users

## PR Status: ##

* [X] Ready.

## Testing Steps: ##
1. Submit an interactive job and confirm all functions normally once session is ready
2. Delete your user credentials for `designsafe.storage.default` with the `wma_prtl` user. (You can do this locally via `get_service_account_client()` and the [removeUserCredential](https://tapis-project.github.io/live-docs/?service=Systems#tag/Credentials/operation/removeUserCredential) endpoint
3. Log in anew, and confirm the onboarding steps succeed and you have access to your My Data
