### PR TITLE
Remove legacy dataset.properties used to merge DS and OpenTopography …

### DIFF
--- a/client/modules/_hooks/src/reconportal/ReconEventContext.tsx
+++ b/client/modules/_hooks/src/reconportal/ReconEventContext.tsx
@@ -19,7 +19,7 @@ const ReconEventContext = createContext<ReconEventContextType | undefined>(
 export const getReconPortalEventIdentifier = (
   event: ReconPortalEvents
 ): string => {
-  const title = event.title || event.properties?.name || '';
+  const title = event.title;
   return `${title}`.toLowerCase().replace(/[^a-z0-9]/g, '-');
 };
 

--- a/client/modules/_hooks/src/reconportal/useGetReconPortalEvents.ts
+++ b/client/modules/_hooks/src/reconportal/useGetReconPortalEvents.ts
@@ -8,16 +8,6 @@ export type ReconPortalDataset = {
   id: string;
 };
 
-export type ReconPortalEventProperties = {
-  name: string;
-  host: string;
-  description: string;
-  dateCreated: string;
-  productAvailable?: string;
-  temporalCoverage?: string;
-  keywords?: string;
-};
-
 export type ReconPortalEvents = {
   location_description: string;
   location: {
@@ -29,8 +19,6 @@ export type ReconPortalEvents = {
   title: string;
   created_date: string;
   datasets: ReconPortalDataset[];
-  main_image_uuid?: string;
-  properties?: ReconPortalEventProperties;
 };
 
 async function getEvents() {

--- a/client/modules/reconportal/src/ReconSidePanel/ReconSidePanel.tsx
+++ b/client/modules/reconportal/src/ReconSidePanel/ReconSidePanel.tsx
@@ -25,7 +25,7 @@ import {
 import { formatDate } from '@client/workspace';
 import dayjs from 'dayjs';
 import { CloseOutlined } from '@ant-design/icons';
-import { getReconEventColor, EVENT_TYPE_COLORS } from '../utils';
+import { getReconEventColor } from '../utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faLocationDot } from '@fortawesome/free-solid-svg-icons';
 
@@ -115,11 +115,10 @@ export const ReconSidePanel: React.FC<LayoutProps> = ({
   };
 
   const renderEventCard = (event: ReconPortalEvents) => {
-    const title = event.title || event.properties?.name || '';
-    const description =
-      event.location_description || event.properties?.description || '';
-    const date = event.event_date || event.properties?.dateCreated || '';
-    const eventType = event.event_type || event.properties?.host || '';
+    const title = event.title;
+    const description = event.location_description;
+    const date = event.event_date;
+    const eventType = event.event_type;
 
     return (
       <div className={styles.eventContainer}>
@@ -135,13 +134,7 @@ export const ReconSidePanel: React.FC<LayoutProps> = ({
               {formatDate(new Date(date))}
             </Text>
             <Tag
-              color={
-                selectedEvent
-                  ? getReconEventColor(selectedEvent)
-                  : EVENT_TYPE_COLORS[
-                      eventType as keyof typeof EVENT_TYPE_COLORS
-                    ]
-              }
+              color={getReconEventColor(event)}
               style={{
                 fontWeight: 600,
                 fontSize: 14,
@@ -157,11 +150,10 @@ export const ReconSidePanel: React.FC<LayoutProps> = ({
   };
 
   const renderEventDetail = (event: ReconPortalEvents) => {
-    const title = event.title || event.properties?.name || '';
-    const description =
-      event.location_description || event.properties?.description || '';
-    const date = event.event_date || event.properties?.dateCreated || '';
-    const eventType = event.event_type || event.properties?.host || '';
+    const title = event.title;
+    const description = event.location_description;
+    const date = event.event_date;
+    const eventType = event.event_type;
     const eventTypeColor = getReconEventColor(event);
     const datasets = event.datasets || [];
     return (
@@ -172,7 +164,7 @@ export const ReconSidePanel: React.FC<LayoutProps> = ({
               <FontAwesomeIcon
                 icon={faLocationDot}
                 size="2x"
-                color={getReconEventColor(selectedEvent)}
+                color={eventTypeColor}
                 style={{ marginRight: '8px' }}
               />
               {title}


### PR DESCRIPTION
## Overview: ##

dataset.properties is a remnant of some early prototyping from last summer. At the time, the approach was to merge DesignSafe and OpenTopography events into a combined object. This PR removes that.

## PR Status: ##

* [X] Ready.


## Related Jira tickets: ##

None

## Testing Steps: ##
1. Confirm works as expected
