### PR TITLE
WA-343: App Form - label update for interactive session

### DIFF
--- a/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
+++ b/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
@@ -19,6 +19,7 @@ import {
   getExecSystemsFromApp,
   getExecSystemFromId,
   getAppQueueValues,
+  getAppRuntimeLabel,
   getQueueValueForExecSystem,
   getQueueMaxMinutes,
   isAppTypeBATCH,
@@ -187,7 +188,7 @@ export const getConfigurationFields = (
 
   if (definition.jobType === 'BATCH' && !definition.notes.hideQueue) {
     configurationFields['execSystemLogicalQueue'] = {
-      description: 'Select the queue this job will execute on.',
+      description: `Select the queue this ${getAppRuntimeLabel(definition)} will execute on.`,
       label: 'Queue',
       name: 'configuration.execSystemLogicalQueue',
       key: 'configuration.execSystemLogicalQueue',
@@ -203,7 +204,7 @@ export const getConfigurationFields = (
   if (definition.jobType === 'BATCH' && !definition.notes.hideAllocation) {
     configurationFields['allocation'] = {
       description:
-        'Select the project allocation you would like to use with this job submission.',
+        `Select the project allocation you would like to use with this ${getAppRuntimeLabel(definition)} submission.`,
       label: 'Allocation',
       name: 'configuration.allocation',
       key: 'configuration.allocation',
@@ -221,12 +222,12 @@ export const getConfigurationFields = (
 
   if (!definition.notes.hideMaxMinutes) {
     configurationFields['maxMinutes'] = {
-      description: `The maximum number of minutes you expect this job to run for. Maximum possible is ${getQueueMaxMinutes(
+      description: `The maximum number of minutes you expect this ${getAppRuntimeLabel(definition)} to run for. Maximum possible is ${getQueueMaxMinutes(
         definition,
         defaultExecSystem,
         queue?.name
-      )} minutes. After this amount of time your job will end. Shorter run times result in shorter queue wait times.`,
-      label: 'Maximum Job Runtime (minutes)',
+      )} minutes. After this amount of time your ${getAppRuntimeLabel(definition)} will end. Shorter run times result in shorter queue wait times.`,
+      label: `Maximum ${getAppRuntimeLabel(definition, true)} Runtime (minutes)`,
       name: 'configuration.maxMinutes',
       key: 'configuration.maxMinutes',
       required: true,

--- a/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
+++ b/client/modules/workspace/src/AppsWizard/AppsFormSchema.ts
@@ -188,7 +188,9 @@ export const getConfigurationFields = (
 
   if (definition.jobType === 'BATCH' && !definition.notes.hideQueue) {
     configurationFields['execSystemLogicalQueue'] = {
-      description: `Select the queue this ${getAppRuntimeLabel(definition)} will execute on.`,
+      description: `Select the queue this ${getAppRuntimeLabel(
+        definition
+      )} will execute on.`,
       label: 'Queue',
       name: 'configuration.execSystemLogicalQueue',
       key: 'configuration.execSystemLogicalQueue',
@@ -203,8 +205,9 @@ export const getConfigurationFields = (
 
   if (definition.jobType === 'BATCH' && !definition.notes.hideAllocation) {
     configurationFields['allocation'] = {
-      description:
-        `Select the project allocation you would like to use with this ${getAppRuntimeLabel(definition)} submission.`,
+      description: `Select the project allocation you would like to use with this ${getAppRuntimeLabel(
+        definition
+      )} submission.`,
       label: 'Allocation',
       name: 'configuration.allocation',
       key: 'configuration.allocation',
@@ -222,12 +225,19 @@ export const getConfigurationFields = (
 
   if (!definition.notes.hideMaxMinutes) {
     configurationFields['maxMinutes'] = {
-      description: `The maximum number of minutes you expect this ${getAppRuntimeLabel(definition)} to run for. Maximum possible is ${getQueueMaxMinutes(
+      description: `The maximum number of minutes you expect this ${getAppRuntimeLabel(
+        definition
+      )} to run for. Maximum possible is ${getQueueMaxMinutes(
         definition,
         defaultExecSystem,
         queue?.name
-      )} minutes. After this amount of time your ${getAppRuntimeLabel(definition)} will end. Shorter run times result in shorter queue wait times.`,
-      label: `Maximum ${getAppRuntimeLabel(definition, true)} Runtime (minutes)`,
+      )} minutes. After this amount of time your ${getAppRuntimeLabel(
+        definition
+      )} will end. Shorter run times result in shorter queue wait times.`,
+      label: `Maximum ${getAppRuntimeLabel(
+        definition,
+        true
+      )} Runtime (minutes)`,
       name: 'configuration.maxMinutes',
       key: 'configuration.maxMinutes',
       required: true,

--- a/client/modules/workspace/src/utils/apps.ts
+++ b/client/modules/workspace/src/utils/apps.ts
@@ -508,3 +508,21 @@ export const getOnDemandEnvVariables = (
   );
   return includeOnDemandVars;
 };
+
+/**
+ * Returns 'interactive session' as app type if it is interactive, otherwise 'job'
+ * 
+ * @param definition - TTapisApp
+ * @param titleCase - boolean, default is false.
+ * @returns string
+ */
+export const getAppRuntimeLabel = (definition: TTapisApp, titleCase: boolean = false): string => {
+  const label = definition.notes.isInteractive ? 'interactive session' : 'job';
+  
+  return titleCase
+    ? label
+        .split(' ')
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ')
+    : label;
+};

--- a/client/modules/workspace/src/utils/apps.ts
+++ b/client/modules/workspace/src/utils/apps.ts
@@ -511,18 +511,21 @@ export const getOnDemandEnvVariables = (
 
 /**
  * Returns 'interactive session' as app type if it is interactive, otherwise 'job'
- * 
+ *
  * @param definition - TTapisApp
  * @param titleCase - boolean, default is false.
  * @returns string
  */
-export const getAppRuntimeLabel = (definition: TTapisApp, titleCase: boolean = false): string => {
+export const getAppRuntimeLabel = (
+  definition: TTapisApp,
+  titleCase: boolean = false
+): string => {
   const label = definition.notes.isInteractive ? 'interactive session' : 'job';
-  
+
   return titleCase
     ? label
         .split(' ')
-        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
         .join(' ')
     : label;
 };


### PR DESCRIPTION
## Overview: ##
This PR clairifies the text in App Form to differentiate between interactive app vs all other apps.
The label of max job runtime and references to job are changed to "interactive session".

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

[WA-343](https://tacc-main.atlassian.net/browse/WA-343)

## Summary of Changes: ##

## Testing Steps: ##
1. View app form for interactive app: https://www.designsafe-ci.org/workspace/qgis-s3?appVersion=3.34.4
2. View app form for regular app: https://designsafe.dev/rw/workspace/mpm?appVersion=1.1.0

## UI Photos:

![Screenshot 2024-11-14 at 4 34 15 PM](https://github.com/user-attachments/assets/bbc86e3a-9bdc-4849-b52a-9ee61d560d9a)

## Notes: ##
