### PR TITLE
Quick: add _TAS_DIR env var for interactive apps for work mounts

### DIFF
--- a/designsafe/apps/workspace/api/views.py
+++ b/designsafe/apps/workspace/api/views.py
@@ -768,6 +768,7 @@ class JobsView(AuthenticatedApiView):
                         "X-Tapis-Tracking-ID": f"portals.{request.session.session_key}"
                     },
                 )
+            job_post["parameterSet"]["envVariables"].append({"key": "_TAS_DIR", "value": tasdir})
 
         # Add webhook subscription for job status updates
         job_post["subscriptions"] = job_post.get("subscriptions", []) + [


### PR DESCRIPTION
## Overview: ##

Add a `_TAS_DIR` environment variable to interactive app job submissions to handle mounting work directories in our interactive VMs

## PR Status: ##

* [X] Ready.