### PR TITLE
Changed onboarding status shown

### DIFF
--- a/client/modules/onboarding/src/OnboardingStatus/OnboardingStatus.tsx
+++ b/client/modules/onboarding/src/OnboardingStatus/OnboardingStatus.tsx
@@ -4,6 +4,7 @@ import { TOnboardingStep } from '@client/hooks';
 import styles from './OnboardingStatus.module.css';
 
 const getContents = (step: TOnboardingStep) => {
+  console.log('Onboarding step:', step); // <-- Add this line
   let color = '';
   switch (step.state) {
     case 'processing':
@@ -38,6 +39,7 @@ const getContents = (step: TOnboardingStep) => {
     case 'userwait':
       return <Tag color={color}>Waiting for User</Tag>;
     case 'failed':
+      return <Tag color={color}>Unsuccessful, view log</Tag>;
     case 'error':
       return <Tag color={color}>Unsuccessful</Tag>;
     case null:
@@ -64,5 +66,6 @@ export const OnboardingStatus = ({ step }: { step: TOnboardingStep }) => {
   if (!contents) {
     return null;
   }
+
   return <span className={styles.root}>{getContents(step)}</span>;
 };


### PR DESCRIPTION
## Overview: ##
This PR updates the onboarding admin UI to clarify the displayed status for onboarding steps that are not successful.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-814](https://tacc-main.atlassian.net/jira/software/c/projects/WP/boards/46?assignee=712020%3Aa66df098-eece-4aae-a1c3-6b226867069f&selectedIssue=WP-814)

## Summary of Changes: ##
Updated the Status column in the onboarding admin table.

If an onboarding step fails (manual denial), the status now displays "Unsuccessful, view log" instead of just "Unsuccessful".

The backend/API does not provide a distinct "denied" state for manual denials; denied steps are returned as state: "failed".

As a result, it is not possible to differentiate between manual denials and other failures in the UI.
## Testing Steps: ##
1. Deny a user's onboarding step in the admin UI.

2.Confirm that the Status column displays "Unsuccessful, view log" for that step.

## UI Photos:
<img width="985" alt="Screenshot 2025-05-01 at 5 14 11 PM" src="https://github.com/user-attachments/assets/a703ef64-0f45-4046-a93d-c8afcd129dfe" />
<img width="620" alt="Screenshot 2025-05-01 at 5 14 21 PM" src="https://github.com/user-attachments/assets/47213f3e-776a-47a7-b278-dd202633be6a" />
<img width="945" alt="Screenshot 2025-05-01 at 5 14 29 PM" src="https://github.com/user-attachments/assets/eab2299a-67ad-438f-8c60-42f967a3b636" />
<img width="621" alt="Screenshot 2025-05-01 at 5 14 36 PM" src="https://github.com/user-attachments/assets/1dff87c8-a441-4b5c-9779-afab89334b2b" />


## Notes: ##
