### PR TITLE
Quick: fix metrics logger name

### DIFF
--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -455,6 +455,7 @@ LOGGING = {
             'level': 'INFO',
             'class': 'logging.StreamHandler',
             'formatter': 'metrics',
+            'filters': ['guidFilter']
         },
     },
     'loggers': {


### PR DESCRIPTION
## Overview: ##

The metrics logger name must exactly match the filter for the guid.

## PR Status: ##

* [X] Ready.
