### PR TITLE
WC-74 and WC-278: Entity Keywords and Datacite Updates

### DIFF
--- a/client/modules/_hooks/src/datafiles/projects/types.ts
+++ b/client/modules/_hooks/src/datafiles/projects/types.ts
@@ -120,6 +120,7 @@ export type TEntityValue = {
   dois?: string[];
   referencedData: TReferencedWork[];
   relatedWork: TAssociatedProject[];
+  keywords?: string[];
 
   experimentType?: TDropdownValue;
   equipmentType?: TDropdownValue;

--- a/client/modules/datafiles/src/projects/ProjectListing.tsx
+++ b/client/modules/datafiles/src/projects/ProjectListing.tsx
@@ -60,7 +60,7 @@ export const ProjectListing: React.FC = () => {
                 showIcon
                 type="error"
                 description={
-                  <span>There was an error retrieving your projects."</span>
+                  <span>There was an error retrieving your projects.</span>
                 }
               />
             )}

--- a/client/modules/datafiles/src/projects/PublishedEntityDetails.tsx
+++ b/client/modules/datafiles/src/projects/PublishedEntityDetails.tsx
@@ -218,13 +218,14 @@ export const PublishedEntityDetails: React.FC<{
               </td>
             </tr>
           )}
-
-          <tr className={styles['prj-row']}>
-            <td>Keywords</td>
-            <td style={{ fontWeight: 'bold' }}>
-              {entityValue.keywords?.join(', ')}
-            </td>
-          </tr>
+          {entityValue.keywords && entityValue.keywords[0] && (
+            <tr className={styles['prj-row']}>
+              <td>Keywords</td>
+              <td style={{ fontWeight: 'bold' }}>
+                {entityValue.keywords?.join(', ')}
+              </td>
+            </tr>
+          )}
         </tbody>
       </table>
       <DescriptionExpander>

--- a/client/modules/datafiles/src/projects/PublishedEntityDetails.tsx
+++ b/client/modules/datafiles/src/projects/PublishedEntityDetails.tsx
@@ -218,6 +218,13 @@ export const PublishedEntityDetails: React.FC<{
               </td>
             </tr>
           )}
+
+          <tr className={styles['prj-row']}>
+            <td>Keywords</td>
+            <td style={{ fontWeight: 'bold' }}>
+              {entityValue.keywords?.join(', ')}
+            </td>
+          </tr>
         </tbody>
       </table>
       <DescriptionExpander>

--- a/client/modules/datafiles/src/projects/forms/PublishableEntityForm.tsx
+++ b/client/modules/datafiles/src/projects/forms/PublishableEntityForm.tsx
@@ -1,4 +1,4 @@
-import { Form, Input, Button, FormInstance, Alert } from 'antd';
+import { Form, Input, Button, FormInstance, Alert, Select } from 'antd';
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   facilityOptions,
@@ -128,6 +128,22 @@ const ExperimentFormFields: React.FC<{
         <RelatedWorkInput name={['value', 'relatedWork']} />
       </Form.Item>
 
+      <Form.Item label="Keywords" required>
+        Choose informative words that indicate the content of the project.
+        Keywords should be comma-separated.
+        <Form.Item
+          name={['value', 'keywords']}
+          rules={[{ required: true }]}
+          className="inner-form-item"
+        >
+          <Select
+            mode="tags"
+            notFoundContent={null}
+            tokenSeparators={[',']}
+          ></Select>
+        </Form.Item>
+      </Form.Item>
+
       <Form.Item label="Experiment Description" required>
         What was under investigation? How was it tested? What was the outcome?
         How can the data be reused? Description must be between 50 and 5000
@@ -243,6 +259,22 @@ const SimulationFormFields: React.FC<{
         <RelatedWorkInput name={['value', 'relatedWork']} />
       </Form.Item>
 
+      <Form.Item label="Keywords" required>
+        Choose informative words that indicate the content of the project.
+        Keywords should be comma-separated.
+        <Form.Item
+          name={['value', 'keywords']}
+          rules={[{ required: true }]}
+          className="inner-form-item"
+        >
+          <Select
+            mode="tags"
+            notFoundContent={null}
+            tokenSeparators={[',']}
+          ></Select>
+        </Form.Item>
+      </Form.Item>
+
       <Form.Item label="Simulation Description" required>
         What was under investigation? How was it tested? What was the outcome?
         How can the data be reused? Description must be between 50 and 5000
@@ -356,6 +388,22 @@ const HybridSimFormFields: React.FC<{
         Information giving context, a linked dataset on DesignSafe, or works
         citing the DOI for this dataset.
         <RelatedWorkInput name={['value', 'relatedWork']} />
+      </Form.Item>
+
+      <Form.Item label="Keywords" required>
+        Choose informative words that indicate the content of the project.
+        Keywords should be comma-separated.
+        <Form.Item
+          name={['value', 'keywords']}
+          rules={[{ required: true }]}
+          className="inner-form-item"
+        >
+          <Select
+            mode="tags"
+            notFoundContent={null}
+            tokenSeparators={[',']}
+          ></Select>
+        </Form.Item>
       </Form.Item>
 
       <Form.Item label="Simulation Description" required>
@@ -527,6 +575,22 @@ const MissionFormFields: React.FC<{
         </div>
       </Form.Item>
 
+      <Form.Item label="Keywords" required>
+        Choose informative words that indicate the content of the project.
+        Keywords should be comma-separated.
+        <Form.Item
+          name={['value', 'keywords']}
+          rules={[{ required: true }]}
+          className="inner-form-item"
+        >
+          <Select
+            mode="tags"
+            notFoundContent={null}
+            tokenSeparators={[',']}
+          ></Select>
+        </Form.Item>
+      </Form.Item>
+
       <Form.Item label="Mission Description" required>
         What was under investigation? How was it tested? What was the outcome?
         How can the data be reused? Description must be between 50 and 5000
@@ -619,6 +683,22 @@ const DocumentFormFields: React.FC<{
             projectUsers={projectUsers}
             currentAuthors={currentAuthors}
           />
+        </Form.Item>
+      </Form.Item>
+
+      <Form.Item label="Keywords" required>
+        Choose informative words that indicate the content of the project.
+        Keywords should be comma-separated.
+        <Form.Item
+          name={['value', 'keywords']}
+          rules={[{ required: true }]}
+          className="inner-form-item"
+        >
+          <Select
+            mode="tags"
+            notFoundContent={null}
+            tokenSeparators={[',']}
+          ></Select>
         </Form.Item>
       </Form.Item>
 

--- a/client/modules/datafiles/src/projects/forms/PublishableEntityForm.tsx
+++ b/client/modules/datafiles/src/projects/forms/PublishableEntityForm.tsx
@@ -406,7 +406,7 @@ const HybridSimFormFields: React.FC<{
         </Form.Item>
       </Form.Item>
 
-      <Form.Item label="Simulation Description" required>
+      <Form.Item label="Hybrid Simulation Description" required>
         What was under investigation? How was it tested? What was the outcome?
         How can the data be reused? Description must be between 50 and 5000
         characters in length.
@@ -702,7 +702,7 @@ const DocumentFormFields: React.FC<{
         </Form.Item>
       </Form.Item>
 
-      <Form.Item label="Mission Description" required>
+      <Form.Item label="Document Description" required>
         What was under investigation? How was it tested? What was the outcome?
         How can the data be reused? Description must be between 50 and 5000
         characters in length.

--- a/designsafe/apps/api/projects_v2/operations/datacite_operations.py
+++ b/designsafe/apps/api/projects_v2/operations/datacite_operations.py
@@ -52,6 +52,7 @@ def get_datacite_json(
     author_attr = []
     institutions = []
     entity_meta = pub_graph.nodes[entity_node]["value"]
+    print(entity_meta)
     authors = entity_meta.get("authors", [])
     datacite_authors = [
         author for author in authors if not author.get("authorship") is False
@@ -62,6 +63,14 @@ def get_datacite_json(
                 "name": f"{author.get('lname', '')}, {author.get('fname', '')}",
                 "givenName": author.get("fname", ""),
                 "familyName": author.get("lname", ""),
+                "affiliation": [
+                    {
+                        "name": author.get("inst",""),
+                        "schemeUri": None,
+                        "affiliationIdentifier": None,
+                        "affiliationIdentifierScheme": None,
+                    }
+                ],
             }
         )
         institutions.append(author.get("inst", ""))
@@ -80,7 +89,7 @@ def get_datacite_json(
     ]
     if not is_other:
         datacite_json["titles"].append(
-            {"title": f"in {base_meta['title']}", "titleType": "Subtitle"}
+            {"title": f"in {base_meta['title']}"}
         )
     datacite_json["publisher"] = "Designsafe-CI"
 
@@ -119,6 +128,10 @@ def get_datacite_json(
     datacite_json["subjects"] = [
         {"subject": keyword} for keyword in base_meta.get("keywords", [])
     ]
+    if not is_other:
+        datacite_json["subjects"].append(
+            {"subject": keyword} for keyword in entity_meta.get("keywords", [])
+        )
 
     facilities = entity_meta.get("facilities", [])
     if exp_facility := entity_meta.get("facility", None):
@@ -181,8 +194,22 @@ def get_datacite_json(
     if version and version > 1:
         datacite_url += f"/?version={version}"
 
+    #todo: fill this out with license info
+    datacite_json["rightsList"] = [
+        {
+            "lang": "en",
+            "rights": base_meta["license"],
+            "rightsUri": None,
+            "schemeUri": None,
+            "rightsIdentifier": None,
+            "rightsIdentifierScheme": None,
+        }
+    ]
+
     datacite_json["url"] = datacite_url
     datacite_json["prefix"] = settings.DATACITE_SHOULDER
+
+    print(datacite_json)
 
     return datacite_json
 

--- a/designsafe/apps/api/projects_v2/operations/datacite_operations.py
+++ b/designsafe/apps/api/projects_v2/operations/datacite_operations.py
@@ -127,18 +127,8 @@ def get_datacite_json(
         for desc in set([base_meta["description"], entity_meta["description"]])
     ]
 
-    # datacite_json["subjects"] = [
-    #     {"subject": keyword} for keyword in base_meta.get("keywords", [])
-    # ]
-    # if not is_other:
-    #     entity_keywords = []
-    #     for keyword in entity_meta.get("keywords",[]):
-    #         entity_keywords.append({"subject": keyword})
-    #     all_keywords = datacite_json["subjects"] + entity_keywords
-    #     datacite_json["subjects"] = all_keywords
-
     if not is_other:
-        all_keywords = base_meta.get("keywords", []) + entity_meta["keywords"]
+        all_keywords = base_meta.get("keywords", []) + entity_meta.get("keywords",[])
         datacite_json["subjects"] = [
             {"subject": keyword} for keyword in all_keywords
         ]
@@ -208,7 +198,6 @@ def get_datacite_json(
     if version and version > 1:
         datacite_url += f"/?version={version}"
 
-    #todo: fill this out with license info
     datacite_json["rightsList"] = [
         {
             "lang": "en",
@@ -222,8 +211,6 @@ def get_datacite_json(
 
     datacite_json["url"] = datacite_url
     datacite_json["prefix"] = settings.DATACITE_SHOULDER
-
-    print(datacite_json)
 
     return datacite_json
 

--- a/designsafe/apps/api/projects_v2/operations/datacite_operations.py
+++ b/designsafe/apps/api/projects_v2/operations/datacite_operations.py
@@ -52,7 +52,6 @@ def get_datacite_json(
     author_attr = []
     institutions = []
     entity_meta = pub_graph.nodes[entity_node]["value"]
-    print(entity_meta)
     authors = entity_meta.get("authors", [])
     datacite_authors = [
         author for author in authors if not author.get("authorship") is False
@@ -125,13 +124,25 @@ def get_datacite_json(
         for desc in set([base_meta["description"], entity_meta["description"]])
     ]
 
-    datacite_json["subjects"] = [
-        {"subject": keyword} for keyword in base_meta.get("keywords", [])
-    ]
+    # datacite_json["subjects"] = [
+    #     {"subject": keyword} for keyword in base_meta.get("keywords", [])
+    # ]
+    # if not is_other:
+    #     entity_keywords = []
+    #     for keyword in entity_meta.get("keywords",[]):
+    #         entity_keywords.append({"subject": keyword})
+    #     all_keywords = datacite_json["subjects"] + entity_keywords
+    #     datacite_json["subjects"] = all_keywords
+
     if not is_other:
-        datacite_json["subjects"].append(
-            {"subject": keyword} for keyword in entity_meta.get("keywords", [])
-        )
+        all_keywords = base_meta.get("keywords", []) + entity_meta["keywords"]
+        datacite_json["subjects"] = [
+            {"subject": keyword} for keyword in all_keywords
+        ]
+    else:
+        datacite_json["subjects"] = [
+            {"subject": keyword} for keyword in base_meta.get("keywords", [])
+        ]
 
     facilities = entity_meta.get("facilities", [])
     if exp_facility := entity_meta.get("facility", None):

--- a/designsafe/apps/api/projects_v2/operations/datacite_operations.py
+++ b/designsafe/apps/api/projects_v2/operations/datacite_operations.py
@@ -64,7 +64,7 @@ def get_datacite_json(
                 "familyName": author.get("lname", ""),
                 "affiliation": [
                     {
-                        "name": author.get("inst",""),
+                        "name": author.get("inst", ""),
                         "schemeUri": None,
                         "affiliationIdentifier": None,
                         "affiliationIdentifierScheme": None,
@@ -87,12 +87,13 @@ def get_datacite_json(
     if not is_other:
 
         datacite_json["titles"] = [
-            {"title": f"{title} in {base_meta['title']}"} for title in set([entity_meta["title"]])
+            {"title": f"{title}, in {base_meta['title']}"}
+            for title in set([entity_meta["title"]])
         ]
     else:
         datacite_json["titles"] = [
-        {"title": title} for title in set([entity_meta["title"]])
-    ]
+            {"title": title} for title in set([entity_meta["title"]])
+        ]
     datacite_json["publisher"] = "Designsafe-CI"
 
     if version == 1 or not version:
@@ -128,10 +129,8 @@ def get_datacite_json(
     ]
 
     if not is_other:
-        all_keywords = base_meta.get("keywords", []) + entity_meta.get("keywords",[])
-        datacite_json["subjects"] = [
-            {"subject": keyword} for keyword in all_keywords
-        ]
+        all_keywords = base_meta.get("keywords", []) + entity_meta.get("keywords", [])
+        datacite_json["subjects"] = [{"subject": keyword} for keyword in all_keywords]
     else:
         datacite_json["subjects"] = [
             {"subject": keyword} for keyword in base_meta.get("keywords", [])

--- a/designsafe/apps/api/projects_v2/operations/datacite_operations.py
+++ b/designsafe/apps/api/projects_v2/operations/datacite_operations.py
@@ -83,13 +83,16 @@ def get_datacite_json(
         for institution in list(set(institutions))
     ]
     datacite_json["creators"] = author_attr
-    datacite_json["titles"] = [
+
+    if not is_other:
+
+        datacite_json["titles"] = [
+            {"title": f"{title} in {base_meta['title']}"} for title in set([entity_meta["title"]])
+        ]
+    else:
+        datacite_json["titles"] = [
         {"title": title} for title in set([entity_meta["title"]])
     ]
-    if not is_other:
-        datacite_json["titles"].append(
-            {"title": f"in {base_meta['title']}"}
-        )
     datacite_json["publisher"] = "Designsafe-CI"
 
     if version == 1 or not version:

--- a/designsafe/apps/api/projects_v2/schema_models/experimental.py
+++ b/designsafe/apps/api/projects_v2/schema_models/experimental.py
@@ -17,6 +17,7 @@ from designsafe.apps.api.projects_v2.schema_models._field_transforms import (
     handle_array_of_none,
     handle_legacy_authors,
     handle_dropdown_value,
+    handle_keywords,
 )
 from designsafe.apps.api.projects_v2.constants import (
     FACILITY_OPTIONS,
@@ -36,6 +37,8 @@ class Experiment(MetadataModel):
 
     referenced_data: list[ReferencedWork] = []
     related_work: list[AssociatedProject] = []
+
+    keywords: Annotated[list[str], BeforeValidator(handle_keywords)] = []
 
     facility: Annotated[
         Optional[DropdownValue],

--- a/designsafe/apps/api/projects_v2/schema_models/field_recon.py
+++ b/designsafe/apps/api/projects_v2/schema_models/field_recon.py
@@ -16,6 +16,7 @@ from designsafe.apps.api.projects_v2.schema_models._field_transforms import (
     handle_array_of_none,
     handle_legacy_authors,
     handle_dropdown_values,
+    handle_keywords,
 )
 from designsafe.apps.api.projects_v2.constants import (
     FR_EQUIPMENT_TYPES,
@@ -33,6 +34,8 @@ class Mission(MetadataModel):
 
     referenced_data: list[ReferencedWork] = []
     related_work: list[AssociatedProject] = []
+
+    keywords: Annotated[list[str], BeforeValidator(handle_keywords)] = []
 
     event: str = ""
     date_start: Optional[str] = None

--- a/designsafe/apps/api/projects_v2/schema_models/field_recon.py
+++ b/designsafe/apps/api/projects_v2/schema_models/field_recon.py
@@ -100,6 +100,8 @@ class FieldReconReport(MetadataModel):
     ] = []
     related_work: list[AssociatedProject] = []
 
+    keywords: Annotated[list[str], BeforeValidator(handle_keywords)] = []
+
     file_tags: list[FileTag] = []
     authors: Annotated[list[ProjectUser], BeforeValidator(handle_legacy_authors)] = (
         Field(default=[], validation_alias=AliasChoices("authors", "dataCollectors"))

--- a/designsafe/apps/api/projects_v2/schema_models/hybrid_sim.py
+++ b/designsafe/apps/api/projects_v2/schema_models/hybrid_sim.py
@@ -16,6 +16,7 @@ from designsafe.apps.api.projects_v2.schema_models._field_transforms import (
     handle_array_of_none,
     handle_legacy_authors,
     handle_dropdown_value,
+    handle_keywords,
 )
 from designsafe.apps.api.projects_v2.constants import HYBRID_SIM_TYPES
 
@@ -34,6 +35,7 @@ class HybridSimulation(MetadataModel):
     procedure_end: Optional[str] = None
     referenced_data: list[ReferencedWork] = []
     related_work: list[AssociatedProject] = []
+    keywords: Annotated[list[str], BeforeValidator(handle_keywords)] = []
     authors: Annotated[list[ProjectUser], BeforeValidator(handle_legacy_authors)] = []
     project: list[str] = []
     dois: list[str] = []

--- a/designsafe/apps/api/projects_v2/schema_models/simulation.py
+++ b/designsafe/apps/api/projects_v2/schema_models/simulation.py
@@ -16,6 +16,7 @@ from designsafe.apps.api.projects_v2.schema_models._field_transforms import (
     handle_array_of_none,
     handle_legacy_authors,
     handle_dropdown_value,
+    handle_keywords,
 )
 from designsafe.apps.api.projects_v2.constants import SIMULATION_TYPES
 
@@ -32,6 +33,7 @@ class Simulation(MetadataModel):
     simulation_type_other: Optional[str] = Field(exclude=True, default=None)
     referenced_data: list[ReferencedWork] = []
     related_work: list[AssociatedProject] = []
+    keywords: Annotated[list[str], BeforeValidator(handle_keywords)] = []
     authors: Annotated[list[ProjectUser], BeforeValidator(handle_legacy_authors)] = []
     project: list[str] = []
     dois: list[str] = []


### PR DESCRIPTION
## Overview: ##
Adding keywords to entities and updating values for datacite

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-74](https://tacc-main.atlassian.net/browse/WC-74)
* [WC-278](https://tacc-main.atlassian.net/browse/WC-278)

## Summary of Changes: ##
Keywords on each entity type

Datacite value updates
* license
* updated author affiliation info
* keywords appended from entity metadata
* modifying subtitle to just be a separate title (I don't know if this is what they're wanting, so this was first take on this request)

## Testing Steps: ##
Basic testing steps, should do per project type
1. Create a project, not type other
2. Curate it, and you should find keywords required on the publishable entity
3. Make sure the keywords are showing on all the places where entity metadata is showing
4. Publish the entity, making sure keywords are showing up in the display
5. Make sure the entity keywords appear in the publication view
6. Pull up the datacite metadata and make sure all the new fields exist

## UI Photos:

## Notes: ##
