### PR TITLE
task/WA-436: order app variants by priority

### DIFF
--- a/client/modules/_hooks/src/workspace/useAppsListing.ts
+++ b/client/modules/_hooks/src/workspace/useAppsListing.ts
@@ -12,6 +12,7 @@ export type TPortalApp = {
   icon?: string;
   is_bundled: boolean;
   label: string;
+  priority: number;
   shortLabel?: string;
   version?: string;
   userGuideLink?: string;

--- a/client/modules/workspace/src/AppsSideNav/AppsSideNav.tsx
+++ b/client/modules/workspace/src/AppsSideNav/AppsSideNav.tsx
@@ -7,17 +7,19 @@ import { useGetAppParams } from '../utils';
 export const AppsSideNav: React.FC<{ categories: TAppCategory[] }> = ({
   categories,
 }) => {
-  type MenuItem = Required<MenuProps>['items'][number];
+  type MenuItem = Required<MenuProps>['items'][number] & { priority: number };
 
   function getItem(
     label: React.ReactNode,
     key: string,
+    priority: number,
     children?: MenuItem[],
     type?: 'group'
   ): MenuItem {
     return {
       label,
       key,
+      priority,
       children,
       type,
     } as MenuItem;
@@ -46,7 +48,8 @@ export const AppsSideNav: React.FC<{ categories: TAppCategory[] }> = ({
               >
                 {app.shortLabel || app.label || app.bundle_label}
               </NavLink>,
-              `${app.app_id}${app.version}${app.bundle_id}`
+              `${app.app_id}${app.version}${app.bundle_id}`,
+              app.priority
             )
           );
         } else {
@@ -61,7 +64,8 @@ export const AppsSideNav: React.FC<{ categories: TAppCategory[] }> = ({
                 >
                   {app.shortLabel || app.label || app.bundle_label}
                 </NavLink>,
-                `${app.app_id}${app.version}${app.bundle_id}`
+                `${app.app_id}${app.version}${app.bundle_id}`,
+                app.priority
               ),
             ],
             label: app.bundle_label,
@@ -78,13 +82,20 @@ export const AppsSideNav: React.FC<{ categories: TAppCategory[] }> = ({
             >
               {app.shortLabel || app.label || app.bundle_label}
             </NavLink>,
-            `${app.app_id}${app.version}${app.bundle_id}`
+            `${app.app_id}${app.version}${app.bundle_id}`,
+            app.priority
           )
         );
       }
     });
-    const bundleItems = Object.entries(bundles).map(([bundleKey, bundle]) =>
-      getItem(`${bundle.label} [${bundle.apps.length}]`, bundleKey, bundle.apps)
+    const bundleItems = Object.entries(bundles).map(
+      ([bundleKey, bundle], index) =>
+        getItem(
+          `${bundle.label} [${bundle.apps.length}]`,
+          bundleKey,
+          index,
+          bundle.apps.sort((a, b) => a.priority - b.priority)
+        )
     );
 
     return categoryItems
@@ -96,6 +107,7 @@ export const AppsSideNav: React.FC<{ categories: TAppCategory[] }> = ({
     return getItem(
       `${category.title} [${category.apps.length}]`,
       category.title,
+      category.priority,
       getCategoryApps(category)
     );
   });

--- a/designsafe/apps/workspace/api/views.py
+++ b/designsafe/apps/workspace/api/views.py
@@ -341,6 +341,7 @@ class AppsTrayView(AuthenticatedApiView):
             "icon",
             "is_bundled",
             "label",
+            "priority",
             "short_label",
             "version",
         ]
@@ -357,6 +358,7 @@ class AppsTrayView(AuthenticatedApiView):
             "icon",
             "is_bundled",
             "label",
+            "priority",
             "short_label",
             "version",
         ]
@@ -387,7 +389,8 @@ class AppsTrayView(AuthenticatedApiView):
                     bundle_label=F("bundle__label"),
                     bundle_license_type=F("bundle__license_type"),
                     bundle_user_guide_link=F("bundle__user_guide_link"),
-                ).values(*values)
+                )
+                .values(*values)
             )
 
             html_apps = list(

--- a/designsafe/apps/workspace/cms_plugins.py
+++ b/designsafe/apps/workspace/cms_plugins.py
@@ -98,7 +98,7 @@ class AppVariants(CMSPluginBase):
 
     def render(self, context, instance: AppListingEntry, placeholder):
         context = super().render(context, instance, placeholder)
-        app_variants = instance.app.appvariant_set.filter()
+        app_variants = instance.app.appvariant_set.order_by("priority")
         context["listing"] = app_variants
 
         return context


### PR DESCRIPTION
## Overview: ##

- Use the `priority` field of an app variant object to sort variants on the app detail cms page and in the apps side nav

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WA-436](https://tacc-main.atlassian.net/browse/WA-436)

## Summary of Changes: ##

## Testing Steps: ##
1. Define distinct priorities for an app with multiple variants
2. Confirm ordering is the same on the cms page and on the workspace

## UI Photos:
<img width="255" alt="Screenshot 2025-05-13 at 6 26 43 PM" src="https://github.com/user-attachments/assets/cb6f51eb-6415-49b6-83b1-f10800bd7d7b" />
<img width="670" alt="Screenshot 2025-05-13 at 6 26 48 PM" src="https://github.com/user-attachments/assets/85e6cea5-a163-40fb-9815-ba7a72e132a7" />

