### PR TITLE
task/WG-523 - Persistent Recon Portal Map Pin Banner

### DIFF
--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import ReactDOM from 'react-dom/client';
 import {
   MapContainer,
@@ -51,8 +51,26 @@ export const mapConfig = {
  */
 export const LeafletMap: React.FC = () => {
   const { data: openTopoData } = useGetOpenTopo();
-  const { setSelectedReconPortalEventIdentifier, filteredReconPortalEvents } =
-    useReconEventContext();
+  const {
+    setSelectedReconPortalEventIdentifier,
+    filteredReconPortalEvents,
+    selectedReconPortalEventIdentfier,
+  } = useReconEventContext();
+
+  const [showSelectedPopup, setShowSelectedPopup] = useState(false);
+
+  // Handle delayed popup showing
+  useEffect(() => {
+    setShowSelectedPopup(false);
+
+    if (!selectedReconPortalEventIdentfier) return;
+
+    const timer = setTimeout(() => {
+      setShowSelectedPopup(true);
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [selectedReconPortalEventIdentfier]);
 
   const openTopoMapFeatures = useMemo(() => {
     const datasets = openTopoData?.Datasets ?? [];
@@ -136,6 +154,15 @@ export const LeafletMap: React.FC = () => {
     );
   };
 
+  // Find the selected event for the banner
+  const selectedEvent = selectedReconPortalEventIdentfier
+    ? filteredReconPortalEvents?.find(
+        (event) =>
+          getReconPortalEventIdentifier(event) ===
+          selectedReconPortalEventIdentfier
+      )
+    : null;
+
   const ReconPortalEvents = useMemo(() => {
     const datasets = filteredReconPortalEvents ?? [];
     const reconPortalMarkers: React.ReactNode[] = [];
@@ -153,12 +180,24 @@ export const LeafletMap: React.FC = () => {
           eventHandlers={{
             click: (e) => handleFeatureClick(reconEvent),
             mouseover: (e) => {
-              e.target.openPopup();
+              // Only show hover popup if this marker is not currently selected
+              if (
+                getReconPortalEventIdentifier(reconEvent) !==
+                selectedReconPortalEventIdentfier
+              ) {
+                e.target.openPopup();
+              }
             },
             mouseout: (e) => {
-              setTimeout(() => {
-                e.target.closePopup();
-              }, 1000);
+              // Only close hover popup if this marker is not currently selected
+              if (
+                getReconPortalEventIdentifier(reconEvent) !==
+                selectedReconPortalEventIdentfier
+              ) {
+                setTimeout(() => {
+                  e.target.closePopup();
+                }, 1000);
+              }
             },
           }}
         >
@@ -169,7 +208,7 @@ export const LeafletMap: React.FC = () => {
       );
     });
     return [...reconPortalMarkers];
-  }, [filteredReconPortalEvents]);
+  }, [filteredReconPortalEvents, selectedReconPortalEventIdentfier]);
 
   return (
     <>
@@ -226,6 +265,18 @@ export const LeafletMap: React.FC = () => {
         </MarkerClusterGroup>
         {/* Zoom control */}
         <ZoomControl position="topright" />
+
+        {/* Selected event banner popup */}
+        {selectedEvent && showSelectedPopup && (
+          <Popup
+            position={[selectedEvent.location.lat, selectedEvent.location.lon]}
+            offset={[0, -10]}
+            closeButton={false}
+            closeOnClick={false}
+          >
+            <ReconPortalPopup dataset={selectedEvent} />
+          </Popup>
+        )}
       </MapContainer>
     </>
   );


### PR DESCRIPTION
## Overview: ##

Adds a persistent banner on top of a map marker for a selected event

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-523](https://tacc-main.atlassian.net/browse/WG-523)

## Summary of Changes: ##

- Added a persistent banner on top of a map marker when an event is selected
- There is a 1 second delay after event selection and the banner display. This was done due to UI glitches that were happening when the map was zooming into the marker and the banner was appearing

## Testing Steps: ##
1. Go to Recon Portal and select an event. Make sure map zooms into the event marker and a persistent banner is shown

## UI Photos:

<img width="1916" height="928" alt="Screenshot 2025-07-17 at 10 43 44 AM" src="https://github.com/user-attachments/assets/f210e3ee-e3f3-4ce4-9b3f-73d36f0f64c1" />



## Notes: ##
