### PR TITLE
task/WG 525 Event Title Wrap Style Fix

### DIFF
--- a/client/modules/reconportal/src/ReconSidePanel/ReconSidePanel.tsx
+++ b/client/modules/reconportal/src/ReconSidePanel/ReconSidePanel.tsx
@@ -168,15 +168,15 @@ export const ReconSidePanel: React.FC<LayoutProps> = ({
       <div className={styles.eventDetail}>
         <Card className={styles.eventDetailCard}>
           <Flex className={styles.eventDetailTitleRow}>
-            <span>
+            <div>
               <FontAwesomeIcon
                 icon={faLocationDot}
                 size="2x"
                 color={eventTypeColor}
                 style={{ marginRight: '8px' }}
               />
-              {title}
-            </span>
+            </div>
+            <div>{title}</div>
             <Button
               shape="circle"
               icon={<CloseOutlined />}


### PR DESCRIPTION
## Overview: ##
 Make sure title does not wrap under pin icon in side panel

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-525](https://tacc-main.atlassian.net/browse/WG-525)

## Summary of Changes: ##

## Testing Steps: ##
1. Go to recon portal and select an event.
2. Make sure the title no longer wraps under the pin icon

## UI Photos:
<img width="371" height="548" alt="Screenshot 2025-07-21 at 12 02 19 PM" src="https://github.com/user-attachments/assets/3216381d-155c-427c-ac3e-9f00fc834120" />

## Notes: ##
