### PR TITLE
task/WI-224: Include tracking id in audit logs

### DIFF
--- a/designsafe/apps/api/datafiles/handlers.py
+++ b/designsafe/apps/api/datafiles/handlers.py
@@ -30,19 +30,19 @@ operations_mapping = {
 }
 
 
-def datafiles_get_handler(api, client, scheme, system, path, operation, username=None, **kwargs):
+def datafiles_get_handler(api, client, scheme, system, path, operation, username=None, tapis_tracking_id=None, **kwargs):
     if operation not in allowed_actions[scheme]:
         raise PermissionDenied
     op = getattr(operations_mapping[api], operation)
 
     try:
-        return op(client, system, path, username=username, **kwargs)
+        return op(client, system, path, username=username, tapis_tracking_id=tapis_tracking_id, **kwargs)
     except BaseTapyException as exc:
         raise ApiException(message=exc.message, status=500) from exc
 
 
 def datafiles_post_handler(api, username, client, scheme, system,
-                           path, operation, body=None):
+                           path, operation, body=None, tapis_tracking_id=None):
 
     if operation not in allowed_actions[scheme]:
         raise PermissionDenied
@@ -51,7 +51,7 @@ def datafiles_post_handler(api, username, client, scheme, system,
     operation in notify_actions and notify(username, operation, '{} operation has started.'.format(operation.capitalize()), 'INFO', {})
 
     try:
-        result = op(client, system, path, **body)
+        result = op(client, system, path, tapis_tracking_id=tapis_tracking_id, **body)
         operation in notify_actions and notify(username, operation, '{} operation was successful.'.format(operation.capitalize()), 'SUCCESS', result)
         return result
     except Exception as exc:
@@ -60,7 +60,7 @@ def datafiles_post_handler(api, username, client, scheme, system,
 
 
 def datafiles_put_handler(api, username, client, scheme, system,
-                          path, operation, body=None):
+                          path, operation, body=None, tapis_tracking_id=None):
     if operation not in allowed_actions[scheme]:
         raise PermissionDenied
 
@@ -68,7 +68,7 @@ def datafiles_put_handler(api, username, client, scheme, system,
     operation in notify_actions and notify(username, operation, '{} operation has started.'.format(operation.capitalize()), 'INFO', {})
 
     try:
-        result = op(client, system, path, **body)
+        result = op(client, system, path, tapis_tracking_id=tapis_tracking_id, **body)
         if operation == 'copy' and system != body.get('dest_system', None):
             notify(username, operation, 'Your file transfer request has been received and will be processed shortly.'.format(operation.capitalize()), 'SUCCESS', result)
         else:

--- a/designsafe/apps/api/datafiles/views.py
+++ b/designsafe/apps/api/datafiles/views.py
@@ -67,7 +67,7 @@ class DataFilesView(BaseApiView):
 
         try:
             response = datafiles_get_handler(
-                api, client, scheme, system, path, operation, username=request.user.username, **request.GET.dict())
+                api, client, scheme, system, path, operation, tapis_tracking_id=f"portals.{request.session.session_key}", username=request.user.username, **request.GET.dict())
             return JsonResponse(response)
         except (BoxOAuthException, DropboxAuthError, GoogleAuthError):
             raise resource_expired_handler(api)
@@ -104,7 +104,7 @@ class DataFilesView(BaseApiView):
                 raise resource_unconnected_handler(api)
 
         try:
-            response = datafiles_put_handler(api, request.user.username, client, scheme, system, path, operation, body=body)
+            response = datafiles_put_handler(api, request.user.username, client, scheme, system, path, operation, tapis_tracking_id=f"portals.{request.session.session_key}", body=body)
         except HTTPError as e:
             return JsonResponse({'message': str(e)}, status=e.response.status_code)
 
@@ -135,7 +135,7 @@ class DataFilesView(BaseApiView):
             except AttributeError:
                 raise resource_unconnected_handler(api)
 
-        response = datafiles_post_handler(api, request.user.username, client, scheme, system, path, operation, body={**post_files, **post_body})
+        response = datafiles_post_handler(api, request.user.username, client, scheme, system, path, operation, tapis_tracking_id=f"portals.{request.session.session_key}", body={**post_files, **post_body})
 
         return JsonResponse(response)
 

--- a/designsafe/apps/workspace/api/views.py
+++ b/designsafe/apps/workspace/api/views.py
@@ -561,7 +561,10 @@ class JobsView(AuthenticatedApiView):
         """Returns detailed information for a given job uuid"""
 
         job_uuid = request.GET.get("uuid")
-        data = client.jobs.getJob(jobUuid=job_uuid)
+        data = client.jobs.getJob(
+            jobUuid=job_uuid,
+            headers={"X-Tapis-Tracking-ID": f"portals.{request.session.session_key}"},
+        )
 
         return data
 
@@ -584,6 +587,7 @@ class JobsView(AuthenticatedApiView):
             skip=skip,
             orderBy="lastUpdated(desc),name(asc)",
             select="allAttributes",
+            headers={"X-Tapis-Tracking-ID": f"portals.{request.session.session_key}"},
             **kwargs,
         )
         if isinstance(data, list):
@@ -626,6 +630,7 @@ class JobsView(AuthenticatedApiView):
             orderBy="lastUpdated(desc),name(asc)",
             request_body={"search": sql_queries},
             select="allAttributes",
+            headers={"X-Tapis-Tracking-ID": f"portals.{request.session.session_key}"},
         )
         return {"listing": data, "reachedEnd": len(data) < int(limit)}
 
@@ -645,7 +650,10 @@ class JobsView(AuthenticatedApiView):
         )
         tapis = request.user.tapis_oauth.client
         job_uuid = request.GET.get("uuid")
-        data = tapis.jobs.hideJob(jobUuid=job_uuid)
+        data = tapis.jobs.hideJob(
+            jobUuid=job_uuid,
+            headers={"X-Tapis-Tracking-ID": f"portals.{request.session.session_key}"},
+        )
         return JsonResponse(
             {
                 "status": 200,
@@ -755,6 +763,9 @@ class JobsView(AuthenticatedApiView):
                 tapis.files.mkdir(
                     systemId=exec_system_id,
                     path=f"{system['home_dir'].format(tasdir)}/.tap",
+                    headers={
+                        "X-Tapis-Tracking-ID": f"portals.{request.session.session_key}"
+                    },
                 )
 
         # Add webhook subscription for job status updates
@@ -771,7 +782,10 @@ class JobsView(AuthenticatedApiView):
         ]
 
         logger.info(f"user: {username} is submitting job: {job_post}")
-        response = tapis.jobs.submitJob(**job_post)
+        response = tapis.jobs.submitJob(
+            **job_post,
+            headers={"X-Tapis-Tracking-ID": f"portals.{request.session.session_key}"},
+        )
         return response
 
     def post(self, request, *args, **kwargs):
@@ -797,7 +811,12 @@ class JobsView(AuthenticatedApiView):
                     status=400,
                 )
             tapis_operation = getattr(tapis.jobs, operation)
-            response = tapis_operation(jobUuid=job_uuid)
+            response = tapis_operation(
+                jobUuid=job_uuid,
+                headers={
+                    "X-Tapis-Tracking-ID": f"portals.{request.session.session_key}"
+                },
+            )
 
         else:
             # submit job

--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -427,7 +427,7 @@ LOGGING = {
         'metrics': {
             'format': '[METRICS] %(levelname)s %(module)s %(name)s.%(funcName)s:%(lineno)s:'
                       ' %(message)s user=%(user)s ip=%(ip)s agent=%(agent)s sessionId=%(sessionId)s op=%(operation)s'
-                      ' info=%(info)s timestamp=%(asctime)s portal=designsafe tenant=designsafe'
+                      ' info=%(info)s timestamp=%(asctime)s trackingId=portal.%(sessionId)s portal=designsafe tenant=designsafe'
         },
     },
     'handlers': {
@@ -508,7 +508,7 @@ TAS_URL = os.environ.get('TAS_URL', None)
 ALLOCATIONS_TO_EXCLUDE = (
     os.environ.get("ALLOCATIONS_TO_EXCLUDE", "").split(",")
     if os.environ.get("ALLOCATIONS_TO_EXCLUDE")
-    else ["DesignSafe-DCV"]
+    else ["DesignSafe-DCV,DesignSafe-Corral"]
 )
 
 


### PR DESCRIPTION
## Overview: ##

Includes audit tracking id in audit logs, and sets as `X-Tapis-Tracking-Id` header in tapipy jobs requests.

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [task/WI-224](https://tacc-main.atlassian.net/browse/task/WI-224)
