### PR TITLE
WC-234: Change Usage Figures Language

### DIFF
--- a/client/modules/datafiles/src/projects/ProjectCitation/ProjectCitation.tsx
+++ b/client/modules/datafiles/src/projects/ProjectCitation/ProjectCitation.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Popover } from 'antd';
 import {
   useDataciteMetrics,
   useProjectDetail,
@@ -24,9 +25,8 @@ export const ProjectCitation: React.FC<{
       {authors
         .map((author, idx) =>
           idx === 0
-            ? `${author.lname}, ${author.fname[0]}${
-                authors.length > 1 ? '.' : ''
-              }`
+            ? `${author.lname}, ${author.fname[0]}${authors.length > 1 ? '.' : ''
+            }`
             : `${author.fname[0]}. ${author.lname}`
         )
         .join(', ')}
@@ -65,9 +65,8 @@ export const PublishedCitation: React.FC<{
       {authors
         .map((author, idx) =>
           idx === 0
-            ? `${author.lname}, ${author.fname[0]}${
-                authors.length > 1 ? '.' : ''
-              }`
+            ? `${author.lname}, ${author.fname[0]}${authors.length > 1 ? '.' : ''
+            }`
             : `${author.fname[0]}. ${author.lname}`
         )
         .join(', ')}{' '}
@@ -170,11 +169,24 @@ export const DownloadCitation: React.FC<{
           </a>
           <div>
             <span className={styles['yellow-highlight']}>
-              {dataciteMetrics?.data.attributes.downloadCount ?? '--'} Downloads
+              <Popover
+                overlayStyle={{ maxWidth: '400px' }}
+                title="Unique Requests"
+                content="User sessions in which one or more files are downloaded or previewed."
+              >
+                {dataciteMetrics?.data.attributes.downloadCount ?? '--'} Unique Requests
+              </Popover>
             </span>
             &nbsp;&nbsp;&nbsp;&nbsp;
             <span className={styles['yellow-highlight']}>
-              {dataciteMetrics?.data.attributes.viewCount ?? '--'} Views
+              <Popover
+                overlayStyle={{ maxWidth: '400px' }}
+                title="Unique Investigations"
+                content="User sessions in which any project or publications metadata is viewed,
+                          or one or more files is downloaded or previewed"
+              >
+                {dataciteMetrics?.data.attributes.viewCount ?? '--'} Unique Investigations
+              </Popover>
             </span>
             &nbsp;&nbsp;&nbsp;&nbsp;
             <span className={styles['yellow-highlight']}>
@@ -182,8 +194,8 @@ export const DownloadCitation: React.FC<{
                 ? 'Loading...'
                 : isClarivateError ||
                   typeof clarivateMetrics?.citationCount !== 'number'
-                ? '0'
-                : clarivateMetrics.citationCount}{' '}
+                  ? '0'
+                  : clarivateMetrics.citationCount}{' '}
               Citations
             </span>
             &nbsp;&nbsp;&nbsp;&nbsp;

--- a/client/modules/datafiles/src/projects/ProjectCitation/ProjectCitation.tsx
+++ b/client/modules/datafiles/src/projects/ProjectCitation/ProjectCitation.tsx
@@ -25,8 +25,9 @@ export const ProjectCitation: React.FC<{
       {authors
         .map((author, idx) =>
           idx === 0
-            ? `${author.lname}, ${author.fname[0]}${authors.length > 1 ? '.' : ''
-            }`
+            ? `${author.lname}, ${author.fname[0]}${
+                authors.length > 1 ? '.' : ''
+              }`
             : `${author.fname[0]}. ${author.lname}`
         )
         .join(', ')}
@@ -65,8 +66,9 @@ export const PublishedCitation: React.FC<{
       {authors
         .map((author, idx) =>
           idx === 0
-            ? `${author.lname}, ${author.fname[0]}${authors.length > 1 ? '.' : ''
-            }`
+            ? `${author.lname}, ${author.fname[0]}${
+                authors.length > 1 ? '.' : ''
+              }`
             : `${author.fname[0]}. ${author.lname}`
         )
         .join(', ')}{' '}
@@ -174,7 +176,8 @@ export const DownloadCitation: React.FC<{
                 title="Unique Requests"
                 content="User sessions in which one or more files are downloaded or previewed."
               >
-                {dataciteMetrics?.data.attributes.downloadCount ?? '--'} Unique Requests
+                {dataciteMetrics?.data.attributes.downloadCount ?? '--'} Unique
+                Requests
               </Popover>
             </span>
             &nbsp;&nbsp;&nbsp;&nbsp;
@@ -185,7 +188,8 @@ export const DownloadCitation: React.FC<{
                 content="User sessions in which any project or publications metadata is viewed,
                           or one or more files is downloaded or previewed"
               >
-                {dataciteMetrics?.data.attributes.viewCount ?? '--'} Unique Investigations
+                {dataciteMetrics?.data.attributes.viewCount ?? '--'} Unique
+                Investigations
               </Popover>
             </span>
             &nbsp;&nbsp;&nbsp;&nbsp;
@@ -194,8 +198,8 @@ export const DownloadCitation: React.FC<{
                 ? 'Loading...'
                 : isClarivateError ||
                   typeof clarivateMetrics?.citationCount !== 'number'
-                  ? '0'
-                  : clarivateMetrics.citationCount}{' '}
+                ? '0'
+                : clarivateMetrics.citationCount}{' '}
               Citations
             </span>
             &nbsp;&nbsp;&nbsp;&nbsp;

--- a/client/modules/datafiles/src/publications/modals/DownloadDatasetModal.tsx
+++ b/client/modules/datafiles/src/publications/modals/DownloadDatasetModal.tsx
@@ -287,7 +287,7 @@ export const DownloadDatasetModal: React.FC<{
                 </a>{' '}
                 and follow the
                 <a
-                  href="/user-guide/managingdata/#data-transfer-guides"
+                  href="/user-guide/managingdata/datatransfer/"
                   target="_blank"
                   aria-describedby="msg-open-new-window"
                 >


### PR DESCRIPTION
## Overview: ##
Updating text for usage figures to match the dataset metrics modal, with mouseovers.
Updated the Data Transfer Guide link in the download dataset modal that got missed in a previous PR.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-234](https://tacc-main.atlassian.net/browse/WC-234)

## Summary of Changes: ##

## Testing Steps: ##
1. Go to publication view for PRJ-3963 (only specified because it's known to have a large zip for testing the download dataset url change, otherwise can use any publication)
2. Check that the highlighted info in the citation area with usage figures shows the correct text, plus the mouseover. (correct text and mouseover is in the jira task)
3. Click the "download dataset" button to view the modal, and click the data transfer guide link.  Update the url to point to prod rather than local and make sure it shows the data transfer guide and not a "this page has moved" page.

## UI Photos:

## Notes: ##
