### PR TITLE
task/WG-495: show open topo datasets on leaflet map

### DIFF
--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
@@ -11,7 +11,11 @@ import {
 } from 'react-leaflet';
 import { faMap } from '@fortawesome/free-solid-svg-icons';
 import { OpenTopoPopup } from './OpenTopoPopup';
-import { createSvgMarkerIcon, getOpenTopoColor, ZoomConditionalLayerGroup } from './leafletUtil';
+import {
+  createSvgMarkerIcon,
+  getOpenTopoColor,
+  ZoomConditionalLayerGroup,
+} from './leafletUtil';
 import { getFirstLatLng } from './utils';
 import { useGetOpenTopo } from '@client/hooks';
 

--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
@@ -8,8 +8,8 @@ import {
   Marker,
 } from 'react-leaflet';
 import { faMap } from '@fortawesome/free-solid-svg-icons';
-import { createSvgMarkerIcon, getOpenTopoColor} from './leafletUtil';
-import { getFirstCoordinate } from './utils';
+import { createSvgMarkerIcon, getOpenTopoColor } from './leafletUtil';
+import { getFirstLatLng } from './utils';
 import { useGetOpenTopo } from '@client/hooks';
 
 /* no need to import leaflet css as already in base index
@@ -17,8 +17,6 @@ import 'leaflet/dist/leaflet.css';
 */
 
 import styles from './LeafletMap.module.css';
-import { LatLng } from 'leaflet';
-
 
 export const mapConfig = {
   startingCenter: [40, -80] as L.LatLngTuple,
@@ -70,8 +68,7 @@ export const LeafletMap: React.FC = () => {
     datasets.forEach(({ Dataset: dataset }) => {
       const { geojson } = dataset.spatialCoverage.geo;
 
-      const lngLatArray = getFirstCoordinate(geojson);
-      const latlng = L.latLng(lngLatArray[1], lngLatArray[0]);
+      const latlngPosition = getFirstLatLng(geojson);
 
       const icon = createSvgMarkerIcon({
         color: getOpenTopoColor(dataset),
@@ -81,7 +78,7 @@ export const LeafletMap: React.FC = () => {
       openTopoMarkers.push(
         <Marker
           key={`marker-${dataset.identifier.value}`}
-          position={latlng}
+          position={latlngPosition}
           icon={icon} //{createSvgMarkerIcon({icon: faMapMarkerAlt, color: getOpenTopoColor(dataset)})}
         ></Marker>
       );

--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   MapContainer,
   ZoomControl,
   TileLayer,
   LayersControl,
+  GeoJSON,
+  Marker,
 } from 'react-leaflet';
+
+import { useGetOpenTopo } from '@client/hooks';
 
 /* no need to import leaflet css as already in base index
 import 'leaflet/dist/leaflet.css';
@@ -26,6 +30,42 @@ export const mapConfig = {
  * Leaflet Map
  */
 export const LeafletMap: React.FC = () => {
+  const { data: openTopoData } = useGetOpenTopo();
+
+  const openTopoMapFeatures = useMemo(() => {
+    debugger;
+    const datasets = openTopoData?.Datasets ?? [];
+
+    // Features for open topo (possibly just polygon and multipolygons)
+    const openTopoGeojsonFeatures: React.ReactNode[] = [];
+
+    // Markers for open topo things that aren't points
+    const openTopoMarkers: React.ReactNode[] = [];
+
+    datasets.forEach(({ Dataset: dataset }) => {
+      const { geojson } = dataset.spatialCoverage.geo;
+
+      // Main GeoJSON rendering
+      openTopoGeojsonFeatures.push(
+        <GeoJSON
+          key={`geojson-${dataset.identifier.value}`}
+          data={geojson}
+          /* todo: style */
+          /* todo: popups/events */
+        />
+      );
+
+
+      // Optional marker for non-Point geometries (e.g., Polygon or LineString)
+      // TODO
+
+
+      // TODO for only show when zoomed in and something selected
+    });
+
+    return [...openTopoGeojsonFeatures, ...openTopoMarkers];
+  }, [openTopoData]);
+
   return (
     <>
       <MapContainer
@@ -57,6 +97,9 @@ export const LeafletMap: React.FC = () => {
             />
           </LayersControl.BaseLayer>
         </LayersControl>
+
+        {/* Open Topo features  */}
+        {openTopoMapFeatures}
 
         {/* Zoom control */}
         <ZoomControl position="topright" />

--- a/client/modules/reconportal/src/LeafletMap/OpenTopoPopup.tsx
+++ b/client/modules/reconportal/src/LeafletMap/OpenTopoPopup.tsx
@@ -55,7 +55,9 @@ export const OpenTopoPopup: React.FC<OpenTopoPopupProps> = ({ dataset }) => {
           <br />
           <Link href={doiUrl} target="_blank" rel="noopener noreferrer">
             {doiUrl}
-            <FontAwesomeIcon icon={faExternalLinkAlt} size="sm" />
+            <span style={{ marginLeft: 4 }}>
+                <FontAwesomeIcon icon={faExternalLinkAlt} size="sm" />
+            </span>
           </Link>
         </div>
       </Space>

--- a/client/modules/reconportal/src/LeafletMap/OpenTopoPopup.tsx
+++ b/client/modules/reconportal/src/LeafletMap/OpenTopoPopup.tsx
@@ -31,33 +31,33 @@ export const OpenTopoPopup: React.FC<OpenTopoPopupProps> = ({ dataset }) => {
 
       <Space direction="vertical" size={6}>
         <div>
-          <Text strong>Date of Survey</Text>
+          <Text>Date of Survey</Text>
           <br />
-          <Text>
+          <Text strong>
             {startDate} – {endDate}
           </Text>
         </div>
 
         <div>
-          <Text strong>Data Source</Text>
+          <Text>Data Source</Text>
           <br />
-          <Text>OpenTopography</Text>
+          <Text strong>OpenTopography</Text>
         </div>
 
         <div>
-          <Text strong>Products Available</Text>
+          <Text>Products Available</Text>
           <br />
-          <Text>{product}</Text>
+          <Text strong>{product}</Text>
         </div>
 
         <div>
-          <Text strong>DOI</Text>
+          <Text>DOI</Text>
           <br />
           <Link href={doiUrl} target="_blank" rel="noopener noreferrer">
             {doiUrl}
-            <span style={{ marginLeft: 4 }}>
+            <Text style={{ marginLeft: 4 }} strong>
                 <FontAwesomeIcon icon={faExternalLinkAlt} size="sm" />
-            </span>
+            </Text>
           </Link>
         </div>
       </Space>

--- a/client/modules/reconportal/src/LeafletMap/OpenTopoPopup.tsx
+++ b/client/modules/reconportal/src/LeafletMap/OpenTopoPopup.tsx
@@ -5,9 +5,7 @@ import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { OpenTopoDataset } from '@client/hooks';
 import { Typography, Space } from 'antd';
 
-
 const { Title, Text, Link } = Typography;
-
 
 interface OpenTopoPopupProps {
   dataset: OpenTopoDataset;
@@ -56,7 +54,7 @@ export const OpenTopoPopup: React.FC<OpenTopoPopupProps> = ({ dataset }) => {
           <Link href={doiUrl} target="_blank" rel="noopener noreferrer">
             {doiUrl}
             <span style={{ marginLeft: 4 }}>
-                <FontAwesomeIcon icon={faExternalLinkAlt} size="sm" />
+              <FontAwesomeIcon icon={faExternalLinkAlt} size="sm" />
             </span>
           </Link>
         </div>

--- a/client/modules/reconportal/src/LeafletMap/OpenTopoPopup.tsx
+++ b/client/modules/reconportal/src/LeafletMap/OpenTopoPopup.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import dayjs from 'dayjs';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { OpenTopoDataset } from '@client/hooks';
 import { Typography, Space } from 'antd';
+
+
 const { Title, Text, Link } = Typography;
 
-import dayjs from 'dayjs';
 
 interface OpenTopoPopupProps {
   dataset: OpenTopoDataset;

--- a/client/modules/reconportal/src/LeafletMap/OpenTopoPopup.tsx
+++ b/client/modules/reconportal/src/LeafletMap/OpenTopoPopup.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
+import { OpenTopoDataset } from '@client/hooks';
+import { Typography, Space } from 'antd';
+const { Title, Text, Link } = Typography;
+
+import dayjs from 'dayjs';
+
+interface OpenTopoPopupProps {
+  dataset: OpenTopoDataset;
+}
+
+export const OpenTopoPopup: React.FC<OpenTopoPopupProps> = ({ dataset }) => {
+  const title = dataset.name;
+  const startDate = dayjs(dataset.temporalCoverage.split('/')[0]).format(
+    'MM/DD/YYYY'
+  );
+  const endDate = dayjs(dataset.temporalCoverage.split('/')[1]).format(
+    'MM/DD/YYYY'
+  );
+  const doiUrl = dataset.url;
+  const product = dataset.fileFormat;
+  return (
+    <Typography style={{ fontSize: '0.9rem', lineHeight: 1.4 }}>
+      <Title level={5} style={{ marginBottom: 6 }}>
+        {title}
+      </Title>
+
+      <Space direction="vertical" size={6}>
+        <div>
+          <Text strong>Date of Survey</Text>
+          <br />
+          <Text>
+            {startDate} – {endDate}
+          </Text>
+        </div>
+
+        <div>
+          <Text strong>Data Source</Text>
+          <br />
+          <Text>OpenTopography</Text>
+        </div>
+
+        <div>
+          <Text strong>Products Available</Text>
+          <br />
+          <Text>{product}</Text>
+        </div>
+
+        <div>
+          <Text strong>DOI</Text>
+          <br />
+          <Link href={doiUrl} target="_blank" rel="noopener noreferrer">
+            {doiUrl}
+            <FontAwesomeIcon icon={faExternalLinkAlt} size="sm" />
+          </Link>
+        </div>
+      </Space>
+    </Typography>
+  );
+};

--- a/client/modules/reconportal/src/LeafletMap/OpenTopoPopup.tsx
+++ b/client/modules/reconportal/src/LeafletMap/OpenTopoPopup.tsx
@@ -55,9 +55,9 @@ export const OpenTopoPopup: React.FC<OpenTopoPopupProps> = ({ dataset }) => {
           <br />
           <Link href={doiUrl} target="_blank" rel="noopener noreferrer">
             {doiUrl}
-            <Text style={{ marginLeft: 4 }} strong>
+            <span style={{ marginLeft: 4 }}>
                 <FontAwesomeIcon icon={faExternalLinkAlt} size="sm" />
-            </Text>
+            </span>
           </Link>
         </div>
       </Space>

--- a/client/modules/reconportal/src/LeafletMap/OpenTopoPopup.tsx
+++ b/client/modules/reconportal/src/LeafletMap/OpenTopoPopup.tsx
@@ -24,7 +24,7 @@ export const OpenTopoPopup: React.FC<OpenTopoPopupProps> = ({ dataset }) => {
   const doiUrl = dataset.url;
   const product = dataset.fileFormat;
   return (
-    <Typography style={{ fontSize: '0.9rem', lineHeight: 1.4 }}>
+    <Typography>
       <Title level={5} style={{ marginBottom: 6 }}>
         {title}
       </Title>

--- a/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
+++ b/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
@@ -2,6 +2,8 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { OpenTopoDataset } from '@client/hooks';
+import { LayerGroup, useMap } from 'react-leaflet';
+import { useEffect, useState } from 'react';
 import L from 'leaflet';
 
 /**
@@ -31,8 +33,35 @@ export function createSvgMarkerIcon({
  * Get color for OpenTopo dataset
  */
 export function getOpenTopoColor(dataset: OpenTopoDataset): string {
-  // TODO: derive color from hazard type
+  // TODO: derive color from hazard type https://tacc-main.atlassian.net/browse/WG-510
   //  Confirm we can do this for some and if not what is our fall
   // back color
   return 'black';
 }
+
+
+/**
+ * A React-Leaflet wrapper that conditionally renders its children (e.g. markers, GeoJSON, etc.)
+ * based on the current zoom level of the map.
+ */
+export const ZoomConditionalLayerGroup: React.FC<{
+  minZoom: number;
+  children: React.ReactNode;
+}> = ({ minZoom, children }) => {
+  const map = useMap();
+  const [visible, setVisible] = useState(map.getZoom() >= minZoom);
+
+  useEffect(() => {
+    const updateVisibility = () => {
+      // TODO also include when DS event is selected
+      // See https://github.com/DesignSafe-CI/portal/pull/1558 and https://tacc-main.atlassian.net/browse/WG-500
+      setVisible(map.getZoom() >= minZoom);
+    };
+    map.on('zoomend', updateVisibility);
+    return () => {
+      map.off('zoomend', updateVisibility);
+    };
+  }, [map, minZoom]);
+
+  return visible ? <LayerGroup>{children}</LayerGroup> : null;
+};

--- a/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
+++ b/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { OpenTopoDataset } from '@client/hooks';
+import L from 'leaflet';
 
 /**
  * Create a Leaflet divIcon using any Font Awesome icon with dynamic color and size.

--- a/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
+++ b/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
@@ -39,7 +39,6 @@ export function getOpenTopoColor(dataset: OpenTopoDataset): string {
   return 'black';
 }
 
-
 /**
  * A React-Leaflet wrapper that conditionally renders its children (e.g. markers, GeoJSON, etc.)
  * based on the current zoom level of the map.

--- a/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
+++ b/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
@@ -30,7 +30,7 @@ export function createSvgMarkerIcon({
  * Get color for OpenTopo dataset
  */
 export function getOpenTopoColor(dataset: OpenTopoDataset): string {
-  // TODO: derive color from hazard type 
+  // TODO: derive color from hazard type
   //  Confirm we can do this for some and if not what is our fall
   // back color
   return 'black';

--- a/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
+++ b/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
@@ -1,0 +1,37 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import { OpenTopoDataset } from '@client/hooks';
+
+/**
+ * Create a Leaflet divIcon using any Font Awesome icon with dynamic color and size.
+ */
+export function createSvgMarkerIcon({
+  color = 'black',
+  size = '2x',
+  icon,
+}: {
+  color?: string;
+  size?: 'xs' | 'sm' | 'lg' | '1x' | '2x' | '3x';
+  icon: IconDefinition;
+}): L.DivIcon {
+  const html = renderToStaticMarkup(
+    <FontAwesomeIcon icon={icon} color={color} size={size} />
+  );
+
+  return L.divIcon({
+    className: '',
+    html,
+    iconAnchor: [12, 24],
+  });
+}
+
+/**
+ * Get color for OpenTopo dataset
+ */
+export function getOpenTopoColor(dataset: OpenTopoDataset): string {
+  // TODO: derive color from hazard type 
+  //  Confirm we can do this for some and if not what is our fall
+  // back color
+  return 'black';
+}

--- a/client/modules/reconportal/src/LeafletMap/utils.ts
+++ b/client/modules/reconportal/src/LeafletMap/utils.ts
@@ -5,13 +5,6 @@ import L, { LatLng } from 'leaflet';
 /**
  * Extract the first coordinate from a GeoJSON FeatureCollection
  * and convert it to a Leaflet LatLng ([lat, lng]).
- *
- * This handles nested coordinates, assumes the geometry is not a GeometryCollection,
- * and always returns a Leaflet-friendly format.
- *
- * @param geojson - A GeoJSON FeatureCollection
- * @returns Leaflet LatLng (lat, lng)
- * @throws If no usable geometry is found
  */
 export function getFirstLatLng(geojson: FeatureCollection): LatLng {
   const firstFeature = geojson.features[0];

--- a/client/modules/reconportal/src/LeafletMap/utils.ts
+++ b/client/modules/reconportal/src/LeafletMap/utils.ts
@@ -1,0 +1,18 @@
+import { OpenTopoDataset } from '@client/hooks';
+import { FeatureCollection } from 'geojson';
+
+// TODO docstr and move to better spot and add types
+// and add return type to make clear the order
+export function getFirstCoordinate(geojson: FeatureCollection) {
+  const firstFeature = geojson.features[0];
+  const coords = firstFeature.geometry?.coordinates || firstFeature.coordinates;
+
+  function findFirstCoord(arr) {
+    if (typeof arr[0] === 'number' && typeof arr[1] === 'number') {
+      return arr;
+    }
+    return findFirstCoord(arr[0]);
+  }
+
+  return findFirstCoord(coords);
+}

--- a/client/modules/reconportal/src/LeafletMap/utils.ts
+++ b/client/modules/reconportal/src/LeafletMap/utils.ts
@@ -22,11 +22,10 @@ export function getFirstLatLng(geojson: FeatureCollection): LatLng {
 
   const coords = geometry.coordinates;
 
-  function findFirstCoord(arr: any): Position {
-    if (typeof arr[0] === 'number' && typeof arr[1] === 'number') {
-      return arr as Position;
-    }
-    return findFirstCoord(arr[0]);
+  function findFirstCoord(arr: unknown): Position {
+    if (Array.isArray(arr) && typeof arr[0] === 'number') return arr as Position;
+    if (Array.isArray(arr)) return findFirstCoord(arr[0]);
+    throw new Error('Invalid coordinates');
   }
 
   // lng lat form in geojson

--- a/client/modules/reconportal/src/LeafletMap/utils.ts
+++ b/client/modules/reconportal/src/LeafletMap/utils.ts
@@ -1,18 +1,45 @@
 import { OpenTopoDataset } from '@client/hooks';
-import { FeatureCollection } from 'geojson';
+import { FeatureCollection, Position } from 'geojson';
+import L, { LatLng } from 'leaflet';
 
-// TODO docstr and move to better spot and add types
-// and add return type to make clear the order
-export function getFirstCoordinate(geojson: FeatureCollection) {
+/**
+ * Extract the first coordinate from a GeoJSON FeatureCollection
+ * and convert it to a Leaflet LatLng ([lat, lng]).
+ *
+ * This handles nested coordinates, assumes the geometry is not a GeometryCollection,
+ * and always returns a Leaflet-friendly format.
+ *
+ * @param geojson - A GeoJSON FeatureCollection
+ * @returns Leaflet LatLng (lat, lng)
+ * @throws If no usable geometry is found
+ */
+export function getFirstLatLng(geojson: FeatureCollection): LatLng {
   const firstFeature = geojson.features[0];
-  const coords = firstFeature.geometry?.coordinates || firstFeature.coordinates;
 
-  function findFirstCoord(arr) {
+  const geometry = firstFeature.geometry;
+
+  if (geometry.type === 'GeometryCollection') {
+    // We don't expect this but note we are assuming not GeometryCollection as
+    // it doesn't have `.coordinates` but `.geometries`
+    throw new Error('GeometryCollection not supported');
+  }
+
+  if (!geometry) {
+    throw new Error('No geometry found in first feature');
+  }
+
+  const coords = geometry.coordinates;
+
+  function findFirstCoord(arr: any): Position {
     if (typeof arr[0] === 'number' && typeof arr[1] === 'number') {
-      return arr;
+      return arr as Position;
     }
     return findFirstCoord(arr[0]);
   }
 
-  return findFirstCoord(coords);
+  // lng lat form in geojson
+  const [lng, lat] = findFirstCoord(coords);
+
+  // convert to lat, lng for leaflet use
+  return L.latLng(lat, lng);
 }

--- a/client/modules/reconportal/src/LeafletMap/utils.ts
+++ b/client/modules/reconportal/src/LeafletMap/utils.ts
@@ -1,4 +1,3 @@
-import { OpenTopoDataset } from '@client/hooks';
 import { FeatureCollection, Position } from 'geojson';
 import L, { LatLng } from 'leaflet';
 

--- a/client/modules/reconportal/src/LeafletMap/utils.ts
+++ b/client/modules/reconportal/src/LeafletMap/utils.ts
@@ -23,7 +23,8 @@ export function getFirstLatLng(geojson: FeatureCollection): LatLng {
   const coords = geometry.coordinates;
 
   function findFirstCoord(arr: unknown): Position {
-    if (Array.isArray(arr) && typeof arr[0] === 'number') return arr as Position;
+    if (Array.isArray(arr) && typeof arr[0] === 'number')
+      return arr as Position;
     if (Array.isArray(arr)) return findFirstCoord(arr[0]);
     throw new Error('Invalid coordinates');
   }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@fortawesome/free-solid-svg-icons": "^6.7.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
         "@hookform/resolvers": "^3.3.4",
         "@swc/helpers": "~0.5.2",
         "@tanstack/react-query": "^5.15.0",
@@ -2766,6 +2768,53 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@hookform/resolvers": {
@@ -12458,7 +12507,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13084,7 +13132,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -13094,8 +13141,7 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,8 @@
   },
   "private": true,
   "dependencies": {
+    "@fortawesome/free-solid-svg-icons": "^6.7.2",
+    "@fortawesome/react-fontawesome": "^0.2.2",
     "@hookform/resolvers": "^3.3.4",
     "@swc/helpers": "~0.5.2",
     "@tanstack/react-query": "^5.15.0",


### PR DESCRIPTION
## Overview: ##

Show OpenTopography datasets on map.

Display OpenTopography datasets by rendering the provided GeoJSON (always a polygon or multipolygon). In addition, place a marker for each dataset at one of its vertices to

Note, there is some follow-up work:
- Determine style for open topo datasets (Issues with this in https://tacc-main.atlassian.net/browse/WG-510)
- Include selected feature when determining if open topo datasets should be shown. (waiting onhttps://github.com/DesignSafe-CI/portal/pull/1558)

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-495](https://tacc-main.atlassian.net/browse/WG-495)

## Summary of Changes: ##

## Testing Steps: ##
1. Zoom into an area (Austin or Florida Panhandle)
2. Click on Marker to see popup
3. Click on polygon to see popup
4. Check contents of popup and link to OpenTopo website.

## UI Photos:
![Screenshot 2025-06-11 at 10 29 47 AM](https://github.com/user-attachments/assets/cbd2874a-cdb7-4eb8-942f-9b4872a71705)

