### PR TITLE
Task/WC-125:  Create/update projects index for V3

### DIFF
--- a/designsafe/apps/api/projects_v2/elasticsearch.py
+++ b/designsafe/apps/api/projects_v2/elasticsearch.py
@@ -22,14 +22,17 @@ class IndexedProject(Document):
 
 def index_project(project_id):
     """Util to index a project by its project ID"""
+    project_meta = ProjectMetadata.get_project_by_id(project_id)
     project_tree = add_values_to_tree(project_id)
     project_json = nx.node_link_data(project_tree)
     try:
         pub_es = IndexedProject.get(project_id)
-        pub_es.update(**project_json)
+        pub_es.update(**project_json, uuid=project_meta.uuid, value=project_meta.value)
 
     except NotFoundError:
-        pub_es = IndexedProject(**project_json)
+        pub_es = IndexedProject(
+            **project_json, uuid=project_meta.uuid, value=project_meta.value
+        )
         pub_es.meta["id"] = project_id
         pub_es.save()
 

--- a/designsafe/apps/api/projects_v2/elasticsearch.py
+++ b/designsafe/apps/api/projects_v2/elasticsearch.py
@@ -1,0 +1,40 @@
+"""Elasticsearch model for published works"""
+
+from elasticsearch_dsl import Document
+from elasticsearch.exceptions import NotFoundError
+import networkx as nx
+from django.conf import settings
+from designsafe.apps.api.projects_v2.models import ProjectMetadata
+from designsafe.apps.api.projects_v2.operations.project_publish_operations import (
+    add_values_to_tree,
+)
+
+
+class IndexedProject(Document):
+    """Elasticsearch model for published works"""
+
+    # pylint: disable=too-few-public-methods
+    class Index:
+        """Index meta settings"""
+
+        name = settings.ES_INDICES["projects_v2"]["alias"]
+
+
+def index_project(project_id):
+    """Util to index a project by its project ID"""
+    project_tree = add_values_to_tree(project_id)
+    project_json = nx.node_link_data(project_tree)
+    try:
+        pub_es = IndexedProject.get(project_id)
+        pub_es.update(**project_json)
+
+    except NotFoundError:
+        pub_es = IndexedProject(**project_json)
+        pub_es.meta["id"] = project_id
+        pub_es.save()
+
+
+def reindex_projects():
+    """Reindex all projects"""
+    for prj in ProjectMetadata.objects.filter(name="designsafe.project"):
+        index_project(prj.project_id)

--- a/designsafe/apps/api/projects_v2/tasks.py
+++ b/designsafe/apps/api/projects_v2/tasks.py
@@ -18,6 +18,7 @@ from designsafe.apps.api.projects_v2.operations.project_publish_operations impor
 from designsafe.apps.api.projects_v2.operations.project_archive_operations import (
     archive_publication_async,
 )
+from designsafe.apps.api.projects_v2.elasticsearch import reindex_projects
 from designsafe.libs.common.context_managers import AsyncTaskContext
 
 
@@ -65,3 +66,10 @@ def alert_sensitive_data(project_id, username):
                 [admin],
                 html_message=email_body,
             )
+
+
+@shared_task()
+def reindex_projects_async():
+    """Async wrapper around project reindex util"""
+    with AsyncTaskContext():
+        reindex_projects()

--- a/designsafe/apps/api/publications_v2/elasticsearch.py
+++ b/designsafe/apps/api/publications_v2/elasticsearch.py
@@ -21,9 +21,9 @@ def index_publication(project_id):
     pub = Publication.objects.get(project_id=project_id)
     try:
         pub_es = IndexedPublication.get(project_id)
-        pub_es.update(**pub.tree)
+        pub_es.update(**pub.tree, created=pub.created)
 
     except NotFoundError:
-        pub_es = IndexedPublication(**pub.tree)
+        pub_es = IndexedPublication(**pub.tree, created=pub.created)
         pub_es.meta["id"] = project_id
         pub_es.save()

--- a/designsafe/celery.py
+++ b/designsafe/celery.py
@@ -31,7 +31,7 @@ app.conf.update(
             'schedule': crontab(minute=0, hour=0),
         },
         'reindex_projects': {
-            'task': 'designsafe.apps.api.tasks.reindex_projects',
+            'task': 'designsafe.apps.api.projects_v2.tasks.reindex_projects_async',
             'schedule': crontab(hour=0, minute=0)
         },
         'clear_old_notifications': {

--- a/designsafe/settings/elasticsearch_settings.py
+++ b/designsafe/settings/elasticsearch_settings.py
@@ -51,7 +51,7 @@ ES_INDICES = {
     'projects_v2': {
         'alias': ES_INDEX_PREFIX.format('projects_v2'),
         'document': 'designsafe.apps.api.projects_v2.elasticsearch.IndexedProject',
-        'kwargs': {}
+        'kwargs': {"index.mapping.ignore_malformed": True} # Squash malformed date fields
     },
     'web_content': {
         'alias': ES_INDEX_PREFIX.format('web-content'),

--- a/designsafe/settings/elasticsearch_settings.py
+++ b/designsafe/settings/elasticsearch_settings.py
@@ -48,6 +48,11 @@ ES_INDICES = {
         'document': 'designsafe.apps.api.publications_v2.elasticsearch.IndexedPublication',
         'kwargs': {}
     },
+    'projects_v2': {
+        'alias': ES_INDEX_PREFIX.format('projects_v2'),
+        'document': 'designsafe.apps.api.projects_v2.elasticsearch.IndexedProject',
+        'kwargs': {}
+    },
     'web_content': {
         'alias': ES_INDEX_PREFIX.format('web-content'),
         'document': 'designsafe.apps.data.models.elasticsearch.IndexedCMSPage',

--- a/designsafe/settings/test_settings.py
+++ b/designsafe/settings/test_settings.py
@@ -696,6 +696,11 @@ ES_INDICES = {
         'document': 'designsafe.apps.api.publications_v2.elasticsearch.IndexedPublication',
         'kwargs': {}
     },
+    'projects_v2': {
+        'alias': ES_INDEX_PREFIX.format('projects_v2'),
+        'document': 'designsafe.apps.api.projects_v2.elasticsearch.IndexedProject',
+        'kwargs': {"index.mapping.ignore_malformed": True} # Squash malformed date fields
+    },
     'web_content': {
         'alias': ES_INDEX_PREFIX.format('web-content'),
         'document': 'designsafe.apps.data.models.elasticsearch.IndexedCMSPage',


### PR DESCRIPTION
## Overview: ##
Create/update an index of published projects so that the Data team can run analyses.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-125](https://tacc-main.atlassian.net/browse/WC-125)

## Summary of Changes: ##

## Testing Steps: ##
```
from django.conf import settings
from designsafe.libs.elasticsearch.indices import setup_index
from designsafe.apps.api.projects_v2.elasticsearch import reindex_projects

prj_conf = settings.ES_INDICES['projects_v2']
setup_index(prj_conf, force=True)
reindex_projects()
```

## UI Photos:

## Notes: ##
