### PR TITLE
Add handling for tms credential creation in datafiles get view

### DIFF
--- a/client/src/workspace/layouts/AppsViewLayout.tsx
+++ b/client/src/workspace/layouts/AppsViewLayout.tsx
@@ -17,13 +17,11 @@ export const AppsViewLayout: React.FC = () => {
   const { data: app } = useGetAppsSuspense({ appId, appVersion });
   const { data } = useAppsListing();
 
-  const icon =
-    findAppById(data, app.definition.id)?.icon ||
-    app.definition.notes.icon ||
-    'Generic-App';
+  const portalApp = findAppById(data, app.definition.id);
+
+  const icon = portalApp?.icon || app.definition.notes.icon || 'Generic-App';
   const userGuideLink =
-    findAppById(data, app.definition.id)?.userGuideLink ||
-    app.definition.notes.helpUrl;
+    portalApp?.userGuideLink || app.definition.notes.helpUrl;
 
   const htmlApp = data?.htmlDefinitions[appId];
   const key = `${appId}-${appVersion}`;
@@ -45,7 +43,9 @@ export const AppsViewLayout: React.FC = () => {
             <Flex justify="space-between">
               <div>
                 <AppIcon name={icon} />
-                {app.definition.notes.label || app.definition.id}
+                {portalApp?.label ||
+                  app.definition.notes.label ||
+                  app.definition.id}
               </div>
               {userGuideLink && (
                 <a

--- a/designsafe/apps/api/datafiles/handlers.py
+++ b/designsafe/apps/api/datafiles/handlers.py
@@ -1,4 +1,7 @@
 import logging
+from django.core.exceptions import PermissionDenied
+from django.urls import reverse
+from tapipy.errors import BaseTapyException, InternalServerError, UnauthorizedError
 from designsafe.apps.api.datafiles.notifications import notify
 from designsafe.apps.api.datafiles.operations import tapis_operations
 from designsafe.apps.api.datafiles.operations import googledrive_operations
@@ -6,9 +9,8 @@ from designsafe.apps.api.datafiles.operations import dropbox_operations
 from designsafe.apps.api.datafiles.operations import box_operations
 from designsafe.apps.api.datafiles.operations import shared_operations
 from designsafe.apps.api.exceptions import ApiException
-from django.core.exceptions import PermissionDenied
-from tapipy.errors import BaseTapyException
-from django.urls import reverse
+from designsafe.libs.common.decorators import retry
+from designsafe.apps.workspace.api.views import test_system_needs_keys
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +32,7 @@ operations_mapping = {
 }
 
 
+@retry(UnauthorizedError, tries=3, max_time=15)
 def datafiles_get_handler(api, client, scheme, system, path, operation, username=None, tapis_tracking_id=None, **kwargs):
     if operation not in allowed_actions[scheme]:
         raise PermissionDenied
@@ -37,6 +40,13 @@ def datafiles_get_handler(api, client, scheme, system, path, operation, username
 
     try:
         return op(client, system, path, username=username, tapis_tracking_id=tapis_tracking_id, **kwargs)
+    except (InternalServerError, UnauthorizedError):
+        system_needs_keys = test_system_needs_keys(client, username, system)
+        if system_needs_keys:
+            logger.error(
+                f"Keys for user {username} must be manually pushed to system: {system_needs_keys.id}"
+            )
+        raise
     except BaseTapyException as exc:
         raise ApiException(message=exc.message, status=500) from exc
 

--- a/designsafe/apps/onboarding/steps/system_access_v3.py
+++ b/designsafe/apps/onboarding/steps/system_access_v3.py
@@ -1,9 +1,6 @@
 """System Access Step for Onboarding."""
 
 import logging
-import requests
-from requests.exceptions import HTTPError
-from django.conf import settings
 from tapipy.errors import (
     NotFoundError,
     BaseTapyException,
@@ -12,7 +9,6 @@ from tapipy.errors import (
 )
 from designsafe.apps.onboarding.steps.abstract import AbstractStep
 from designsafe.apps.onboarding.state import SetupState
-from designsafe.utils.encryption import createKeyPair
 from designsafe.apps.api.agave import get_service_account_client, get_tg458981_client
 from designsafe.apps.api.tasks import agave_indexer
 from designsafe.libs.common.decorators import retry

--- a/designsafe/apps/workspace/api/views.py
+++ b/designsafe/apps/workspace/api/views.py
@@ -140,7 +140,7 @@ def test_system_needs_keys(tapis, username, system_id):
                 )
                 return False
             except (InternalServerError, UnauthorizedError):
-                logger.warning(f"Authentication still failing for system: {system_id}, user: {username}")
+                logger.error(f"TMS_KEYS credential generation failed for system: {system_id}, user: {username}")
                 raise
         return True
 

--- a/designsafe/apps/workspace/api/views.py
+++ b/designsafe/apps/workspace/api/views.py
@@ -27,10 +27,7 @@ from designsafe.apps.workspace.models.app_entries import (
 )
 from designsafe.apps.api.users.utils import get_allocations
 from designsafe.apps.workspace.api.utils import check_job_for_timeout
-from designsafe.apps.onboarding.steps.system_access_v3 import (
-    create_system_credentials,
-    create_system_credentials_with_keys,
-)
+from designsafe.apps.onboarding.steps.system_access_v3 import create_system_credentials
 
 
 logger = logging.getLogger(__name__)
@@ -128,24 +125,24 @@ def test_system_needs_keys(tapis, username, system_id):
         system_id (str): The ID of the Tapis system to test.
 
     Returns:
-        SystemDef: The system definition if an error occurs.
+        bool
     """
-    system_def = tapis.systems.getSystem(systemId=system_id)
     try:
-        tapis.files.listFiles(systemId=system_id, path="/")
-        return None
+        tapis.systems.checkUserCredential(systemId=system_id, userName=username)
+        return False
     except (InternalServerError, UnauthorizedError):
         # Check if the system uses TMS_KEYS and create credentials if necessary
+        system_def = tapis.systems.getSystem(systemId=system_id)
         if system_def.get("defaultAuthnMethod") == "TMS_KEYS":
             try:
                 create_system_credentials(
                     tapis, username, system_id, createTmsKeys=True
                 )
-                tapis.files.listFiles(systemId=system_id, path="/")
-                return None
+                return False
             except (InternalServerError, UnauthorizedError):
-                logger.warning(f"Authentication still failing for system: {system_id}")
-        return system_def
+                logger.warning(f"Authentication still failing for system: {system_id}, user: {username}")
+                raise
+        return True
 
 
 class SystemListingView(AuthenticatedApiView):
@@ -223,19 +220,6 @@ class AppsView(AuthenticatedApiView):
 
         except ObjectDoesNotExist:
             data = _get_app(app_id, app_version, request.user)
-
-        # NOTE: DesignSafe default storage system can be assumed to not need keys pushed, as is using key service
-        # Check if default storage system needs keys pushed
-        # if settings.AGAVE_STORAGE_SYSTEM:
-        #     tapis = request.user.tapis_oauth.client
-        #     system_needs_keys = test_system_needs_keys(
-        #         tapis, settings.AGAVE_STORAGE_SYSTEM
-        #     )
-        #     if system_needs_keys:
-        #         logger.info(
-        #             f"Keys for user {request.user.username} must be manually pushed to system: {system_needs_keys.id}"
-        #         )
-        #         data["defaultSystemNeedsKeys"] = system_needs_keys
 
         return JsonResponse(
             {

--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -747,7 +747,7 @@ PORTAL_USER_ACCOUNT_SETUP_STEPS = [
         "step": "designsafe.apps.onboarding.steps.system_access_v3.SystemAccessStepV3",
         "settings": {
             "credentials_systems": os.environ.get(
-                "TMS_SYSTEMS", "cloud.data,designsafe.storage.default,wma-exec-01"
+                "TMS_SYSTEMS", "designsafe.storage.default,cloud.data,wma-exec-01,wma-dcv-01,vista,frontera,stampede3,ls6"
             ).split(","),
             "create_path_systems": [
                 {"system_id": "designsafe.storage.default", "path": "{username}"}


### PR DESCRIPTION
## Overview: ##

- Handle TMS credential creation in datafiles for failed TMS system listings
- Do not show push keys modal in apps for TMS_KEYS systems

## PR Status: ##

* [X] Ready.

## Testing Steps: ##
1. Delete your `designsafe.storage.default` credential
2. Navigate to your my data listing
3. Confirm creds are created in the background and your listing succeeds
