### PR TITLE
task/WG-486: refactor types and hooks in recon-portal

### DIFF
--- a/client/modules/_hooks/src/reconportal/index.ts
+++ b/client/modules/_hooks/src/reconportal/index.ts
@@ -1,3 +1,3 @@
-export * from './useGetEvents';
-export * from './useGetEventTypes';
+export * from './useGetReconPortalEvents';
+export * from './useGetReconPortalEventTypes';
 export * from './useGetOpenTopo';

--- a/client/modules/_hooks/src/reconportal/useGetOpenTopo.ts
+++ b/client/modules/_hooks/src/reconportal/useGetOpenTopo.ts
@@ -1,176 +1,64 @@
 import { useQuery } from '@tanstack/react-query';
+import { FeatureCollection } from 'geojson';
 import apiClient from '../apiClient';
-import * as turf from '@turf/turf';
-import { Feature, Point } from 'geojson';
 
-export type OpenTopoFeature = {
-  type: 'Feature';
-  properties: {
-    id: string;
-    name: string;
-    productAvailable: string;
-    dateCreated: string;
-    temporalCoverage: string;
-    doiUrl: string;
-    url: string;
-    host: string;
-    keywords: string;
-    alternateName: string;
+
+export type OpenTopoDataset = {
+  name: string;
+  identifier: {
+    '@type': string;
+    propertyID: string;
+    value: string;
   };
-  geometry: {
-    type: 'Point' | 'Polygon' | 'MultiPolygon';
-    coordinates: number[] | number[][][] | number[][][][];
+  alternateName: string;
+  url: string;
+  fileFormat: string;
+  description: string;
+  dateCreated: string;
+  citation: string;
+  temporalCoverage: string;
+  keywords: string;
+  spatialCoverage: {
+    '@type': string;
+    geo: {
+      '@type': string;
+      geojson: FeatureCollection;
+    };
+    additionalProperty: {
+      '@type': string;
+      additionalType: string;
+      name: string;
+      value: string;
+    }[];
+    variableMeasured: {
+      '@type': string;
+      name: string;
+      value: string;
+    }[];
   };
 };
 
-export type OpenTopoResponse = {
+
+export type OpenTopoDatasetList = {
   Datasets: {
-    Dataset: {
-      name: string;
-      identifier: {
-        value: string;
-      };
-      alternateName: string;
-      url: string;
-      fileFormat: string;
-      description: string;
-      dateCreated: string;
-      temporalCoverage: string;
-      keywords: string;
-      spatialCoverage: {
-        geo: {
-          geojson: {
-            features: {
-              geometry: {
-                type: 'Polygon' | 'MultiPolygon';
-                coordinates: number[][][] | number[][][][];
-              };
-            }[];
-          };
-        };
-      };
-    };
+    Dataset: OpenTopoDataset;
   }[];
 };
 
-export type ProcessedOpenTopoData = {
-  original: {
-    type: 'FeatureCollection';
-    features: OpenTopoFeature[];
-  };
-  centroids: {
-    type: 'FeatureCollection';
-    features: OpenTopoFeature[];
-  };
-};
 
-async function fetchOpenTopoData(): Promise<OpenTopoResponse> {
-  const res = await apiClient.get<OpenTopoResponse>('/recon-portal/opentopo/');
+async function fetchOpenTopoData(): Promise<OpenTopoDatasetList> {
+  const res = await apiClient.get<OpenTopoDatasetList>('/recon-portal/opentopo/');
   return res.data;
-}
-
-function preprocessData(data: OpenTopoResponse): ProcessedOpenTopoData {
-  const seenUrls = new Map<string, OpenTopoFeature>();
-  const result: ProcessedOpenTopoData['original'] = {
-    type: 'FeatureCollection',
-    features: [] as OpenTopoFeature[],
-  };
-  const centroidResult: ProcessedOpenTopoData['centroids'] = {
-    type: 'FeatureCollection',
-    features: [] as OpenTopoFeature[],
-  };
-  data.Datasets.forEach(({ Dataset: datasetInfo }) => {
-    const {
-      url,
-      fileFormat,
-      spatialCoverage,
-      identifier,
-      name,
-      alternateName,
-      dateCreated,
-      temporalCoverage,
-      keywords,
-    } = datasetInfo;
-
-    if (!url) return;
-
-    if (seenUrls.has(url)) {
-      const existingFeature = seenUrls.get(url);
-      if (existingFeature && fileFormat) {
-        existingFeature.properties.productAvailable += `, ${fileFormat}`;
-      }
-    } else {
-      let geometry = {} as OpenTopoFeature['geometry'];
-      if (spatialCoverage?.geo?.geojson?.features?.[0]?.geometry) {
-        geometry = spatialCoverage.geo.geojson.features[0]
-          .geometry as OpenTopoFeature['geometry'];
-      }
-
-      const feature: OpenTopoFeature = {
-        type: 'Feature',
-        properties: {
-          id: identifier.value,
-          name,
-          host: 'OpenTopo',
-          url,
-          doiUrl: url,
-          alternateName,
-          dateCreated,
-          temporalCoverage,
-          keywords,
-          productAvailable: fileFormat,
-        },
-        geometry,
-      };
-      seenUrls.set(url, feature);
-      result.features.push(feature);
-
-      // Generate centroid
-      if (
-        geometry &&
-        (geometry.type === 'Polygon' || geometry.type === 'MultiPolygon')
-      ) {
-        const geomShape = turf.centroid(feature as Feature);
-        const centroidFeature: OpenTopoFeature = {
-          type: 'Feature',
-          properties: {
-            id: identifier.value,
-            name,
-            host: 'OpenTopo',
-            alternateName,
-            doiUrl: url,
-            dateCreated,
-            keywords,
-            temporalCoverage,
-            url: `/datasetMetadata?otCollectionID=OT.${identifier.value
-              .split('.')
-              .slice(1)
-              .join('.')}`,
-            productAvailable: fileFormat,
-          },
-          geometry: {
-            type: 'Point',
-            coordinates: (geomShape.geometry as Point).coordinates,
-          },
-        };
-        centroidResult.features.push(centroidFeature);
-      }
-    }
-  });
-  return { original: result, centroids: centroidResult };
 }
 
 export const getOpenTopoQuery = () => ({
   queryKey: ['opentopo'],
-  queryFn: async () => {
-    const data = await fetchOpenTopoData();
-    return preprocessData(data);
-  },
+  queryFn: fetchOpenTopoData,
   staleTime: 1000 * 60 * 5, // 5 minute stale time
 });
 
 export function useGetOpenTopo() {
-  return useQuery(getOpenTopoQuery());
+  return useQuery<OpenTopoDatasetList>(getOpenTopoQuery());
 }
 
 export default useGetOpenTopo;

--- a/client/modules/_hooks/src/reconportal/useGetOpenTopo.ts
+++ b/client/modules/_hooks/src/reconportal/useGetOpenTopo.ts
@@ -2,7 +2,6 @@ import { useQuery } from '@tanstack/react-query';
 import { FeatureCollection } from 'geojson';
 import apiClient from '../apiClient';
 
-
 export type OpenTopoDataset = {
   name: string;
   identifier: {
@@ -38,16 +37,16 @@ export type OpenTopoDataset = {
   };
 };
 
-
 export type OpenTopoDatasetList = {
   Datasets: {
     Dataset: OpenTopoDataset;
   }[];
 };
 
-
 async function fetchOpenTopoData(): Promise<OpenTopoDatasetList> {
-  const res = await apiClient.get<OpenTopoDatasetList>('/recon-portal/opentopo/');
+  const res = await apiClient.get<OpenTopoDatasetList>(
+    '/recon-portal/opentopo/'
+  );
   return res.data;
 }
 

--- a/client/modules/_hooks/src/reconportal/useGetReconPortalEventTypes.ts
+++ b/client/modules/_hooks/src/reconportal/useGetReconPortalEventTypes.ts
@@ -1,4 +1,4 @@
-import { useSuspenseQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import apiClient from '../apiClient';
 
 export type EventTypeResponse = {
@@ -13,19 +13,14 @@ async function getEventTypes() {
   return res.data;
 }
 
-export const getEventTypesQuery = () => ({
+export const getReconPortalEventTypesQuery = () => ({
   queryKey: ['reconportal', 'getEventTypes'],
   queryFn: getEventTypes,
   staleTime: 1000 * 60 * 5, // 5 minute stale time
 });
 
-export function useGetEventTypes() {
-  return useSuspenseQuery(getEventTypesQuery());
+export function useGetReconPortalEventTypes() {
+  return useQuery<EventTypeResponse[]>(getReconPortalEventTypesQuery());
 }
 
-export const usePrefetchGetEventTypes = () => {
-  const queryClient = useQueryClient();
-  queryClient.ensureQueryData(getEventTypesQuery());
-};
-
-export default useGetEventTypes;
+export default useGetReconPortalEventTypes;

--- a/client/modules/_hooks/src/reconportal/useGetReconPortalEvents.ts
+++ b/client/modules/_hooks/src/reconportal/useGetReconPortalEvents.ts
@@ -1,15 +1,14 @@
-// src/reconportal/useGetEvents.ts
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, UseQueryResult} from '@tanstack/react-query';
 import apiClient from '../apiClient';
 
-export type Dataset = {
+export type ReconPortalDataset = {
   url: string;
   title: string;
   doi: string;
   id: string;
 };
 
-export type EventsResponse = {
+export type ReconPortalEvents = {
   location_description: string;
   location: {
     lat: number;
@@ -19,11 +18,11 @@ export type EventsResponse = {
   event_type: string;
   title: string;
   created_date: string;
-  datasets: Dataset[];
+  datasets: ReconPortalDataset[];
 };
 
 async function getEvents() {
-  const res = await apiClient.get<EventsResponse[]>('/recon-portal/events');
+  const res = await apiClient.get<ReconPortalEvents[]>('/recon-portal/events');
   return res.data;
 }
 
@@ -33,8 +32,8 @@ export const getEventsQuery = () => ({
   staleTime: 1000 * 60 * 5, // 5 minute stale time
 });
 
-export function useGetEvents() {
-  return useQuery(getEventsQuery());
+export function useGetReconPortalEvents(): UseQueryResult<ReconPortalEvents[]> {
+  return useQuery<ReconPortalEvents[]>(getEventsQuery());
 }
 
-export default useGetEvents;
+export default useGetReconPortalEvents;

--- a/client/modules/_hooks/src/reconportal/useGetReconPortalEvents.ts
+++ b/client/modules/_hooks/src/reconportal/useGetReconPortalEvents.ts
@@ -1,4 +1,4 @@
-import { useQuery, UseQueryResult} from '@tanstack/react-query';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import apiClient from '../apiClient';
 
 export type ReconPortalDataset = {

--- a/client/tsconfig.base.json
+++ b/client/tsconfig.base.json
@@ -18,8 +18,8 @@
       "@client/common-components": ["modules/_common_components/src/index.ts"],
       "@client/datafiles": ["modules/datafiles/src/index.ts"],
       "@client/hooks": ["modules/_hooks/src/index.ts"],
-      "@client/reconportal": ["modules/reconportal/src/index.ts"],
       "@client/onboarding": ["modules/onboarding/src/index.ts"],
+      "@client/reconportal": ["modules/reconportal/src/index.ts"],
       "@client/test-fixtures": ["modules/_test-fixtures/src/index.ts"],
       "@client/workspace": ["modules/workspace/src/index.ts"]
     }


### PR DESCRIPTION
## Overview: ##

Refactor types and hooks in recon-portal:

* Updated hook names to include more info (i.e. recon portal and open topo)
* Improve types
    * added some missing properties
    * use `geojson`' `FeatureCollection`
    * used types (e.g. useQuery typing and response typing)
* Removed calculation of midpoint.  can always revert this but assume we'll show the actual geometry of open topo data due to the new design. 


## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-486](https://tacc-main.atlassian.net/browse/WG-486)

## Testing Steps: ##

Change `client/modules/reconportal/src/ReconPortalHeader/ReconPortalHeader.tsx` to:

```
import React from 'react';
import styles from './ReconPortalHeader.module.css';
import { useGetOpenTopo, useGetReconPortalEvents, useGetReconPortalEventTypes } from '@client/hooks'
import { Spin } from 'antd';

export const ReconPortalHeader: React.FC = () => {
  const {data: openTopo, isLoading: isLoadingOpenTopo } = useGetOpenTopo();
  const {data: events, isLoading: isLoadingEvents } = useGetReconPortalEvents();
  const {data: eventTypes, isLoading: isLoadingEventsTypes } = useGetReconPortalEventTypes();

  if (isLoadingOpenTopo || isLoadingEvents || isLoadingEventsTypes) return <Spin/>

  debugger;
  return <div className={styles.root}>Header Placeholder</div>;
};

```
and check data in debugger.
