### PR TITLE
fix: app cards only two lines tall

### DIFF
--- a/designsafe/static/styles/app-card.css
+++ b/designsafe/static/styles/app-card.css
@@ -24,10 +24,11 @@
     padding-inline: 1.5rem;
     margin-block: 1.5rem;
 }
-/* To set height to twice line-height */
-/* SEE: ./app-page.css#L34-L36 (circa v7.1.4) */
+/* To set explicit height equal to N lines of text */
 .s-app-page p.c-app-card__desc {
-    height: 3.6em;
+    --lines: 3; /* to override Core-Styles c-app-card truncate */
+
+    height: calv(var(--lines) * var(--line-height));
 }
 
 /* Types */

--- a/designsafe/static/styles/app-page.css
+++ b/designsafe/static/styles/app-page.css
@@ -32,7 +32,9 @@
 }
 
 .s-app-page p {
-    line-height: 1.8;
+    --line-height: 1.8; /* variable so app-card.css can use */
+
+    line-height: var(--line-height);
 }
 
 /* Add more space between Bootstrap columns */


### PR DESCRIPTION
## Overview

Make descriptions of App Cards (on [Tools & Applications page](https://designsafe-ci.org/use-designsafe/tools-applications/)) (maximum) 3 lines tall, not two.

## Status

* [X] Ready.

## Related

* [DSAPP-87](https://tacc-main.atlassian.net/browse/DSAPP-87)

## Changes

* **changed** cross-file CSS math to use variables
* **added** 3 lines value override

## Testing

1. Open https://designsafeci-next.tacc.utexas.edu/use-designsafe/tools-applications/.
2. Change window size until Jupyter card description shows three lines.
    - If it shows two lines and "..." truncation, then I failed.

## UI

https://github.com/user-attachments/assets/965a79bb-7049-48d0-be33-337c37905dac