### PR TITLE
Working when selecting app w/o exec system

### DIFF
--- a/client/modules/workspace/src/components/SystemStatusModal/SystemStatusModal.tsx
+++ b/client/modules/workspace/src/components/SystemStatusModal/SystemStatusModal.tsx
@@ -39,7 +39,7 @@ const SystemStatusContent: React.FC<SystemStatusModalProps> = ({
         appExecSystems
       );
 
-      if (defaultExecSystem?.id) {
+      if (defaultExecSystem && defaultExecSystem?.id) {
         setActiveSystem(getSystemDisplayName(defaultExecSystem.id));
       }
     }

--- a/client/modules/workspace/src/utils/apps.ts
+++ b/client/modules/workspace/src/utils/apps.ts
@@ -50,6 +50,9 @@ export const getExecSystemsFromApp = (
     );
   }
 
+  const execSystemId = definition.jobAttributes?.execSystemId;
+  if (!execSystemId) return [];
+
   const sys = execSystems.find(
     (s) => s.id === definition.jobAttributes.execSystemId
   );
@@ -68,7 +71,7 @@ export const getDefaultExecSystem = (
   if (!isAppUsingDynamicExecSystem(definition)) {
     return getExecSystemFromId(
       execSystems,
-      definition.jobAttributes.execSystemId
+      definition.jobAttributes?.execSystemId
     );
   }
 


### PR DESCRIPTION
## Overview: ##
Fixes crash when accessing apps without a exec system.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-1016](https://tacc-main.atlassian.net/jira/software/c/projects/WP/boards/46?assignee=712020%3Aa66df098-eece-4aae-a1c3-6b226867069f&selectedIssue=WP-1016)

## Summary of Changes: ##
-Used optional chaining to prevent accessing properties of undefined
-if jobAttributes or execSystemId is missing return empty array
## Testing Steps: ##
1. Open app that dosen't have exec system like Simulation -> Ansys or Simulation -> EE-UQ -> EE-UQ (Download)

## UI Photos:
<img width="1026" alt="Screenshot 2025-07-07 at 3 09 30 PM" src="https://github.com/user-attachments/assets/c05303e0-a3ff-4160-a5de-260b6cbc3600" />
<img width="1022" alt="Screenshot 2025-07-07 at 3 09 44 PM" src="https://github.com/user-attachments/assets/0362a14f-e480-4f97-9b01-49bed3a1fd87" />

## Notes: ##
