### PR TITLE
task/wg-519-add-hover-on-opentopo

### DIFF
--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.spec.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.spec.tsx
@@ -1,0 +1,10 @@
+import { render } from '@client/test-fixtures';
+
+import { LeafletMap } from './LeafletMap';
+
+describe('Recon Portal leaflet map', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<LeafletMap />);
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
@@ -96,6 +96,10 @@ export const LeafletMap: React.FC = () => {
                 layer.getPopup()?.update();
               }, 0);
             });
+            layer.on('mouseover', () => {
+              const thisPopup = layer.getPopup();
+              thisPopup?.togglePopup();
+            });
           }}
         />
       );
@@ -119,6 +123,11 @@ export const LeafletMap: React.FC = () => {
           key={`marker-${dataset.identifier.value}-${index}`}
           position={latlngPosition}
           icon={icon}
+          eventHandlers={{
+            mouseover: (e) => {
+              e.target.togglePopup();
+            },
+          }}
         >
           <Popup>
             <OpenTopoPopup dataset={dataset} />


### PR DESCRIPTION
## Overview: ##

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-519](https://tacc-main.atlassian.net/browse/WP-519)

## Summary of Changes: ##

Adds hover popup over open topography markers and geojsons

## Testing Steps: ##
1. Go to [https://designsafe.dev/recon-portal/?eventId=2017-hurricane-harvey](https://designsafe.dev/recon-portal/?eventId=2017-hurricane-harvey)
2. Check the functionality of the popup on click, hover, and mouse out.
3. Make sure test successfully runs

## UI Photos:

## Notes: ##
