### PR TITLE
Hotfix: Ensure all datafiles operations accept kwargs

### DIFF
--- a/designsafe/apps/api/datafiles/operations/box_operations.py
+++ b/designsafe/apps/api/datafiles/operations/box_operations.py
@@ -60,14 +60,14 @@ def copy(client, src_system, src_path, dest_system, dest_path, filetype='file', 
 
     return {}
 
-def download_bytes(client, system, path):
+def download_bytes(client, system, path, *args, **kwargs):
     filename = client.file(path).get().name
     resp = client.file(path).content()
     result = io.BytesIO(resp)
     result.name = filename
     return result
 
-def upload(client, system, path, uploaded_file):
+def upload(client, system, path, uploaded_file, *args, **kwargs):
     if not path:
         folder = client.root_folder()
     else:
@@ -76,7 +76,7 @@ def upload(client, system, path, uploaded_file):
     folder.upload_stream(uploaded_file, file_name=uploaded_file.name)
     return {}
 
-def mkdir(client, system, path, dirname):
+def mkdir(client, system, path, dirname, *args, **kwargs):
     if not path:
         folder = client.root_folder()
     else:

--- a/designsafe/apps/api/datafiles/operations/dropbox_operations.py
+++ b/designsafe/apps/api/datafiles/operations/dropbox_operations.py
@@ -81,7 +81,7 @@ def preview(client, system, path, *args, **kwargs):
     return {'href': url, 'fileType': file_type}
 
 
-def copy(client, src_system, src_path, dest_system, dest_path, filename, filetype='file', *args):
+def copy(client, src_system, src_path, dest_system, dest_path, filename, filetype='file', *args, **kwargs):
     if src_path and not src_path.startswith('/'):
         src_path = '/' + src_path
     if dest_path and not dest_path.startswith('/'):
@@ -93,7 +93,7 @@ def copy(client, src_system, src_path, dest_system, dest_path, filename, filetyp
     return {}
 
 
-def download_bytes(client, system, path):
+def download_bytes(client, system, path, *args, **kwargs):
     if not path.startswith('/'):
         path = '/' + path
     (meta, response) = client.files_download(path)
@@ -103,7 +103,7 @@ def download_bytes(client, system, path):
     return result
 
 
-def upload(client, system, path, uploaded_file):
+def upload(client, system, path, uploaded_file, *args, **kwargs):
     if path and not path.startswith('/'):
         path = '/' + path
     upload_path = '{}/{}'.format(path, uploaded_file.name).replace('//', '/')
@@ -111,7 +111,7 @@ def upload(client, system, path, uploaded_file):
     return {}
 
 
-def mkdir(client, system, path, dirname):
+def mkdir(client, system, path, dirname, *args, **kwargs):
     if path and not path.startswith('/'):
         path = '/' + path
     folder_path = '{}/{}'.format(path, dirname).replace('//', '/')

--- a/designsafe/apps/api/datafiles/operations/googledrive_operations.py
+++ b/designsafe/apps/api/datafiles/operations/googledrive_operations.py
@@ -78,7 +78,7 @@ def upload(client, system, path, uploaded_file, *args, **kwargs):
     client.files().create(body=file_meta, media_body=media).execute()
 
 
-def mkdir(client, system, path, dir_name):
+def mkdir(client, system, path, dir_name, *args, **kwargs):
     if not path:
         path = 'root'
     file_metadata = {
@@ -150,7 +150,7 @@ def preview(client, system, path, *args, **kwargs):
     return {'href': url, 'fileType': file_type}
 
 
-def copy(client, src_system, src_path, dest_system, dest_path, filename, filetype='file', *args):
+def copy(client, src_system, src_path, dest_system, dest_path, filename, filetype='file', *args, **kwargs):
     from designsafe.apps.api.datafiles.operations.transfer_operations import transfer, transfer_folder
     if not src_path:
         src_path = 'root'

--- a/designsafe/apps/api/datafiles/operations/tapis_operations.py
+++ b/designsafe/apps/api/datafiles/operations/tapis_operations.py
@@ -201,7 +201,7 @@ def download(client, system, path=None, paths=None, *args, **kwargs):
     return {"href": f"https://designsafe-download01.tacc.utexas.edu/download/{download_key}"}
 
 
-def mkdir(client, system, path, dir_name):
+def mkdir(client, system, path, dir_name, *args, **kwargs):
     """Create a new directory.
 
     Params
@@ -226,7 +226,8 @@ def mkdir(client, system, path, dir_name):
     agave_indexer.apply_async(kwargs={'systemId': system,
                                       'filePath': path,
                                       'recurse': False},
-                              queue='indexing')
+                              queue='indexing',
+                              headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id")})
     return {"result": "OK"}
 
 
@@ -577,7 +578,7 @@ def preview(client, system, path, href="", max_uses=3, lifetime=600, *args, **kw
     return {'href': url, 'fileType': file_type, 'fileMeta': meta}
 
 
-def download_bytes(client, system, path):
+def download_bytes(client, system, path, *args, **kwargs):
     """Creates a postit pointing to this file.
 
     Params


### PR DESCRIPTION
## Overview: ##
Datafiles operations can now receive a tapis tracking id as a keyword arg, so they need to have their function signatures updated to accept that argument without raising an exception.
