### PR TITLE
task/WG-463: improve hazmapper map filtering in pprd

### DIFF
--- a/client/modules/datafiles/src/projects/utils.ts
+++ b/client/modules/datafiles/src/projects/utils.ts
@@ -48,7 +48,10 @@ export const getHazmapperUrl = (
  */
 export const filterHazmapperMaps = (maps: THazmapperMap[]): THazmapperMap[] => {
   // Filter out non-production maps if we are DS prod
-  if (window.location.origin.startsWith('https://www.designsafe-ci.org')) {
+  if (
+    window.location.origin.startsWith('https://www.designsafe-ci.org') ||
+    window.location.origin.startsWith('https://designsafe-ci.org')
+  ) {
     return maps.filter((map) => map.deployment === 'production');
   }
   return maps;

--- a/client/modules/datafiles/src/projects/utils.ts
+++ b/client/modules/datafiles/src/projects/utils.ts
@@ -47,10 +47,9 @@ export const getHazmapperUrl = (
  * out.
  */
 export const filterHazmapperMaps = (maps: THazmapperMap[]): THazmapperMap[] => {
-  // Filter out non-production maps if we are DS prod (i.e. 'designsafe-ci.org')
-  if (window.location.origin.includes('designsafe-ci.org')) {
+  // Filter out non-production maps if we are DS prod
+  if (window.location.origin.startsWith('https://www.designsafe-ci.org')) {
     return maps.filter((map) => map.deployment === 'production');
   }
-
   return maps;
 };


### PR DESCRIPTION
## Overview: ##

Our way to filter non-production maps on prod broke with the newish host for dev/pprd (`pprd.designsafe-ci.org`).  This PR improves the filtering.

## PR Status: ##

* [X] Ready

## Related Jira tickets: ##

* [WG-463](https://tacc-main.atlassian.net/browse/WG-463)

