### PR TITLE
task/WP-718: NCO Search includes Co-PIs

### DIFF
--- a/designsafe/apps/nco/managers/ttc_grants.py
+++ b/designsafe/apps/nco/managers/ttc_grants.py
@@ -45,6 +45,7 @@ class NcoTtcGrantsManager(object):
                 {'Title': {'$regex': params['text_search'], '$options': 'i'}},
                 {'Abstract': {'$regex': params['text_search'], '$options': 'i'}},
                 {'PiName': {'$regex': params['text_search'], '$options': 'i'}},
+                {'CoPiNames': {'$regex': params['text_search'], '$options': 'i'}},
             ]
 
         #get the grants list

--- a/designsafe/static/scripts/nco/components/nco-ttc-grants/nco-ttc-grants.template.html
+++ b/designsafe/static/scripts/nco/components/nco-ttc-grants/nco-ttc-grants.template.html
@@ -36,7 +36,7 @@
         </form>
         <!--text input-->
         <form class="filter-group ttc-text-search">
-            <label for="ttc-text-search">Search Title/Abstract/PI Name:</label>
+            <label for="ttc-text-search">Search Title/Abstract/PI/Co-PI:</label>
             <input type="text" name="ttc-text-search" ng-model="$ctrl.textSearch" />
         </form>
         <br />


### PR DESCRIPTION
## Overview: ##
Adding in Co-PIs to the searchable fields for the text search

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-718](https://tacc-main.atlassian.net/browse/WP-718)

## Summary of Changes: ##
Updated label for text search
Added Co-PI field to db query

## Testing Steps: ##
1. Go to /nco/ttc_grants
2. Look in the listing for a Co-PI in one of the rows, then search on that name.
3. Test with and without capitalization, meaning the search should be case-insensitive.
4. Test on a Co-PI that has a comma after their last name, to double check that the search returns that listing.
5. Example: 'millea`/'Millea' should return 1 result

## UI Photos:

## Notes: ##
Sometimes on local dev, the searches take a bit to respond and update the page and it won't look like anything is happening.  If you've run a search and nothing is changing, give it a bit and it should update.