### PR TITLE
task/WC-173: Remove duplicate project name in citation for type Other

### DIFF
--- a/client/modules/datafiles/src/projects/ProjectCitation/ProjectCitation.tsx
+++ b/client/modules/datafiles/src/projects/ProjectCitation/ProjectCitation.tsx
@@ -17,7 +17,6 @@ export const ProjectCitation: React.FC<{
     entityDetails?.value.authors?.filter(
       (a) => a.fname && a.lname && a.authorship !== false
     ) ?? [];
-
   if (!data || !entityDetails) return null;
   return (
     <div>

--- a/client/modules/datafiles/src/projects/ProjectCitation/ProjectCitation.tsx
+++ b/client/modules/datafiles/src/projects/ProjectCitation/ProjectCitation.tsx
@@ -17,6 +17,7 @@ export const ProjectCitation: React.FC<{
     entityDetails?.value.authors?.filter(
       (a) => a.fname && a.lname && a.authorship !== false
     ) ?? [];
+
   if (!data || !entityDetails) return null;
   return (
     <div>
@@ -29,8 +30,12 @@ export const ProjectCitation: React.FC<{
             : `${author.fname[0]}. ${author.lname}`
         )
         .join(', ')}
-      . "{entityDetails.value.title}", in <i>{data.baseProject.value.title}</i>.
-      DesignSafe-CI. (DOI will appear after publication)
+      .{' '}
+      {data.baseProject.value.projectType !== 'other' && (
+        <span>"{entityDetails.value.title}", in </span>
+      )}
+      <i>{data.baseProject.value.title}</i>. DesignSafe-CI. (DOI will appear
+      after publication)
     </div>
   );
 };
@@ -66,8 +71,11 @@ export const PublishedCitation: React.FC<{
             : `${author.fname[0]}. ${author.lname}`
         )
         .join(', ')}{' '}
-      ({new Date(entityDetails.publicationDate).getFullYear()}). "
-      {entityDetails.value.title}", in <i>{data.baseProject.title}</i>
+      ({new Date(entityDetails.publicationDate).getFullYear()}).{' '}
+      {data.baseProject.projectType !== 'other' && (
+        <span>"{entityDetails.value.title}", in </span>
+      )}
+      <i>{data.baseProject.title}</i>
       {(version ?? 1) > 1 && <span> [Version {version}]</span>}. DesignSafe-CI.{' '}
       {doi && (
         <a

--- a/client/modules/datafiles/src/projects/ProjectPipeline/PipelineOrderAuthors.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPipeline/PipelineOrderAuthors.tsx
@@ -121,7 +121,10 @@ export const PipelineOrderAuthors: React.FC<{
                         : `${author.fname[0]}. ${author.lname}`
                     )
                     .join(', ')}
-                  . "{entity.value.title}", in{' '}
+                  .{' '}
+                  {data.baseProject.value.projectType !== 'other' && (
+                    <span>"{entity.value.title}", in </span>
+                  )}
                   <i>{data.baseProject.value.title}</i>. DesignSafe-CI. (DOI
                   will appear after publication)
                 </div>


### PR DESCRIPTION
## Overview: ##
Replace `"PROJECT_NAME", in PROJECT_NAME` with just the name of the project for type Other.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-173](https://tacc-main.atlassian.net/browse/WC-173)

## Summary of Changes: ##

## Testing Steps: ##
1. 

## UI Photos:
<img width="781" alt="image" src="https://github.com/user-attachments/assets/92da0abf-d663-4f11-a8e9-df075f1e753c" />
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/7fad3fa0-f757-42ca-a7ea-4b42eb0f0222" />


## Notes: ##
