### PR TITLE
fix: add RENDER_REACT to designsave.sample.env

### DIFF
--- a/conf/env_files/designsafe.sample.env
+++ b/conf/env_files/designsafe.sample.env
@@ -1,7 +1,7 @@
 ###
 # Set to `True` to enable React (e.g. the Workspace)
 #
-REACT_RENDER=True
+RENDER_REACT=True
 
 ###
 # Set to `True` to enable Django DEBUG mode.

--- a/conf/env_files/designsafe.sample.env
+++ b/conf/env_files/designsafe.sample.env
@@ -1,5 +1,10 @@
 ###
-# Set to "True" to enable Django DEBUG mode.
+# Set to `True` to enable React (e.g. the Workspace)
+#
+REACT_RENDER=True
+
+###
+# Set to `True` to enable Django DEBUG mode.
 # https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-DEBUG
 #
 DJANGO_DEBUG=True


### PR DESCRIPTION
## Overview: ##

Add missing setting.

## PR Status: ##

* [X] Ready.

## Related: ##

* follow-up to #1472

## Summary of Changes: ##

* **add** `REACT_RENDER` to `designsafe.sample.env`

## Testing Steps: ##

1. Run project.
2. Visit (`/rw/`)`workspace`.
3. Verify app loads.

## UI Photos:

Skipped.