### PR TITLE
task/WG-535: keep selected event popup from closing

### DIFF
--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.module.css
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.module.css
@@ -58,3 +58,8 @@
   /* Offset slightly to account for border */
   margin-top: -1px;
 }
+
+/* Remove triangle for selected event */
+.selectedEventPopup :global(.leaflet-popup-tip-container) {
+  display: none;
+}

--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
@@ -256,8 +256,8 @@ export const LeafletMap: React.FC = () => {
             },
           }}
         >
-          <Popup>
-            <ReconPortalPopup dataset={reconEvent} />
+          <Popup closeButton={false}>
+            <ReconPortalPopup dataset={reconEvent}  />
           </Popup>
         </Marker>
       );

--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
@@ -328,6 +328,7 @@ export const LeafletMap: React.FC = () => {
             offset={[0, -10]}
             closeButton={false}
             closeOnClick={false}
+            autoClose={false}
           >
             <ReconPortalPopup dataset={selectedEvent} showDetails={false} />
           </Popup>

--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
@@ -324,6 +324,7 @@ export const LeafletMap: React.FC = () => {
         {/* Selected event banner popup */}
         {selectedEvent && showSelectedPopup && (
           <Popup
+            className={styles.selectedEventPopup}
             position={[selectedEvent.location.lat, selectedEvent.location.lon]}
             offset={[0, -10]}
             closeButton={false}


### PR DESCRIPTION
## Overview: ##

This PR keeps the selected event popup from closing when other events or OT datasets are hovered.

This PR also:
* Improve styling of selected event banner by removing the popup bottom tip/triangle
* Removes close button from DS events

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-535](https://tacc-main.atlassian.net/browse/WG-535)

## Summary of Changes: ##

## Testing Steps: ##
1. Select 

## UI Photos:
<img width="1022" height="292" alt="Screenshot 2025-07-21 at 1 37 26 PM" src="https://github.com/user-attachments/assets/f5b08b2d-bb7c-47b2-9cee-fe5cd49c03d5" />

