### PR TITLE
task/WI-221: Add retry decorator and retry system access steps during onboarding

### DIFF
--- a/designsafe/apps/onboarding/steps/system_access_v3.py
+++ b/designsafe/apps/onboarding/steps/system_access_v3.py
@@ -156,7 +156,7 @@ class SystemAccessStepV3(AbstractStep):
             system_id = system["system_id"]
             path = system["path"].format(username=self.user.username)
             try:
-                self.check_system(system_id, path)
+                self.check_system(system_id, path, skip_retry=True)
                 self.log(
                     f"Path and permissions already created for system: {system_id} and path: {path} for user: {self.user.username}"
                 )

--- a/designsafe/libs/common/decorators.py
+++ b/designsafe/libs/common/decorators.py
@@ -24,33 +24,35 @@ def deprecated(func):
         warnings.warn(
             "Call to deprecated function {}.".format(func.__name__),
             category=DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
         return func(*args, **kwargs)
+
     return new_func
+
 
 def profile(func):
     @functools.wraps(func)
     def decorated_function(*args, **kwargs):
-        if getattr(settings, 'PORTAL_PROFILE', False):
+        if getattr(settings, "PORTAL_PROFILE", False):
             prf = cProfile.Profile()
             prf.enable()
             resp = func(*args, **kwargs)
             prf.disable()
 
-            stats_dirpath = os.path.join(os.path.dirname(__file__), '../../../stats')
+            stats_dirpath = os.path.join(os.path.dirname(__file__), "../../../stats")
             spec = inspect.getargspec(func)
-            if spec.args and spec.args[0] == 'self':
+            if spec.args and spec.args[0] == "self":
                 _self = args[0]
                 clsname = _self.__class__.__name__
                 modulename = _self.__module__
                 funcname = func.__name__
-                filename = '{}.{}.{}'.format(modulename, clsname, funcname)
+                filename = "{}.{}.{}".format(modulename, clsname, funcname)
                 request = args[1]
             else:
                 modulename = func.__module__
                 funcname = func.__name__
-                filename = '{}.{}'.format(modulename, funcname)
+                filename = "{}.{}".format(modulename, funcname)
                 request = args[0]
 
             filename = re.sub(r"[^a-zA-Z0-9\_\-]", "_", filename)
@@ -59,15 +61,15 @@ def profile(func):
             if not os.path.isdir(stats_dirpath):
                 os.mkdir(stats_dirpath)
 
-            if os.path.isfile(filepath + '.stats'):
-                filename += '_{}'.format(str(time.time()))
+            if os.path.isfile(filepath + ".stats"):
+                filename += "_{}".format(str(time.time()))
                 filepath = os.path.join(stats_dirpath, filename)
 
-            filepath_prof = filepath + '.prof'
-            filepath_stats = filepath + '.stats'
+            filepath_prof = filepath + ".prof"
+            filepath_stats = filepath + ".stats"
 
             prf.dump_stats(filepath_prof)
-            with open(filepath_stats, 'w+') as flo:
+            with open(filepath_stats, "w+") as flo:
                 if isinstance(request, HttpRequest):
                     flo.write(
                         """Request path: {path}
@@ -76,9 +78,10 @@ def profile(func):
                         """.format(
                             path=request.path,
                             post=request.POST.dict(),
-                            get=request.GET.dict())
+                            get=request.GET.dict(),
                         )
-                prfs = pstats.Stats(prf, stream=flo).sort_stats('cumtime')
+                    )
+                prfs = pstats.Stats(prf, stream=flo).sort_stats("cumtime")
                 prfs.print_stats()
         else:
             resp = func(*args, **kwargs)
@@ -86,3 +89,48 @@ def profile(func):
         return resp
 
     return decorated_function
+
+
+def retry(exc: Exception, tries=4, delay=3, backoff=2, max_time=10 * 60):
+    """
+    A decorator that retries a function call with exponential backoff in case of an exception.
+
+    Note: Pass skip_retry=True to the function to skip the retry logic.
+
+    Args:
+        exc (Exception): The exception to catch and retry on.
+        tries (int, optional): The maximum number of attempts. Defaults to 4.
+        delay (int, optional): The initial delay between retries in seconds. Defaults to 3.
+        backoff (int, optional): The multiplier applied to the delay after each retry. Defaults to 2.
+        max_time (int, optional): The maximum time to retry in seconds. Defaults to 10*60 == 10 minutes.
+
+    Returns:
+        function: A decorator that wraps the function with retry logic.
+
+    Example:
+        @retry(ValueError, tries=3, delay=2, backoff=2, max_time=5*60)
+        def test_function():
+            # function implementation
+    """
+
+    def deco_retry(func):
+
+        @functools.wraps(func)
+        def f_retry(*args, **kwargs):
+            if kwargs.get("skip_retry"):
+                return func(*args, **kwargs)
+            mtries, mdelay, mmax_time = tries, delay, max_time
+            while mtries and mmax_time > 0:
+                try:
+                    return func(*args, **kwargs)
+                except exc:
+                    logger.warning(f"{str(exc)}, Retrying in {mdelay} seconds...")
+                    time.sleep(mdelay)
+                    mtries -= 1
+                    mdelay *= backoff
+                    mmax_time -= mdelay
+            return func(*args, **kwargs)
+
+        return f_retry
+
+    return deco_retry


### PR DESCRIPTION
## Overview: ##

Add `retry` decorator, and retry steps during System Access step known to be time-sensitive.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WI-221](https://tacc-main.atlassian.net/browse/WI-221)

## Testing Steps: ##
1. Create a test user and delete their 'My Data'
2. Run the System Access step
3. Confirm that the step retries while the setfacl command is being run, until it succeeds.


Relevant logs showing retry
```
des_workers        | [DJANGO] $(processName)s INFO 2024-11-13 20:19:16,515 receivers designsafe.apps.api.notifications.receivers.send_setup_event:53: Sending setup event through websocket
des_workers        | [DJANGO] WARNING 2024-11-13 20:19:17,574 decorators designsafe.libs.common.decorators.f_retry:127: <class 'tapipy.errors.UnauthorizedError'>, Retrying in 3 seconds...
des_workers        | [DJANGO] $(processName)s WARNING 2024-11-13 20:19:17,574 decorators designsafe.libs.common.decorators.f_retry:127: <class 'tapipy.errors.UnauthorizedError'>, Retrying in 3 seconds...
des_workers        | [DJANGO] WARNING 2024-11-13 20:19:21,846 decorators designsafe.libs.common.decorators.f_retry:127: <class 'tapipy.errors.UnauthorizedError'>, Retrying in 6 seconds...
des_workers        | [DJANGO] $(processName)s WARNING 2024-11-13 20:19:21,846 decorators designsafe.libs.common.decorators.f_retry:127: <class 'tapipy.errors.UnauthorizedError'>, Retrying in 6 seconds...
des_workers        | [DJANGO] INFO 2024-11-13 20:19:30,155 system_access_v3 designsafe.apps.onboarding.steps.system_access_v3.process:165: Ensuring directory exists for user=sal_test then going to run setfacl on system=designsafe.storage.default path=sal_test
```