### PR TITLE
task/WG-520 -  Recon Portal Map Filtering

### DIFF
--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
@@ -52,7 +52,7 @@ export const mapConfig = {
  */
 export const LeafletMap: React.FC = () => {
   const { data: openTopoData } = useGetOpenTopo();
-  const { setSelectedReconPortalEventIdentifier } = useReconEventContext();
+  const { setSelectedReconPortalEventIdentifier, filteredReconPortalEvents } = useReconEventContext();
 
   const openTopoMapFeatures = useMemo(() => {
     const datasets = openTopoData?.Datasets ?? [];
@@ -130,8 +130,6 @@ export const LeafletMap: React.FC = () => {
     return [...openTopoGeojsonFeatures, ...openTopoMarkers];
   }, [openTopoData]);
 
-  const { data: reconData } = useGetReconPortalEvents();
-
   const handleFeatureClick = (reconEvent: ReconPortalEvents) => {
     setSelectedReconPortalEventIdentifier(
       getReconPortalEventIdentifier(reconEvent)
@@ -139,7 +137,7 @@ export const LeafletMap: React.FC = () => {
   };
 
   const ReconPortalEvents = useMemo(() => {
-    const datasets = reconData ?? [];
+    const datasets = filteredReconPortalEvents ?? [];
     const reconPortalMarkers: React.ReactNode[] = [];
 
     datasets.map((reconEvent, index) => {
@@ -171,7 +169,7 @@ export const LeafletMap: React.FC = () => {
       );
     });
     return [...reconPortalMarkers];
-  }, [reconData]);
+  }, [filteredReconPortalEvents]);
 
   return (
     <>

--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
@@ -20,7 +20,6 @@ import {
 import { getOpenTopoColor, getReconEventColor } from '../utils';
 import { getFirstLatLng } from './utils';
 import {
-  useGetReconPortalEvents,
   type ReconPortalEvents,
   useGetOpenTopo,
   useReconEventContext,

--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
@@ -52,7 +52,8 @@ export const mapConfig = {
  */
 export const LeafletMap: React.FC = () => {
   const { data: openTopoData } = useGetOpenTopo();
-  const { setSelectedReconPortalEventIdentifier, filteredReconPortalEvents } = useReconEventContext();
+  const { setSelectedReconPortalEventIdentifier, filteredReconPortalEvents } =
+    useReconEventContext();
 
   const openTopoMapFeatures = useMemo(() => {
     const datasets = openTopoData?.Datasets ?? [];


### PR DESCRIPTION
## Overview: ##

Sync markers on the map with filters from the side panel

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-520](https://tacc-main.atlassian.net/browse/WG-520)

## Summary of Changes: ##

- Updated to use `useReconEventContext` to get `filteredReconPortalEvents` to display on map

## Testing Steps: ##
1. Go to Recon Portal and use the filters in the side panel. Make sure map markers are updated accordingly

