### PR TITLE
feat: DSAPP-67 conditional "Get Started" button

### DIFF
--- a/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin_button.html
+++ b/designsafe/apps/workspace/templates/designsafe/apps/workspace/app_variant_plugin_button.html
@@ -1,9 +1,15 @@
 {# @var variant #}
 
         {% if variant.enabled %}
-        <a class="btn btn-success" href="{{variant.href}}" {% if variant.external_href %}target="_blank"{% endif %}>
+            {% if variant.external_href %}
+        <a class="btn btn-success" href="{{variant.external_href}}" target="_blank">
+            Launch
+        </a>
+            {% else %}
+        <a class="btn btn-success" href="{{variant.href}}">
             Get Started
         </a>
+            {% endif %}
         {% else %}
         <a class="btn btn-secondary disabled" href="{{variant.href}}">
             Coming Soon


### PR DESCRIPTION
## Overview

- **If** app variant is external, button reads "Launch" and open in new window.
- **Otherwise** button reads "Get Started" and opens workspace content.

## Related

* [DES-67](https://tacc-main.atlassian.net/browse/DSAPP-67)

## Changes

- **changed** "Get Started" link text and path to be conditional

## Testing

1. Open overview pages for external/HTML apps.
2. Verify button reads "Launch" and opens new tab/window.
3. Open overview pages for workspace apps.
4. Verify button reads "Get Started" and opens workspace.

## UI

…