### PR TITLE
task/WG-530: limit year dropdown to available years

### DIFF
--- a/client/modules/_hooks/src/reconportal/index.ts
+++ b/client/modules/_hooks/src/reconportal/index.ts
@@ -1,3 +1,4 @@
+export * from './useAvailableEventYears';
 export * from './useGetReconPortalEvents';
 export * from './useGetReconPortalEventTypes';
 export * from './useGetOpenTopo';

--- a/client/modules/_hooks/src/reconportal/useAvailableEventYears.ts
+++ b/client/modules/_hooks/src/reconportal/useAvailableEventYears.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+import type { ReconPortalEvents } from '@client/hooks';
+
+/**
+ * Returns a list of available years from events, filtered by event type if provided.
+ */
+export function useAvailableEventYears(
+  events: ReconPortalEvents[],
+  selectedEventType: string | null
+): string[] {
+  return useMemo(() => {
+    const relevantEvents = selectedEventType
+      ? events.filter((e) => e.event_type === selectedEventType)
+      : events;
+
+    const years = Array.from(
+      new Set(
+        relevantEvents.map((e) =>
+          new Date(e.event_date).getFullYear().toString()
+        )
+      )
+    ).sort((a, b) => Number(b) - Number(a));
+
+    return years;
+  }, [events, selectedEventType]);
+}

--- a/client/modules/reconportal/src/ReconSidePanel/ReconSidePanel.tsx
+++ b/client/modules/reconportal/src/ReconSidePanel/ReconSidePanel.tsx
@@ -6,7 +6,6 @@ import {
   Image,
   Input,
   Select,
-  DatePicker,
   Typography,
   List,
   Card,
@@ -21,6 +20,7 @@ import {
   type EventTypeResponse,
   useReconEventContext,
   getReconPortalEventIdentifier,
+  useAvailableEventYears,
 } from '@client/hooks';
 import { formatDate } from '@client/workspace';
 import dayjs from 'dayjs';
@@ -53,6 +53,16 @@ export const ReconSidePanel: React.FC<LayoutProps> = ({
   const { data: eventTypes = [] } = useGetReconPortalEventTypes();
   const { data: events = [] } = useGetReconPortalEvents();
 
+  const availableYears = useAvailableEventYears(events, selectedEventType);
+
+  // When event type changes, ensure selected year is still valid; reset if not
+  useEffect(() => {
+    if (selectedYear && !availableYears.includes(selectedYear)) {
+      // clear selected year as no longer makes sense
+      setSelectedYear(null);
+    }
+  }, [selectedEventType, availableYears]);
+
   useEffect(() => {
     if (events.length > 0) {
       setFilteredReconPortalEvents(events);
@@ -69,8 +79,7 @@ export const ReconSidePanel: React.FC<LayoutProps> = ({
     filterEvents(searchText, value, selectedYear);
   };
 
-  const handleYearChange = (date: dayjs.Dayjs | null) => {
-    const year = date ? date.format('YYYY') : null;
+  const handleYearChange = (year: string | null) => {
     setSelectedYear(year);
     filterEvents(searchText, selectedEventType, year);
   };
@@ -317,14 +326,19 @@ export const ReconSidePanel: React.FC<LayoutProps> = ({
                     ))}
                   </Select>
 
-                  <DatePicker
-                    picker="year"
+                  <Select
                     placeholder="Select Year"
                     style={{ flex: 1 }}
                     onChange={handleYearChange}
-                    value={selectedYear ? dayjs(selectedYear) : null}
+                    value={selectedYear}
                     allowClear
-                  />
+                  >
+                    {availableYears.map((year) => (
+                      <Select.Option key={year} value={year}>
+                        {year}
+                      </Select.Option>
+                    ))}
+                  </Select>
                 </Flex>
               </div>
 


### PR DESCRIPTION
## Overview: ##

Limit year dropdown to available years (for selected event type)

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-530](https://tacc-main.atlassian.net/browse/WG-530)

## Testing Steps: ##
1. Change years
2. Change types
3. Notice that the selected year gets reset to null if new event type doesn't have that year.

## UI Photos:

<img width="341" height="542" alt="Screenshot 2025-07-18 at 3 18 28 PM" src="https://github.com/user-attachments/assets/7ca8530a-a457-46e4-9a25-d99cbfe02683" />
<img width="345" height="547" alt="Screenshot 2025-07-18 at 3 18 41 PM" src="https://github.com/user-attachments/assets/4303f1a5-2ff2-4f19-8219-ef74bfd956f7" />
