### PR TITLE
Task/wp 773 remove Box and Google Drive integration

### DIFF
--- a/client/modules/datafiles/src/DatafilesSideNav/DatafilesSideNav.tsx
+++ b/client/modules/datafiles/src/DatafilesSideNav/DatafilesSideNav.tsx
@@ -53,22 +53,10 @@ export const DatafilesSideNav: React.FC = () => {
           <hr style={{ margin: '0' }} />
 
           <DataFilesNavLink
-            to="/box"
-            tooltip="Access to my Box files for copying"
-          >
-            Box.com
-          </DataFilesNavLink>
-          <DataFilesNavLink
             to="/dropbox"
             tooltip="Access to my Dropbox files for copying"
           >
             Dropbox.com
-          </DataFilesNavLink>
-          <DataFilesNavLink
-            to="/googledrive"
-            tooltip="Access to my Google Drive files for copying"
-          >
-            Google Drive
           </DataFilesNavLink>
 
           <hr style={{ margin: '0' }} />

--- a/designsafe/apps/box_integration/integrations.py
+++ b/designsafe/apps/box_integration/integrations.py
@@ -3,9 +3,9 @@ from django.urls import reverse
 
 def provide_integrations():
     return [
-        {
-            'label': 'Box.com',
-            'href': reverse('box_integration:index'),
-            'description': 'Access files from your Box.com account in DesignSafe.',
-        },
+        #{
+        #    'label': 'Box.com',
+        #    'href': reverse('box_integration:index'),
+        #    'description': 'Access files from your Box.com account in DesignSafe.',
+        #},
     ]

--- a/designsafe/apps/googledrive_integration/integrations.py
+++ b/designsafe/apps/googledrive_integration/integrations.py
@@ -3,9 +3,9 @@ from django.urls import reverse
 
 def provide_integrations():
     return [
-        {
-            'label': 'GoogleDrive',
-            'href': reverse('googledrive_integration:index'),
-            'description': 'Access files from your Google Drive account in DesignSafe.',
-        },
+        #{
+        #    'label': 'GoogleDrive',
+        #    'href': reverse('googledrive_integration:index'),
+        #    'description': 'Access files from your Google Drive account in DesignSafe.',
+        #},
     ]


### PR DESCRIPTION
## Overview: ##

Remove Box and Google Drive integration.
This is just UI change, not functional.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-773](https://tacc-main.atlassian.net/browse/WP-773)

## Summary of Changes: ##

## Testing Steps: ##
1. Navigate to Data Depot. Box.com and Google Drive options should not be displayed in left navigation bar.
2. Navigate to /account/applications/.  Box.com and Google Drive options should not be displayed as 3rd Party Applications.

## UI Photos:
<img width="804" alt="Screenshot 2025-01-22 at 10 58 28 AM" src="https://github.com/user-attachments/assets/3865f8db-9a28-4979-8a5f-ed90fd33043c" />

<img width="341" alt="Screenshot 2025-01-22 at 10 57 54 AM" src="https://github.com/user-attachments/assets/5a0b1a48-044e-4968-ac90-71eb31edc5a7" />



## Notes: ##
