### PR TITLE
task/WP-637: Disable trash for VM or HPC file listings

### DIFF
--- a/client/modules/datafiles/src/DatafilesToolbar/DatafilesToolbar.tsx
+++ b/client/modules/datafiles/src/DatafilesToolbar/DatafilesToolbar.tsx
@@ -58,6 +58,7 @@ export function getToolbarRules(
       isAuthenticated &&
       selectedFiles.length >= 1 &&
       !isReadOnly &&
+      system !== USER_WORK_SYSTEM &&
       notContainingHazmapperFile,
     canDownload:
       selectedFiles.length >= 1 &&


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-637](https://tacc-main.atlassian.net/browse/WP-637)

## Summary of Changes: ##
- Add check for `USER_WORK_SYSTEM` for determining if selected files can be trashed or not (copying approach for download eligibility)

## Testing Steps: ##
1. Go to Data Depot > Work file listing (hosted on cloud.data)
2. Confirm that, for any file(s)/folder(s) selected in this listing, the `Trash` toolbar button is disabled
3. Go to Data Depot > My Data file listing and confirm Trash behavior is unchanged 

## UI Photos:

## Notes: ##
