### PR TITLE
Quick: fix error when logging metrics on jobs push keys response

### DIFF
--- a/designsafe/apps/auth/backends.py
+++ b/designsafe/apps/auth/backends.py
@@ -23,32 +23,10 @@ logger = logging.getLogger(__name__)
 @receiver(user_logged_out)
 def on_user_logged_out(sender, request, user, **kwargs):
     "Signal processor for user_logged_out"
-    backend = request.session.get("_auth_user_backend", None)
-    tas_backend_name = "%s.%s" % (TASBackend.__module__, TASBackend.__name__)
-    tapis_backend_name = "%s.%s" % (
-        TapisOAuthBackend.__module__,
-        TapisOAuthBackend.__name__,
-    )
 
-    if backend == tas_backend_name:
-        login_provider = "TACC"
-    elif backend == tapis_backend_name:
-        login_provider = "TACC"
-
-    logger.info(
-        "Revoking tapis token: %s",
-        TapisOAuthToken().get_masked_token(user.tapis_oauth.access_token),
-    )
-    backend = TapisOAuthBackend()
-    TapisOAuthBackend.revoke(backend, user.tapis_oauth.access_token)
-
-    logout_message = (
-        "<h4>You are Logged Out!</h4>"
-        "You are now logged out of DesignSafe! However, you may still "
-        f"be logged in at {login_provider}. To ensure security, you should close your "
-        "browser to end all authenticated sessions."
-    )
-    messages.warning(request, logout_message)
+    if user is not None and hasattr(user, "tapis_oauth"):
+        backend = TapisOAuthBackend()
+        TapisOAuthBackend.revoke(backend, user.tapis_oauth.access_token)
 
 
 class TASBackend(ModelBackend):

--- a/designsafe/apps/workspace/api/views.py
+++ b/designsafe/apps/workspace/api/views.py
@@ -786,6 +786,22 @@ class JobsView(AuthenticatedApiView):
             **job_post,
             headers={"X-Tapis-Tracking-ID": f"portals.{request.session.session_key}"},
         )
+
+        METRICS.info(
+            "Jobs",
+            extra={
+                "user": username,
+                "sessionId": getattr(request.session, "session_key", ""),
+                "operation": "submitJob",
+                "agent": request.META.get("HTTP_USER_AGENT"),
+                "ip": get_client_ip(request),
+                "info": {
+                    "body": body,
+                    "response": response.__dict__ if response else None,
+                },
+            },
+        )
+
         return response
 
     def post(self, request, *args, **kwargs):
@@ -817,25 +833,25 @@ class JobsView(AuthenticatedApiView):
                     "X-Tapis-Tracking-ID": f"portals.{request.session.session_key}"
                 },
             )
+            METRICS.info(
+                "Jobs",
+                extra={
+                    "user": username,
+                    "sessionId": getattr(request.session, "session_key", ""),
+                    "operation": operation,
+                    "agent": request.META.get("HTTP_USER_AGENT"),
+                    "ip": get_client_ip(request),
+                    "info": {
+                        "body": body,
+                        "response": response.__dict__ if response else None,
+                    },
+                },
+            )
 
         else:
             # submit job
             response = self._submit_job(request, body, tapis, username)
 
-        METRICS.info(
-            "Jobs",
-            extra={
-                "user": username,
-                "sessionId": getattr(request.session, "session_key", ""),
-                "operation": operation,
-                "agent": request.META.get("HTTP_USER_AGENT"),
-                "ip": get_client_ip(request),
-                "info": {
-                    "body": body,
-                    "response": response.__dict__ if response else None,
-                },
-            },
-        )
 
         return JsonResponse(
             {


### PR DESCRIPTION
## Overview: ##
- Fixes an error where METRICS logging would fail when attempting to log the tapis response in the case where the response is a "push keys" signal sent to the frontend from the portal jobs api
- Cleans up the logout backend: primarily addressing a rare error where the `user` object is `None`

## PR Status: ##

* [X] Ready.

## Testing Steps: ##
1. Submit a job for a system where you need credentials
2. Confirm process works normally, and metrics log successfully
