### PR TITLE
Hotfix/ds download dataset

### DIFF
--- a/conf/docker/docker-compose-dev.all.debug.yml
+++ b/conf/docker/docker-compose-dev.all.debug.yml
@@ -1,7 +1,6 @@
 services:
   redis:
     image: redis:7
-    platform: "linux/amd64"
     volumes:
       - redis_data_v3:/data
     ports:
@@ -10,7 +9,7 @@ services:
     hostname: des_redis
 
   rabbitmq:
-    image: arm64v8/rabbitmq:3.6.14-management
+    image: rabbitmq:3.6.10-management
     volumes:
       - rabbitmq_data_v3:/var/lib/rabbitmq/mnesia/rabbit@des_rabbitmq
     env_file: ../env_files/rabbitmq.env
@@ -21,13 +20,11 @@ services:
 
   memcached:
     image: memcached:latest
-    platform: "linux/amd64"
     container_name: des_memcached
     hostname: des_memcached
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.4.0
-    platform: "linux/amd64"
     ulimits:
       memlock: -1
     environment:
@@ -57,7 +54,6 @@ services:
 
   nginx:
     image: nginx
-    platform: "linux/amd64"
     volumes:
       - ../nginx/nginx.debug.conf:/etc/nginx/nginx.conf
       - ../nginx/gzip.conf:/etc/nginx/gzip.conf


### PR DESCRIPTION
## Overview: ##
On DS publications, need the 2G limit changed to 5G and then button to turn on.
Also, change the message in the pop up - the last sentence at the top:
"Alternatively, download subsets of files or individually by selecting the file and using the download button in the toolbar."

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DES-XXXX](https://tacc-main.atlassian.net/browse/DES-XXXX)

## Summary of Changes: ##

## Testing Steps: ##
1. 

## UI Photos:

## Notes: ##
