### PR TITLE
task/WP-698: NCO text search made case insensitive

### DIFF
--- a/client/modules/datafiles/src/nees/NeesDetails.tsx
+++ b/client/modules/datafiles/src/nees/NeesDetails.tsx
@@ -117,10 +117,10 @@ export const NeesDetails: React.FC<{ neesId: string }> = ({ neesId }) => {
                   <td>
                     {exp.creators
                       ? exp.creators?.map((c) => (
-                        <div key={c.lastName}>
-                          {c.firstName} {c.lastName}
-                        </div>
-                      ))
+                          <div key={c.lastName}>
+                            {c.firstName} {c.lastName}
+                          </div>
+                        ))
                       : 'No Creators Listed'}
                   </td>
                 </tr>
@@ -212,16 +212,16 @@ export const NeesDetails: React.FC<{ neesId: string }> = ({ neesId }) => {
                   <td>
                     {exp.material
                       ? exp.material?.map((mat) => (
-                        <div key={mat.component}>
-                          <div>{mat.component}:</div>
-                          <div>
-                            {mat.materials?.map((mats) => (
-                              <div key={mats}>{mats}</div>
-                            ))}
+                          <div key={mat.component}>
+                            <div>{mat.component}:</div>
+                            <div>
+                              {mat.materials?.map((mats) => (
+                                <div key={mats}>{mats}</div>
+                              ))}
+                            </div>
+                            <br />
                           </div>
-                          <br />
-                        </div>
-                      ))
+                        ))
                       : 'No Materials Listed  '}
                   </td>
                 </tr>
@@ -297,10 +297,10 @@ export const NeesDetails: React.FC<{ neesId: string }> = ({ neesId }) => {
                   <td className={styles['nees-td']}>
                     {neesProjectData?.pis
                       ? neesProjectData?.pis.map((u) => (
-                        <div key={u.lastName}>
-                          {u.firstName} {u.lastName}
-                        </div>
-                      ))
+                          <div key={u.lastName}>
+                            {u.firstName} {u.lastName}
+                          </div>
+                        ))
                       : 'No PIs Listed'}
                   </td>
                 </tr>
@@ -313,10 +313,10 @@ export const NeesDetails: React.FC<{ neesId: string }> = ({ neesId }) => {
                   <td className={styles['nees-td']}>
                     {neesProjectData?.organization
                       ? neesProjectData?.organization.map((u) => (
-                        <div key={u.name}>
-                          {u.name} {u.state}, {u.country}
-                        </div>
-                      ))
+                          <div key={u.name}>
+                            {u.name} {u.state}, {u.country}
+                          </div>
+                        ))
                       : 'No Organizations Listed'}
                   </td>
                 </tr>
@@ -347,12 +347,12 @@ export const NeesDetails: React.FC<{ neesId: string }> = ({ neesId }) => {
                   <td className={styles['nees-td']}>
                     {neesProjectData?.sponsor
                       ? neesProjectData?.sponsor?.map((u) => (
-                        <div key={u.name}>
-                          <Link to={u.url} key={u.name}>
-                            {u.name}
-                          </Link>
-                        </div>
-                      ))
+                          <div key={u.name}>
+                            <Link to={u.url} key={u.name}>
+                              {u.name}
+                            </Link>
+                          </div>
+                        ))
                       : 'No Sponsors Listed'}
                   </td>
                 </tr>

--- a/client/modules/datafiles/src/nees/NeesDetails.tsx
+++ b/client/modules/datafiles/src/nees/NeesDetails.tsx
@@ -117,10 +117,10 @@ export const NeesDetails: React.FC<{ neesId: string }> = ({ neesId }) => {
                   <td>
                     {exp.creators
                       ? exp.creators?.map((c) => (
-                          <div key={c.lastName}>
-                            {c.firstName} {c.lastName}
-                          </div>
-                        ))
+                        <div key={c.lastName}>
+                          {c.firstName} {c.lastName}
+                        </div>
+                      ))
                       : 'No Creators Listed'}
                   </td>
                 </tr>
@@ -212,16 +212,16 @@ export const NeesDetails: React.FC<{ neesId: string }> = ({ neesId }) => {
                   <td>
                     {exp.material
                       ? exp.material?.map((mat) => (
-                          <div key={mat.component}>
-                            <div>{mat.component}:</div>
-                            <div>
-                              {mat.materials?.map((mats) => (
-                                <div key={mats}>{mats}</div>
-                              ))}
-                            </div>
-                            <br />
+                        <div key={mat.component}>
+                          <div>{mat.component}:</div>
+                          <div>
+                            {mat.materials?.map((mats) => (
+                              <div key={mats}>{mats}</div>
+                            ))}
                           </div>
-                        ))
+                          <br />
+                        </div>
+                      ))
                       : 'No Materials Listed  '}
                   </td>
                 </tr>
@@ -297,10 +297,10 @@ export const NeesDetails: React.FC<{ neesId: string }> = ({ neesId }) => {
                   <td className={styles['nees-td']}>
                     {neesProjectData?.pis
                       ? neesProjectData?.pis.map((u) => (
-                          <div key={u.lastName}>
-                            {u.firstName} {u.lastName}
-                          </div>
-                        ))
+                        <div key={u.lastName}>
+                          {u.firstName} {u.lastName}
+                        </div>
+                      ))
                       : 'No PIs Listed'}
                   </td>
                 </tr>
@@ -313,10 +313,10 @@ export const NeesDetails: React.FC<{ neesId: string }> = ({ neesId }) => {
                   <td className={styles['nees-td']}>
                     {neesProjectData?.organization
                       ? neesProjectData?.organization.map((u) => (
-                          <div key={u.name}>
-                            {u.name} {u.state}, {u.country}
-                          </div>
-                        ))
+                        <div key={u.name}>
+                          {u.name} {u.state}, {u.country}
+                        </div>
+                      ))
                       : 'No Organizations Listed'}
                   </td>
                 </tr>
@@ -347,12 +347,12 @@ export const NeesDetails: React.FC<{ neesId: string }> = ({ neesId }) => {
                   <td className={styles['nees-td']}>
                     {neesProjectData?.sponsor
                       ? neesProjectData?.sponsor?.map((u) => (
-                          <div key={u.name}>
-                            <Link to={u.url} key={u.name}>
-                              {u.name}
-                            </Link>
-                          </div>
-                        ))
+                        <div key={u.name}>
+                          <Link to={u.url} key={u.name}>
+                            {u.name}
+                          </Link>
+                        </div>
+                      ))
                       : 'No Sponsors Listed'}
                   </td>
                 </tr>

--- a/designsafe/apps/nco/managers/ttc_grants.py
+++ b/designsafe/apps/nco/managers/ttc_grants.py
@@ -42,9 +42,9 @@ class NcoTtcGrantsManager(object):
             query['Type'] = params['grant_type']
         if params['text_search']:
             query['$or'] = [
-                {'Title': {'$regex': params['text_search']}},
-                {'Abstract': {'$regex': params['text_search']}},
-                {'PiName': {'$regex': params['text_search']}},
+                {'Title': {'$regex': params['text_search'], '$options': 'i'}},
+                {'Abstract': {'$regex': params['text_search'], '$options': 'i'}},
+                {'PiName': {'$regex': params['text_search'], '$options': 'i'}},
             ]
 
         #get the grants list


### PR DESCRIPTION
## Overview: ##
Mongodb queries by default are case insensitive, and NCO requested, if possible, for it to be made case-insensitive.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-698](https://tacc-main.atlassian.net/browse/WP-698)

## Summary of Changes: ##
Added "i" flag to the regex queries that are part of the text search field to make them case-insensitive.

## Testing Steps: ##
1. Page is here: [local-url]/nco/ttc_grants
2. search for "simpson" and "Simpson" should show the same results.  Clear the search between attempts to make sure you're seeing the search happen.  Also note that you have to click the search button manually for the search to happen.

## UI Photos:

## Notes: ##
Need to be on the vpn for the connection to the nco mongodb to work.
Also, this solution will work, but if the database grows much larger, this could cause the searches to become slow.  However, due to how the search needs to be run, there's no way around this from my research.