### PR TITLE
Hotfix: Resolve onboarding mkdir race condition

### DIFF
--- a/designsafe/apps/auth/tasks.py
+++ b/designsafe/apps/auth/tasks.py
@@ -71,7 +71,7 @@ def check_or_configure_system_and_user_directory(
                 logger.info(
                     f"Directory for user={username} on system={system_id}/{path} exists and works. "
                 )
-            except (NotFoundError, ForbiddenError, UnauthorizedError) as e:
+            except (NotFoundError, ForbiddenError, UnauthorizedError):
                 logger.info(
                     "Ensuring directory exists for user=%s then going to run setfacl on system=%s path=%s",
                     username,
@@ -80,9 +80,11 @@ def check_or_configure_system_and_user_directory(
                 )
 
                 tg458981_client = get_tg458981_client()
-                if isinstance(e, NotFoundError):
-                    tg458981_client.files.mkdir(systemId=system_id, path=path)
 
+                # Create directory, resolves NotFoundError
+                tg458981_client.files.mkdir(systemId=system_id, path=path)
+
+                # Set ACLs, resolves UnauthorizedError and ForbiddenError
                 tg458981_client.files.setFacl(
                     systemId=system_id,
                     path=path,


### PR DESCRIPTION
## Overview: ##

Resolve race condition where the `setfacl` step in onboarding fails because the `mkdir` command has not been run. Instead of resolving each error individually, resolve all each time. No error is thrown if the particular issue has already been resolved and is "re-resolved".

## PR Status: ##

* [X] Ready.
