### PR TITLE
bug/WP-1010: Token refresh fails when Tapipy client cannot be instantiated

### DIFF
--- a/designsafe/apps/auth/models.py
+++ b/designsafe/apps/auth/models.py
@@ -3,11 +3,9 @@
 
 import logging
 import time
-import json
 import requests
 from django.db import models
 from django.conf import settings
-import requests.auth
 from tapipy.tapis import Tapis
 from tapipy.errors import BaseTapyException
 


### PR DESCRIPTION
## Overview: ##
We’ve had multiple instances where a user has a faulty Tapis access token but their refresh token is still valid. In these cases a Tapipy client cannot be instantiated (the telltale error is a 404 when listing tenants in [this method](https://github.com/tapis-project/tapipy/blob/4e3d1d25dfd8ed327c3b4d356d8266c5577d4533/tapipy/tapis.py#L346)). The token can only be refreshed by calling the Tapis /oauth2/tokens endpoint directly, after which their new access token is added to the Django user model.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-1010](https://tacc-main.atlassian.net/browse/WP-1010)

## Summary of Changes: ##
Catch the exception that occurs when a Tapipy client fails to instantiate, and attempt a token refresh using a direct call to the Tapis API.

## Testing Steps: ##
Inside the Django shell:
1. `from django.contrib.auth import get_user_model()`
2. `user = get_user_model().objects.get(username=<your username>)`
3. `user.tapis_oauth.refresh_tokens_api()`
These steps should proceed without error and the `created` date on your user's access token should match when the refresh method was called.

## UI Photos:

## Notes: ##
