### PR TITLE
Hotfix: Prevent long category names from overflowing the selection UI

### DIFF
--- a/client/modules/datafiles/src/projects/ProjectCurationFileListing/ProjectCurationFileListing.tsx
+++ b/client/modules/datafiles/src/projects/ProjectCurationFileListing/ProjectCurationFileListing.tsx
@@ -207,7 +207,7 @@ const FileCurationSelector: React.FC<{
       ))}
       <li style={{ display: 'flex', gap: '4rem' }}>
         {showEntitySelector ? (
-          <section style={{ display: 'flex', flex: 1 }}>
+          <section style={{ display: 'flex', flex: 1, minWidth: 0 }}>
             <Select<string>
               virtual={false}
               value={selectedEntity}
@@ -219,10 +219,11 @@ const FileCurationSelector: React.FC<{
                   ? `for ${selectedFiles.length} selected file(s)`
                   : ''
               }`}
-              style={{ flex: 1 }}
+              style={{ flex: 1, minWidth: 0 }}
             />
             {selectedEntity && (
               <Button
+                style={{ marginLeft: '5px' }}
                 onClick={() =>
                   addFileAssociation(
                     {
@@ -240,7 +241,7 @@ const FileCurationSelector: React.FC<{
                 }
                 type="link"
               >
-                &nbsp; Save
+                Save
               </Button>
             )}
           </section>


### PR DESCRIPTION
## Overview: ##
Needed to set a minimum width of 0 on flex elements to prevent them from overflowing past the visible width of the table cell.