### PR TITLE
enhance(client): html-app-container css

### DIFF
--- a/client/src/workspace/layouts/AppsViewLayout.tsx
+++ b/client/src/workspace/layouts/AppsViewLayout.tsx
@@ -60,7 +60,7 @@ export const AppsViewLayout: React.FC = () => {
             </Flex>
           </Header>
           {htmlApp ? (
-            <div className={styles['overflow']}>
+            <div className={`${styles['overflow']} ${styles['html-app-container']}`}>
               {parse(htmlApp.html as string)}
             </div>
           ) : (

--- a/client/src/workspace/layouts/AppsViewLayout.tsx
+++ b/client/src/workspace/layouts/AppsViewLayout.tsx
@@ -60,7 +60,9 @@ export const AppsViewLayout: React.FC = () => {
             </Flex>
           </Header>
           {htmlApp ? (
-            <div className={`${styles['overflow']} ${styles['html-app-container']}`}>
+            <div
+              className={`${styles['overflow']} ${styles['html-app-container']}`}
+            >
               {parse(htmlApp.html as string)}
             </div>
           ) : (

--- a/client/src/workspace/layouts/layout.module.css
+++ b/client/src/workspace/layouts/layout.module.css
@@ -14,6 +14,12 @@
   overflow: auto;
 }
 
+.html-app-container {
+  & p {
+    margin-block: 1em 2em;
+  }
+}
+
 .appDetail-placeholder-message {
   display: flex;
   justify-content: center;

--- a/designsafe/static/styles/ng-designsafe.css
+++ b/designsafe/static/styles/ng-designsafe.css
@@ -1074,8 +1074,3 @@ i[class^="icon-ls-pre/post"]:before,
 :root {
     color-scheme: only light !important;
 }
-
-.html-app-container {
-    padding: 30px !important;
-    margin-top: 20px !important;
-}


### PR DESCRIPTION
## Overview: ##

Move and change `.html-app-container` CSS.

## PR Status: ##

* [X] Ready.

> [!NOTE]
> After prod deploy, delete `<style …>…</style>` from HTML of each such variant. (See "Notes".)

## Related Jira tickets: ##

* [DSAPP-60](https://tacc-main.atlassian.net/browse/DSAPP-60)

## Summary of Changes: ##

- **delete** old global styles
- **add** new styles (and put them where they are used)

## Testing Steps: ##

> [!WARNING]
> Not deployed to dev. To test, do so locally.

1. Run/Deploy site.
2. Create/Have an app with a variant that has "HTML" e.g. [EE-UQ (dev admin)](https://designsafeci-dev.tacc.utexas.edu/admin/workspace/applistingentry/22/change/).
3. Open that variant in the workspace e.g. [EE-UQ (dev workspace)](https://designsafeci-dev.tacc.utexas.edu/workspace/eeuq).
4. Verify class `._html-app-container_...` is on the wrapper div (from workspace code).
5. Verify `<p>`’s inside have extra margin (`margin-block: 1em 2em`).

## UI Photos: ##

| Before | After |
| - | - |
| <img width="920" alt="BEFORE - paragraphs" src="https://github.com/user-attachments/assets/7ee766c4-6f95-4f6f-b16f-2b115cad7007"> | <img width="920" alt="AFTER - paragraphs" src="https://github.com/user-attachments/assets/aa4c0dfd-b88f-4094-96f3-ca0af2dee805"> |
| <img width="920" alt="BEFORE - container" src="https://github.com/user-attachments/assets/e3506f9f-68fb-4238-b7b1-f7ba4a533fc1"> | <img width="920" alt="AFTER - container" src="https://github.com/user-attachments/assets/4889afb0-4956-4048-a8ce-e0df41a7cb0c"> |

## Notes: ##

The result on existing app entry variants HML is uglier, but the new styles are meant for the new  HTML, which is already on prod e.g. [EE-UQ (prod)](https://designsafe-ci.org/workspace/eeuq).

<details><summary>I hacked the styles onto production by including them in the "HTML" of every such app variant.</summary><img width="920" alt="PROD - hack" src="https://github.com/user-attachments/assets/c6a773e8-3cbd-4a7c-bbda-a4569a17b6ce"></details>

[Stakeholder has been asked to review.](https://designsafe-ci.slack.com/archives/G5YKB9KMH/p1729030234113579)