### PR TITLE
task/WG-532 add white border to event position markers

### DIFF
--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
@@ -9,7 +9,7 @@ import {
   Marker,
   Popup,
 } from 'react-leaflet';
-import { faMap, faLocationDot, faLocationPin } from '@fortawesome/free-solid-svg-icons';
+import { faMap, faLocationDot } from '@fortawesome/free-solid-svg-icons';
 import { OpenTopoPopup } from './OpenTopoPopup';
 import {
   createSvgMarkerIcon,
@@ -201,7 +201,6 @@ export const LeafletMap: React.FC = () => {
       const icon = createSvgMarkerIcon({
         color: getReconEventColor(reconEvent),
         icon: faLocationDot,
-        withConstrastBackgrounIcon: faLocationPin
       });
       reconPortalMarkers.push(
         <Marker

--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
@@ -9,7 +9,7 @@ import {
   Marker,
   Popup,
 } from 'react-leaflet';
-import { faMap, faLocationDot } from '@fortawesome/free-solid-svg-icons';
+import { faMap, faLocationDot, faLocationPin } from '@fortawesome/free-solid-svg-icons';
 import { OpenTopoPopup } from './OpenTopoPopup';
 import {
   createSvgMarkerIcon,
@@ -201,6 +201,7 @@ export const LeafletMap: React.FC = () => {
       const icon = createSvgMarkerIcon({
         color: getReconEventColor(reconEvent),
         icon: faLocationDot,
+        withConstrastBackgrounIcon: faLocationPin
       });
       reconPortalMarkers.push(
         <Marker

--- a/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
+++ b/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
@@ -22,30 +22,46 @@ export function createSvgMarkerIcon({
   icon: IconDefinition;
   withConstrastBackgrounIcon?: IconDefinition;
 }): L.DivIcon {
-  const outlineSize = 28; // slightly larger
-  const iconSize = 24;    // actual icon
-
   const html = renderToStaticMarkup(
-  <span
-    style={{
-      position: 'relative',
-      width: '24px',
-      height: '28px',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      backgroundColor: 'white',
-      borderRadius: '50%',
-    }}
-  >
-    <FontAwesomeIcon icon={icon} color={color} style={{ fontSize: '24px' }} />
-  </span>
-);
+    <span
+      style={{
+        position: 'relative',
+        display: 'inline-block',
+        width: '36px',
+        height: '36px',
+      }}
+    >
+      {withConstrastBackgrounIcon && (
+        <FontAwesomeIcon
+          icon={withConstrastBackgrounIcon}
+          color="white"
+          style={{
+            fontSize: '36px',
+            position: 'absolute',
+            top: 0,
+            left: 1,
+            zIndex: 0,
+          }}
+        />
+      )}
+      <FontAwesomeIcon
+        icon={icon}
+        color={color}
+        style={{
+          fontSize: '30px',
+          position: 'absolute',
+          top: '3px',
+          left: '3px',
+          zIndex: 1,
+        }}
+      />
+    </span>
+  );
 
   return L.divIcon({
     className: '',
     html,
-    iconAnchor: [outlineSize / 2, outlineSize], // bottom center
+    iconAnchor: [18, 36], // center bottom
   });
 }
 

--- a/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
+++ b/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
@@ -1,5 +1,4 @@
 import { renderToStaticMarkup } from 'react-dom/server';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import {
   useReconEventContext,
@@ -14,57 +13,40 @@ import styles from './LeafletMap.module.css';
  * Create a Leaflet divIcon using any Font Awesome icon with dynamic color and size.
  */
 export function createSvgMarkerIcon({
-  color = 'black',
   icon,
-  withConstrastBackgrounIcon,
+  color = 'black',
+  withOutline = true,
 }: {
-  color?: string;
   icon: IconDefinition;
-  withConstrastBackgrounIcon?: IconDefinition;
+  color?: string;
+  withOutline?: boolean;
 }): L.DivIcon {
+  const [width, height, , , svgPath] = icon.icon;
+
+  const d = Array.isArray(svgPath) ? svgPath.join(' ') : svgPath;
+
   const html = renderToStaticMarkup(
-    <span
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="36"
+      height="36"
+      viewBox={`0 0 ${width} ${height}`}
       style={{
-        position: 'relative',
-        display: 'inline-block',
-        width: '36px',
-        height: '36px',
+        filter: withOutline
+          ? 'drop-shadow(0 0 1px white) drop-shadow(0 0 2px white) drop-shadow(0 0 3px white)'
+          : undefined,
       }}
     >
-      {withConstrastBackgrounIcon && (
-        <FontAwesomeIcon
-          icon={withConstrastBackgrounIcon}
-          color="white"
-          style={{
-            fontSize: '36px',
-            position: 'absolute',
-            top: 0,
-            left: 1,
-            zIndex: 0,
-          }}
-        />
-      )}
-      <FontAwesomeIcon
-        icon={icon}
-        color={color}
-        style={{
-          fontSize: '30px',
-          position: 'absolute',
-          top: '3px',
-          left: '3px',
-          zIndex: 1,
-        }}
-      />
-    </span>
+      <path d={d} fill={color} />
+    </svg>
   );
 
   return L.divIcon({
     className: '',
     html,
-    iconAnchor: [18, 36], // center bottom
+    iconAnchor: [18, 36],
   });
 }
-
 
 /**
  * Create a cluster icon and declare defaults

--- a/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
+++ b/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
@@ -26,40 +26,21 @@ export function createSvgMarkerIcon({
   const iconSize = 24;    // actual icon
 
   const html = renderToStaticMarkup(
-    <span
-      style={{
-        position: 'relative',
-        display: 'inline-block',
-        width: `${outlineSize}px`,
-        height: `${outlineSize}px`,
-      }}
-    >
-      {withConstrastBackgrounIcon && (
-        <FontAwesomeIcon
-          icon={withConstrastBackgrounIcon}
-          color="white"
-          style={{
-            fontSize: `${outlineSize}px`,
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            zIndex: 0,
-          }}
-        />
-      )}
-      <FontAwesomeIcon
-        icon={icon}
-        color={color}
-        style={{
-          fontSize: `${iconSize}px`,
-          position: 'absolute',
-          top: `${(outlineSize - iconSize) / 2}px`,
-          left: `${(outlineSize - iconSize) / 2}px`,
-          zIndex: 1,
-        }}
-      />
-    </span>
-  );
+  <span
+    style={{
+      position: 'relative',
+      width: '24px',
+      height: '28px',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: 'white',
+      borderRadius: '50%',
+    }}
+  >
+    <FontAwesomeIcon icon={icon} color={color} style={{ fontSize: '24px' }} />
+  </span>
+);
 
   return L.divIcon({
     className: '',

--- a/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
+++ b/client/modules/reconportal/src/LeafletMap/leafletUtil.tsx
@@ -15,23 +15,59 @@ import styles from './LeafletMap.module.css';
  */
 export function createSvgMarkerIcon({
   color = 'black',
-  size = '2x',
   icon,
+  withConstrastBackgrounIcon,
 }: {
   color?: string;
-  size?: 'xs' | 'sm' | 'lg' | '1x' | '2x' | '3x';
   icon: IconDefinition;
+  withConstrastBackgrounIcon?: IconDefinition;
 }): L.DivIcon {
+  const outlineSize = 28; // slightly larger
+  const iconSize = 24;    // actual icon
+
   const html = renderToStaticMarkup(
-    <FontAwesomeIcon icon={icon} color={color} size={size} />
+    <span
+      style={{
+        position: 'relative',
+        display: 'inline-block',
+        width: `${outlineSize}px`,
+        height: `${outlineSize}px`,
+      }}
+    >
+      {withConstrastBackgrounIcon && (
+        <FontAwesomeIcon
+          icon={withConstrastBackgrounIcon}
+          color="white"
+          style={{
+            fontSize: `${outlineSize}px`,
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            zIndex: 0,
+          }}
+        />
+      )}
+      <FontAwesomeIcon
+        icon={icon}
+        color={color}
+        style={{
+          fontSize: `${iconSize}px`,
+          position: 'absolute',
+          top: `${(outlineSize - iconSize) / 2}px`,
+          left: `${(outlineSize - iconSize) / 2}px`,
+          zIndex: 1,
+        }}
+      />
+    </span>
   );
 
   return L.divIcon({
     className: '',
     html,
-    iconAnchor: [12, 24],
+    iconAnchor: [outlineSize / 2, outlineSize], // bottom center
   });
 }
+
 
 /**
  * Create a cluster icon and declare defaults


### PR DESCRIPTION
## Overview: ##

Add white border/shadow to DS events and Opentopo dataset markers

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-532](https://tacc-main.atlassian.net/browse/WG-532)


## UI Photos:
<img width="257" height="273" alt="Screenshot 2025-07-18 at 8 56 33 PM" src="https://github.com/user-attachments/assets/e93fd132-d18a-454a-81f2-1eabab9d91e5" />


