### PR TITLE
task/WC-284: Filter out inactive accounts when adding users to projects

### DIFF
--- a/designsafe/apps/api/users/views.py
+++ b/designsafe/apps/api/users/views.py
@@ -143,7 +143,8 @@ class ProjectUserView(BaseApiView):
             raise ApiException(message="Authentication required", status=401)
 
         username_query = request.GET.get("q")
-        user_match = get_user_model().objects.filter(username__iexact=username_query)
+        user_match = get_user_model().objects.filter(is_active=True,
+                                                     username__iexact=username_query)
         user_resp = [
             {
                 "fname": u.first_name,


### PR DESCRIPTION
## Overview: ##
Prevent users with `is_active=False` from being added to projects. This attribute is set manually in Django-admin and we can use it to resolve issues for users who have multiple TACC accounts.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-284](https://tacc-main.atlassian.net/browse/WC-284)

## Summary of Changes: ##

## Testing Steps: ##
1. Try adding an inactive user to a project and make sure that their username doesn't give any results. If you have a recent db dump then `fpanzera` can be used to test.

## UI Photos:

## Notes: ##
