### PR TITLE
hotfix/main-nav-event-type-color-bug

### DIFF
--- a/client/modules/reconportal/src/ReconSidePanel/ReconSidePanel.tsx
+++ b/client/modules/reconportal/src/ReconSidePanel/ReconSidePanel.tsx
@@ -25,7 +25,7 @@ import {
 import { formatDate } from '@client/workspace';
 import dayjs from 'dayjs';
 import { CloseOutlined } from '@ant-design/icons';
-import { getReconEventColor } from '../utils';
+import { getReconEventColor, EVENT_TYPE_COLORS } from '../utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faLocationDot } from '@fortawesome/free-solid-svg-icons';
 
@@ -135,7 +135,13 @@ export const ReconSidePanel: React.FC<LayoutProps> = ({
               {formatDate(new Date(date))}
             </Text>
             <Tag
-              color={getReconEventColor(selectedEvent)}
+              color={
+                selectedEvent
+                  ? getReconEventColor(selectedEvent)
+                  : EVENT_TYPE_COLORS[
+                      eventType as keyof typeof EVENT_TYPE_COLORS
+                    ]
+              }
               style={{
                 fontWeight: 600,
                 fontSize: 14,


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Summary of Changes: ##

## Testing Steps: ##
1. Go to [https://designsafe.dev/recon-portal/](https://designsafe.dev/recon-portal/) and make sure main page has the colors for the Event Type tags on the left side panel 

## UI Photos:
![Screenshot 2025-07-01 at 4 13 23 PM](https://github.com/user-attachments/assets/5e63a57b-5ddc-4693-a49a-0cad4d4e1b01)


## Notes: ##
