### PR TITLE
fix: DSAPP-57 alignment of app card hazard tags

### DIFF
--- a/designsafe/static/styles/app-card.css
+++ b/designsafe/static/styles/app-card.css
@@ -1,7 +1,7 @@
 /* STRUCTURE */
 
 /* To load most structure from Core-Styles */
-@import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@enhance/DSAPP-57-limit-height-of-app-card-desc/dist/components/c-app-card.css");
+@import url("https://cdn.jsdelivr.net/npm/@tacc/core-styles@v2.35.0/dist/components/c-app-card.css");
 
 
 

--- a/designsafe/static/styles/app-card.css
+++ b/designsafe/static/styles/app-card.css
@@ -1,7 +1,7 @@
 /* STRUCTURE */
 
 /* To load most structure from Core-Styles */
-@import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@v2.26.0/dist/components/c-app-card.css");
+@import url("https://cdn.jsdelivr.net/gh/TACC/core-styles@enhance/DSAPP-57-limit-height-of-app-card-desc/dist/components/c-app-card.css");
 
 
 
@@ -23,6 +23,11 @@
 .c-app-card__desc {
     padding-inline: 1.5rem;
     margin-block: 1.5rem;
+}
+/* To set height to twice line-height */
+/* SEE: ./app-page.css#L34-L36 (circa v7.1.4) */
+.s-app-page p.c-app-card__desc {
+    height: 3.6em;
 }
 
 /* Types */


### PR DESCRIPTION
## Overview: ##

Fix alignment of gray box of hazard tags on an app card on Tools & Apps page.

## PR Status: ##

* [X] Ready.

> [!IMPORTANT]
> To self:
> 1. If approved, publish page (to activate [snippet](https://designsafe-ci.org/admin/djangocms_snippet/snippet/21/change/)).
> 2. If deployed, delete [snippet](https://designsafe-ci.org/admin/djangocms_snippet/snippet/21/change/).

## Related Jira tickets: ##

* [DSAPP-57](https://tacc-main.atlassian.net/browse/DSAPP-57)
* requires https://github.com/TACC/Core-Styles/pull/405

## Summary of Changes: ##

* **changed** version of Core-Styles for `c-app-card`
* **added** forced height on `c-app-card` description

## Testing Steps: ##

1. Replicate layout on prod with code from this branch:
    - **A**: [snippet](https://designsafe-ci.org/admin/djangocms_snippet/snippet/21/change/) and [top 3 simulation apps](https://designsafe-ci.org/use-designsafe/tools-applications/)
        - _Available on production in [`?edit` mode of Tools & Apps page](https://designsafe-ci.org/use-designsafe/tools-applications/?edit)._
        - _Compare to production in [`?preview&edit_off` mode of Tools & Apps page](https://designsafe-ci.org/use-designsafe/tools-applications/?preview&edit_off)._
    - **B**: Update dev CMS with prod CMS and deploy this branch.
    - **C**: Reconstruct it locally… (have fun with that).
2. Change window width and/or zoom until you have:
    - one column "Simulation" full width
    - three columns of cards:
        - one has **two**-line gray box, **one**-line desc
        - one has **one**-line gray box, **one**-line desc
        - one has **one**-line gray box, **two**-line desc
3. Verify alignment of gray boxes is consistent.

## UI Photos:

| before | after |
| - | - |
| <img width="960" alt="before" src="https://github.com/user-attachments/assets/6839353c-f01b-4586-8f00-39573b24b8f6"> | <img width="960" alt="after" src="https://github.com/user-attachments/assets/2e304e40-70ff-414d-aba0-ae768fff0481"> |

## Notes: ##

<details><summary>Snippet to Replicate this Change</summary>

```html
<style id="css-dsapp-57-fix-app-card-hazard-alignment">
/* https://github.com/DesignSafe-CI/portal/pull/1474/files#diff-4fc2ef0ac0e52e3482998ece7245f66b5fe995dace36982b98a561f73a723283R4 */
@import url("https://cdn.jsdelivr.net/npm/@tacc/core-styles@v2.35.0/dist/components/c-app-card.css");

/* https://github.com/DesignSafe-CI/portal/pull/1474/files#diff-4fc2ef0ac0e52e3482998ece7245f66b5fe995dace36982b98a561f73a723283R27-R31 */
.c-app-card__desc {
    height: 3.6em;
}
</style>
```

</details> 