### PR TITLE
Create folder text box clears every time its opened

### DIFF
--- a/client/modules/datafiles/src/DatafilesModal/NewFolderModal/NewFolderModal.tsx
+++ b/client/modules/datafiles/src/DatafilesModal/NewFolderModal/NewFolderModal.tsx
@@ -1,6 +1,6 @@
 import { Button, Modal, Form, Input } from 'antd';
 import { useNewFolder } from '@client/hooks';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { TModalChildren } from '../DatafilesModal';
 import styles from './NewFolderModal.module.css';
 
@@ -12,6 +12,13 @@ export const NewFolderModalBody: React.FC<{
   handleCancel: () => void;
 }> = ({ isOpen, api, system, path, handleCancel }) => {
   const { mutate } = useNewFolder();
+  const [form] = Form.useForm();
+
+  useEffect(() => {
+    if (isOpen) {
+      form.resetFields();
+    }
+  }, [isOpen, form]);
 
   const handleNewFolderFinish = async (values: { newFolder: string }) => {
     const newFolder = values.newFolder;
@@ -55,6 +62,7 @@ export const NewFolderModalBody: React.FC<{
       onCancel={handleCancel}
     >
       <Form
+        form={form}
         autoComplete="off"
         layout="vertical"
         onFinish={handleNewFolderFinish}


### PR DESCRIPTION
## Overview: ##
Addresses an issue where the "New/Create Folder" modal in Data Depot did not clear the folder name input field between uses. Now, every time the modal is opened, the input is reset.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-640](https://tacc-main.atlassian.net/jira/software/c/projects/WP/boards/46?assignee=712020%3Aa66df098-eece-4aae-a1c3-6b226867069f&selectedIssue=WP-640)

## Summary of Changes: ##
Added form reset login using Form.useForm() adn resetFields() to clear the folder name input every time the modal is opened.

## Testing Steps: ##
1. Go to Data Depot
2.Select a Project
3.Add → New Folder
4.Enter some value and create a folder.
5.Repeat step 3, the textbox should be empty.

## UI Photos: (this was after creating a new folder)
<img width="686" alt="Screenshot 2025-05-08 at 4 42 11 PM" src="https://github.com/user-attachments/assets/a5d3fdb0-b5c2-4599-a715-0f1881d65576" />

## Notes: ## 
N/A
