### PR TITLE
Hotfix: Fix database order of operations during publication pipeline

### DIFF
--- a/designsafe/apps/api/projects_v2/operations/project_publish_operations.py
+++ b/designsafe/apps/api/projects_v2/operations/project_publish_operations.py
@@ -487,12 +487,13 @@ def publish_project(
         for node in pub_tree.successors("NODE_ROOT")
     ]
 
+    project_uuid = ProjectMetadata.get_project_by_id(project_id).uuid
+
     # If we don't explicitly close the db connection, it will remain open during the
     # entire data-copying step, which can cause operations to fail.
     close_old_connections()
 
     if not settings.DEBUG:
-        project_uuid = ProjectMetadata.get_project_by_id(project_id).uuid
         # Copy files first so if it fails we don't create orphan metadata/datacite entries.
         copy_publication_files(
             path_mapping,


### PR DESCRIPTION
## Overview: ##
The file layout changes introduced a database call as part of the file copying step during the publication pipeline, resulting in the following order of operations:
1. Close database connections
2. Lookup original project UUID
3. Copy publication files

The lookup step (2) opens a new db connection that can result in a timeout when the db is accessed again after copying files. The fix is to perform the lookup BEFORE closing the connection, so that there aren't any connections left open before we start the final part of the pipeline.
