### PR TITLE
Quick: Prevent null value from being passed as Tapis tracking ID

### DIFF
--- a/designsafe/apps/api/datafiles/operations/tapis_operations.py
+++ b/designsafe/apps/api/datafiles/operations/tapis_operations.py
@@ -48,7 +48,7 @@ def listing(client, system, path, offset=0, limit=100, q=None, *args, **kwargs):
                                          path=(path or '/'),
                                          offset=int(offset),
                                          limit=int(limit),
-                                         headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id")})
+                                         headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
 
     try:
         # Convert file objects to dicts for serialization.
@@ -84,7 +84,7 @@ def detail(client, system, path, *args, **kwargs):
     """
     Retrieve the uuid for a file by parsing the query string in _links.metadata.href
     """
-    _listing = client.files.listFiles(systemId=system, path=urllib.parse.quote(path), offset=0, limit=1, headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id")})
+    _listing = client.files.listFiles(systemId=system, path=urllib.parse.quote(path), offset=0, limit=1, headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
     f = _listing[0]
     listing_res = {
             'system': system,
@@ -227,7 +227,7 @@ def mkdir(client, system, path, dir_name, *args, **kwargs):
                                       'filePath': path,
                                       'recurse': False},
                               queue='indexing',
-                              headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id")})
+                              headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
     return {"result": "OK"}
 
 
@@ -262,7 +262,7 @@ def move(client, src_system, src_path, dest_system, dest_path, *args, **kwargs):
                           path=src_path,
                           operation="MOVE",
                           newPath=dest_path_full,
-                          headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id")})
+                          headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
     
     move_file_meta_async.delay(src_system, src_path, dest_system, dest_path_full)
 
@@ -325,7 +325,7 @@ def copy(client, src_system, src_path, dest_system, dest_path, *args, **kwargs):
                                             path=src_path,
                                             operation="COPY",
                                             newPath=full_dest_path,
-                                            headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id")})
+                                            headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
     else:
         src_url = f'tapis://{src_system}/{src_path}'
         dest_url = f'tapis://{dest_system}/{full_dest_path}'
@@ -333,7 +333,7 @@ def copy(client, src_system, src_path, dest_system, dest_path, *args, **kwargs):
         copy_response = client.files.createTransferTask(elements=[{
             'sourceURI': src_url,
             'destinationURI': dest_url
-        }], headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id")})
+        }], headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
         copy_result = {
             'uuid': copy_response.uuid,
             'status': copy_response.status,
@@ -369,7 +369,7 @@ def copy(client, src_system, src_path, dest_system, dest_path, *args, **kwargs):
 def delete(client, system, path, *args, **kwargs):
     return client.files.delete(systemId=system,
                                filePath=urllib.parse.quote(path),
-                               headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id")})
+                               headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
 
 def rename(client, system, path, new_name, *args, **kwargs):
     """Renames a file. This is performed under the hood by moving the file to
@@ -403,7 +403,7 @@ def rename(client, system, path, new_name, *args, **kwargs):
                           path=path,
                           operation="MOVE",
                           newPath=new_path,
-                          headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id")})
+                          headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
 
     move_file_meta_async.delay(system, path, system, new_path)
 
@@ -448,7 +448,7 @@ def trash(client, system, path, trash_path, *args, **kwargs):
     except tapipy.errors.NotFoundError:
         mkdir(client, system, trash_root, trash_foldername)
 
-    resp = move(client, system, path, system, trash_path, headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id")})
+    resp = move(client, system, path, system, trash_path, headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
 
     return resp
 
@@ -489,7 +489,7 @@ def upload(client, system, path, uploaded_file, webkit_relative_path=None, *args
     response_json = client.files.insert(systemId=system,   
                                         path=dest_path, 
                                         file=uploaded_file, 
-                                        headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id")})
+                                        headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
     return {"result": "OK"}
     agave_indexer.apply_async(kwargs={'systemId': system,
                                       'filePath': path,
@@ -549,7 +549,7 @@ def preview(client, system, path, href="", max_uses=3, lifetime=600, *args, **kw
     except FileMetaModel.DoesNotExist:
         meta = {}
 
-    postit_result = client.files.createPostIt(systemId=system, path=path, allowedUses=max_uses, validSeconds=lifetime, headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id")})
+    postit_result = client.files.createPostIt(systemId=system, path=path, allowedUses=max_uses, validSeconds=lifetime, headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
     url = postit_result.redeemUrl
 
     if file_ext in settings.SUPPORTED_TEXT_PREVIEW_EXTS:

--- a/designsafe/apps/api/datafiles/operations/tapis_operations.py
+++ b/designsafe/apps/api/datafiles/operations/tapis_operations.py
@@ -448,7 +448,7 @@ def trash(client, system, path, trash_path, *args, **kwargs):
     except tapipy.errors.NotFoundError:
         mkdir(client, system, trash_root, trash_foldername)
 
-    resp = move(client, system, path, system, trash_path, headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
+    resp = move(client, system, path, system, trash_path, tapis_tracking_id=kwargs.get("tapis_tracking_id", ""))
 
     return resp
 


### PR DESCRIPTION
## Overview: ##
If tracking ID isn't passed, default to an empty string. Null values produce errors in Tapis.
