### PR TITLE
task/DSAPP-77,  task/WA-363:  Remote Job Id & Interactive Session Modal handling

### DIFF
--- a/client/modules/_hooks/src/workspace/useInteractiveModalContext.ts
+++ b/client/modules/_hooks/src/workspace/useInteractiveModalContext.ts
@@ -5,6 +5,7 @@ type TInteractiveModalDetails = {
   interactiveSessionLink?: string;
   message?: string;
   openedBySubmit?: boolean;
+  uuid?: string;
 };
 
 export type TInteractiveModalContext = [

--- a/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
+++ b/client/modules/workspace/src/AppsSubmissionForm/AppsSubmissionForm.tsx
@@ -379,7 +379,11 @@ export const AppsSubmissionForm: React.FC = () => {
     } else if (isSuccess) {
       reset(initialValues);
       if (definition.notes.isInteractive) {
-        setInteractiveModalDetails({ show: true, openedBySubmit: true });
+        setInteractiveModalDetails({
+          show: true,
+          openedBySubmit: true,
+          uuid: submitResult.uuid,
+        });
       }
     }
   }, [submitResult]);

--- a/client/modules/workspace/src/JobsDetailModal/JobsDetailModal.tsx
+++ b/client/modules/workspace/src/JobsDetailModal/JobsDetailModal.tsx
@@ -80,6 +80,7 @@ export const JobsDetailModalBody: React.FC<{
       ></Collapse>
     ),
     ...(jobData.remoteOutcome && { 'Remote Outcome': jobData.remoteOutcome }),
+    ...(jobData.remoteJobId && { 'Remote Job ID': jobData.remoteJobId }),
   };
 
   if (jobData.remoteOutcome) {

--- a/client/modules/workspace/src/JobsListing/JobsListing.tsx
+++ b/client/modules/workspace/src/JobsListing/JobsListing.tsx
@@ -75,6 +75,7 @@ const InteractiveSessionButtons: React.FC<{
             show: true,
             interactiveSessionLink,
             message,
+            uuid: uuid,
           })
         }
       >

--- a/client/modules/workspace/src/Toast/Toast.tsx
+++ b/client/modules/workspace/src/Toast/Toast.tsx
@@ -11,7 +11,7 @@ import {
   useInteractiveModalContext,
   TInteractiveModalContext,
 } from '@client/hooks';
-import { getToastMessage } from '../utils';
+import { getToastMessage, isTerminalState } from '../utils';
 import styles from './Notifications.module.css';
 
 const Notifications = () => {
@@ -63,6 +63,17 @@ const Notifications = () => {
             navigate('/history');
           },
         });
+
+        // close interactive session modal if job is ended
+        if (
+          isTerminalState(notification.extra.status) &&
+          notification.extra.uuid === interactiveModalDetails.uuid
+        ) {
+          setInteractiveModalDetails({
+            show: false,
+          });
+        }
+
         break;
       case 'markAllNotificationsAsRead':
         // update unread count state


### PR DESCRIPTION
## Overview: ##

- Displays remote job id (slurm job id) in job detail modals, if it exists
- Closes interactive session modal if job webhook comes back with failed status

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [DSAPP-77](https://tacc-main.atlassian.net/browse/DSAPP-77)
* [WA-363](https://tacc-main.atlassian.net/browse/WA-363)

## Testing Steps: ##
1. Go to https://designsafe.dev/rw/workspace/history and confirm `Remote Job Id` displays for jobs that are past the queuing stage
2. Submit an interactive job with a runtime of 10 minutes, then confirm the modal closes itself once the job ends

## UI Photos:

![Screenshot 2024-11-14 at 1 25 43 PM](https://github.com/user-attachments/assets/603c1561-225c-4290-8723-10ee56422bd7)

