### PR TITLE
Quick: Remove expensive prefix filter from Elasticsearch file queries

### DIFF
--- a/designsafe/apps/api/datafiles/operations/tapis_operations.py
+++ b/designsafe/apps/api/datafiles/operations/tapis_operations.py
@@ -157,11 +157,13 @@ def search(client, system, path, offset=0, limit=100, query_string='', **kwargs)
 
     if not path.startswith('/'):
         path = '/' + path
-    if not path.endswith('/'):
-        path = path + '/'
+
+    path = f"/{path.strip('/')}"
+
     search = IndexedFile.search()
     search = search.query(ngram_query | match_query)
-    search = search.filter('prefix', **{'path._exact': path})
+    if path != '/':
+        search = search.filter('term', **{'path._comps': path})
     search = search.filter('term', **{'system._exact': system})
     search = search.extra(from_=int(offset), size=int(limit))
     res = search.execute()
@@ -219,7 +221,7 @@ def mkdir(client, system, path, dir_name, *args, **kwargs):
     -------
     dict
     """
-    path_input = str(Path(path) / Path(dir_name))
+    path_input = str(Path(path) / Path(dir_name)).rstrip(" ")
     client.files.mkdir(systemId=system, path=path_input)
 
 


### PR DESCRIPTION
## Overview: ##
This might be related to recent cluster upgrades, but search in the Data Depot has gotten really slow due to the Elasticsearch query planner evaluating filters in the wrong order. The prefix query is being evaluated **first**, which causes Elasticsearch to iterate over the entire index instead of just the small subset of results from the query_string query.

This diff replaces the prefix filter with an equivalent term filter using our existing path_hierarchy tokens.
