### PR TITLE
Fixed vm or non-hpc app to default system selection

### DIFF
--- a/client/modules/workspace/src/components/SystemStatusModal/SystemStatusModal.tsx
+++ b/client/modules/workspace/src/components/SystemStatusModal/SystemStatusModal.tsx
@@ -46,9 +46,16 @@ const SystemStatusContent: React.FC<SystemStatusModalProps> = ({
   }, [app, appId, executionSystems]);
 
   const { data: systems, isLoading, error } = useSystemOverview();
+  const availableSystems = systems?.map((sys) => sys.display_name) || [];
   const selectedSystem = systems?.find(
     (sys) => sys.display_name === activeSystem
   );
+
+  useEffect(() => {
+    if (systems && !availableSystems.includes(activeSystem)) {
+      setActiveSystem('Vista');
+    }
+  }, [systems, activeSystem]);
 
   return (
     <Modal
@@ -111,7 +118,7 @@ const SystemStatusContent: React.FC<SystemStatusModalProps> = ({
               </div>
             </>
           ) : (
-            <div>No data found for {activeSystem}</div>
+            <div>No data found</div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Overview: ##
Fixed issue when selecting either a VM or non-HPC app that it would not show any queues for systems until manually pressed on.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-686](https://tacc-main.atlassian.net/browse/WP-686)

## Summary of Changes: ##
-Modified SystemStatusModal.tsx to automatically default to Vista system when the app's default execution system is not one of the main HPC systems (Frontera, Vista, Stampede3, Lonestar6)

-Added useEffect to automatically switch to Vista when activeSystem is not in the available systems list


## Testing Steps: ##
1. Open app using VM or non-hpc
<img width="309" alt="Screenshot 2025-06-25 at 7 06 38 PM" src="https://github.com/user-attachments/assets/cebdd591-0db9-49d3-98db-47f5f79e0bfb" />

2.Verify Vista is selected when system status modal is opened up

## UI Photos:

## Notes: ##
