### PR TITLE
RT Support preview for Tapis output files

### DIFF
--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -683,7 +683,8 @@ SUPPORTED_TEXT_PREVIEW_EXTS = [
     '.java', '.js', '.less', '.m', '.make', '.md', '.ml', '.mm', '.msg', '.php',
     '.pl', '.properties', '.py', '.rb', '.sass', '.scala', '.script', '.sh', '.sml',
     '.sql', '.txt', '.vi', '.vim', '.xml', '.xsd', '.xsl', '.yaml', '.yml', '.tcl',
-    '.json', '.out', '.err', '.geojson', '.do', '.sas', '.hazmapper', ".log"
+    '.json', '.out', '.err', '.geojson', '.do', '.sas', '.hazmapper', ".log", ".env",
+    ".exitcode", ".pid"
 ]
 
 SUPPORTED_OBJECT_PREVIEW_EXTS = [


### PR DESCRIPTION
## Overview: ##
Addresses RT ticket https://consult.tacc.utexas.edu/Ticket/Display.html?id=103566 by adding preview support for the following ascii file extensions:
- `.env`
- `.exitcode`
-`.pid`
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.
