### PR TITLE
task/WC-177: Update label and colors for Engineering/Geoscience collections

### DIFF
--- a/client/modules/datafiles/src/projects/constants.ts
+++ b/client/modules/datafiles/src/projects/constants.ts
@@ -77,7 +77,7 @@ export const PROJECT_COLORS: Record<string, { outline: string; fill: string }> =
     [FIELD_RECON_COLLECTION]: { outline: '#43A59D', fill: '#CAE9E6' },
     [FIELD_RECON_REPORT]: { outline: '#cccccc', fill: '#f5f5f5' },
     [FIELD_RECON_MISSION]: { outline: '#000000', fill: '#ffffff' },
-    [FIELD_RECON_GEOSCIENCE]: { outline: '#43A59D', fill: '#CAE9E6' },
+    [FIELD_RECON_GEOSCIENCE]: { outline: '#1568C9', fill: '#C4D9F2' },
     [FIELD_RECON_SOCIAL_SCIENCE]: { outline: '#B59300', fill: '#ECE4BF' },
     [FIELD_RECON_PLANNING]: { outline: '#43A59D', fill: '#CAE9E6' },
   };
@@ -195,7 +195,7 @@ export const DISPLAY_NAMES: Record<string, string> = {
   // Field Recon
   [FIELD_RECON_MISSION]: 'Mission',
   [FIELD_RECON_COLLECTION]: 'Collection',
-  [FIELD_RECON_GEOSCIENCE]: 'Geoscience Collection',
+  [FIELD_RECON_GEOSCIENCE]: 'Engineering/Geoscience Collection',
   [FIELD_RECON_SOCIAL_SCIENCE]: 'Social Science Collection',
   [FIELD_RECON_REPORT]: 'Document Collection',
   [FIELD_RECON_PLANNING]: 'Research Planning Collection',

--- a/client/modules/datafiles/src/projects/forms/ProjectCategoryFormHelp.tsx
+++ b/client/modules/datafiles/src/projects/forms/ProjectCategoryFormHelp.tsx
@@ -125,7 +125,7 @@ export const ProjectCategoryFormHelp: React.FC<{ projectType: string }> = ({
             files help others understand the context of your data.
           </div>
           <div>
-            <span className="category-yellow">
+            <span className="category-blue">
               Engineering/Geosciences Collection
             </span>{' '}
             Groups related data from the engineering/geosciences domain.


### PR DESCRIPTION
## Overview: ##
- Update label from "Geoscience Collection" to "Engineering/Geoscience Collection"
- Update display color for Engineering/Geoscience to be distinct from Research Planning

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-177](https://tacc-main.atlassian.net/browse/WC-177)

## Summary of Changes: ##

## UI Photos:
<img width="816" alt="image" src="https://github.com/user-attachments/assets/9059a822-3faf-4476-b537-ecda4a431a86" />
<img width="852" alt="image" src="https://github.com/user-attachments/assets/3d6d4496-92ea-4a96-a1a0-6ecf95f11fe2" />


## Notes: ##
