### PR TITLE
Hotfix: increase axios timeout

### DIFF
--- a/client/modules/_hooks/src/apiClient.ts
+++ b/client/modules/_hooks/src/apiClient.ts
@@ -3,7 +3,7 @@ import axios, { AxiosError } from 'axios';
 export type TApiError = AxiosError<{ message?: string }>;
 
 export const apiClient = axios.create({
-  timeout: 30000,
+  timeout: 60 * 1000, // 1 minute
   xsrfHeaderName: 'X-CSRFToken',
   xsrfCookieName: 'csrftoken',
 });

--- a/client/modules/_hooks/src/datafiles/useUploadFile.ts
+++ b/client/modules/_hooks/src/datafiles/useUploadFile.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import apiClient from '../apiClient';
 
+apiClient.defaults.timeout = 5 * 60 * 1000; // 5 minutes
+
 type TUploadFileParam = {
   api: string;
   system: string;

--- a/client/modules/_hooks/src/datafiles/useUploadFolder.ts
+++ b/client/modules/_hooks/src/datafiles/useUploadFolder.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import apiClient from '../apiClient';
 
+apiClient.defaults.timeout = 5 * 60 * 1000; // 5 minutes
+
 type TUploadFolderParam = {
   api: string;
   system: string;
@@ -8,7 +10,6 @@ type TUploadFolderParam = {
   path: string;
   uploaded_folder: FormData;
 };
-
 function uploadFolderFn(params: TUploadFolderParam) {
   const { api, system, scheme, path, uploaded_folder } = params;
   return apiClient.post(


### PR DESCRIPTION
## Overview: ##

Defaults to 1min now for timeout, and increases upload timeouts to 5min

## PR Status: ##

* [X] Ready.

## Testing Steps: ##
1. Upload a largeish file and confirm it succeeds
2. In `client/modules/_hooks/src/datafiles/useUploadFile.ts, change the default timeout to `1000`, 1 second. Upload the same file and watch it fail.
