### PR TITLE
Quick: Exclude 'setup_complete' from the profile update form

### DIFF
--- a/designsafe/apps/accounts/forms.py
+++ b/designsafe/apps/accounts/forms.py
@@ -333,7 +333,7 @@ class ProfessionalProfileForm(forms.ModelForm):
 
     class Meta:
         model = DesignSafeProfile
-        exclude = ['user', 'ethnicity', 'gender', 'update_required', 'institution', 'homedir']
+        exclude = ['user', 'ethnicity', 'gender', 'update_required', 'institution', 'homedir', 'setup_complete']
 
 
 class UserRegistrationForm(UserProfileForm, ProfessionalProfileForm):


### PR DESCRIPTION
## Overview: ##
Noticed this during intern onboarding- the profile update form auto-generates a field for the `setup_complete` attribute, which could interfere with onboarding.
