### PR TITLE
Quick: Fix long filenames showing up as ellipsis

### DIFF
--- a/client/modules/datafiles/src/FileListing/FileListing.module.css
+++ b/client/modules/datafiles/src/FileListing/FileListing.module.css
@@ -1,3 +1,3 @@
 .file-listing-table td {
-    overflow: hidden;
+  overflow: hidden;
 }

--- a/client/modules/datafiles/src/FileListing/FileListing.module.css
+++ b/client/modules/datafiles/src/FileListing/FileListing.module.css
@@ -1,0 +1,3 @@
+.file-listing-table td {
+    overflow: hidden;
+}

--- a/client/modules/datafiles/src/FileListing/FileListing.tsx
+++ b/client/modules/datafiles/src/FileListing/FileListing.tsx
@@ -9,6 +9,7 @@ import {
 import { NavLink } from 'react-router-dom';
 import { PreviewModalBody } from '../DatafilesModal/PreviewModal';
 import { TFileListing, TFileTag, useDoiContext } from '@client/hooks';
+import styles from './FileListing.module.css';
 
 export function toBytes(bytes?: number) {
   if (bytes === 0) return '0 bytes';
@@ -53,7 +54,7 @@ export const FileListing: React.FC<
       {
         title: 'File Name',
         dataIndex: 'name',
-        ellipsis: true,
+        ellipsis: false,
         width: '50%',
         render: (data, record) => (
           <>
@@ -122,6 +123,7 @@ export const FileListing: React.FC<
   return (
     <>
       <FileListingTable
+        className={styles['file-listing-table']}
         api={api}
         system={system}
         scheme={scheme}


### PR DESCRIPTION
## Overview: ##
Fix long file names showing up as just an ellipsis

## UI Photos:
Before: 
<img width="1211" alt="image" src="https://github.com/user-attachments/assets/9aec3ceb-cca1-434f-aafc-2638c31e31b8">
After:
<img width="1072" alt="image" src="https://github.com/user-attachments/assets/5a1351b6-0b97-4f75-b833-0e4ecab77493">


## Notes: ##
