### PR TITLE
Quick: Fix 500 error when session_id is None

### DIFF
--- a/designsafe/apps/api/datafiles/views.py
+++ b/designsafe/apps/api/datafiles/views.py
@@ -76,7 +76,7 @@ class DataFilesView(BaseApiView):
             return JsonResponse({'message': 'Please log in to access this feature.'}, status=403)
 
         try:
-            session_key_hash = sha256(request.session.session_key.encode()).hexdigest()
+            session_key_hash = sha256((request.session.session_key or '').encode()).hexdigest()
             response = datafiles_get_handler(
                 api, client, scheme, system, path, operation, tapis_tracking_id=f"portals.{session_key_hash}", username=request.user.username, **request.GET.dict())
             return JsonResponse(response)
@@ -115,7 +115,7 @@ class DataFilesView(BaseApiView):
                 raise resource_unconnected_handler(api)
 
         try:
-            session_key_hash = sha256(request.session.session_key.encode()).hexdigest()
+            session_key_hash = sha256((request.session.session_key or '').encode()).hexdigest()
             response = datafiles_put_handler(api, request.user.username, client, scheme, system, path, operation, tapis_tracking_id=f"portals.{session_key_hash}", body=body)
         except HTTPError as e:
             return JsonResponse({'message': str(e)}, status=e.response.status_code)
@@ -147,7 +147,7 @@ class DataFilesView(BaseApiView):
             except AttributeError:
                 raise resource_unconnected_handler(api)
         
-        session_key_hash = sha256(request.session.session_key.encode()).hexdigest()
+        session_key_hash = sha256((request.session.session_key or '').encode()).hexdigest()
         response = datafiles_post_handler(api, request.user.username, client, scheme, system, path, operation, tapis_tracking_id=f"portals.{session_key_hash}", body={**post_files, **post_body})
 
         return JsonResponse(response)

--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -422,7 +422,8 @@ def guid_filter(record):
     """Log filter that adds a guid to each entry"""
 
     record.logGuid = uuid.uuid4().hex
-    record.sessionId = sha256(record.sessionId.encode()).hexdigest()
+    if record.sessionId is not None:
+        record.sessionId = sha256(record.sessionId.encode()).hexdigest()
     return True
 
 LOGGING = {


### PR DESCRIPTION
## Overview: ##
Fixes a bug where unauthenticated users (`session_id=None`) were seeing 500 errors because their session ID couldn't be hashed.
