### PR TITLE
Hotfix: Replace cloud.corral with cloud.data in project system operations

### DIFF
--- a/designsafe/apps/api/projects_v2/operations/project_system_operations.py
+++ b/designsafe/apps/api/projects_v2/operations/project_system_operations.py
@@ -103,7 +103,7 @@ def create_workspace_system(client, project_uuid: str) -> str:
     system_id = f"project-{project_uuid}"
     system_args = {
         "id": system_id,
-        "host": "cloud.corral.tacc.utexas.edu",
+        "host": "cloud.data.tacc.utexas.edu",
         "port": 22,
         "systemType": "LINUX",
         "defaultAuthnMethod": "PKI_KEYS",

--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -596,7 +596,7 @@ PROJECT_STORAGE_SYSTEM_TEMPLATE = {
         'port': 2222,
         'homeDir': '/',
         'protocol': 'SFTP',
-        'host': 'cloud.corral.tacc.utexas.edu',
+        'host': 'cloud.data.tacc.utexas.edu',
         'publicAppsDir': None,
         'proxy': None,
         'rootDir': '/corral-repl/projects/NHERI/projects/{}',

--- a/designsafe/settings/test_settings.py
+++ b/designsafe/settings/test_settings.py
@@ -474,7 +474,7 @@ PROJECT_STORAGE_SYSTEM_TEMPLATE = {
         'port': 2222,
         'homeDir': '/',
         'protocol': 'SFTP',
-        'host': 'cloud.corral.tacc.utexas.edu',
+        'host': 'cloud.data.tacc.utexas.edu',
         'publicAppsDir': None,
         'proxy': None,
         'rootDir': '/corral-repl/projects/NHERI/projects/{}',


### PR DESCRIPTION
## Overview: ##
Replace cloud.corral with cloud.data in project system definitions.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

