### PR TITLE
bug/WP-987: Application Select File/Folder Modal updates

### DIFF
--- a/client/modules/workspace/src/SelectModal/SelectModal.tsx
+++ b/client/modules/workspace/src/SelectModal/SelectModal.tsx
@@ -35,9 +35,7 @@ import {
 import styles from './SelectModal.module.css';
 import { SelectModalProjectListing } from './SelectModalProjectListing';
 
-import {
-  truncateMiddle,
-} from '../utils';
+import { truncateMiddle } from '../utils';
 
 const api = 'tapis';
 const portalName = 'DesignSafe';
@@ -220,9 +218,7 @@ function getFilesColumns(
                 className={iconClassName}
                 style={{ color: '#333333', marginRight: '8px' }}
               ></i>
-              <Tooltip title={data}>
-                {truncateMiddle(data, 35)}
-              </Tooltip>
+              <Tooltip title={data}>{truncateMiddle(data, 35)}</Tooltip>
             </Button>
           );
         }
@@ -234,9 +230,7 @@ function getFilesColumns(
               className={iconClassName}
               style={{ color: '#333333', marginRight: '8px' }}
             ></i>
-            <Tooltip title={data}>
-              {truncateMiddle(data, 35)}
-            </Tooltip>
+            <Tooltip title={data}>{truncateMiddle(data, 35)}</Tooltip>
           </span>
         );
       },

--- a/client/modules/workspace/src/SelectModal/SelectModal.tsx
+++ b/client/modules/workspace/src/SelectModal/SelectModal.tsx
@@ -34,7 +34,6 @@ import {
 } from '@client/common-components';
 import styles from './SelectModal.module.css';
 import { SelectModalProjectListing } from './SelectModalProjectListing';
-
 import { truncateMiddle } from '../utils';
 
 const api = 'tapis';

--- a/client/modules/workspace/src/SelectModal/SelectModal.tsx
+++ b/client/modules/workspace/src/SelectModal/SelectModal.tsx
@@ -7,6 +7,7 @@ import {
   Form,
   ConfigProvider,
   ThemeConfig,
+  Tooltip,
 } from 'antd';
 import {
   CaretDownOutlined,
@@ -33,6 +34,10 @@ import {
 } from '@client/common-components';
 import styles from './SelectModal.module.css';
 import { SelectModalProjectListing } from './SelectModalProjectListing';
+
+import {
+  truncateMiddle,
+} from '../utils';
 
 const api = 'tapis';
 const portalName = 'DesignSafe';
@@ -215,7 +220,9 @@ function getFilesColumns(
                 className={iconClassName}
                 style={{ color: '#333333', marginRight: '8px' }}
               ></i>
-              {data}
+              <Tooltip title={data}>
+                {truncateMiddle(data, 35)}
+              </Tooltip>
             </Button>
           );
         }
@@ -227,10 +234,13 @@ function getFilesColumns(
               className={iconClassName}
               style={{ color: '#333333', marginRight: '8px' }}
             ></i>
-            {data}
+            <Tooltip title={data}>
+              {truncateMiddle(data, 35)}
+            </Tooltip>
           </span>
         );
       },
+      width: '70%',
     },
     {
       dataIndex: 'path',
@@ -457,7 +467,7 @@ export const SelectModal: React.FC<{
     <Modal
       open={isModalOpen}
       onCancel={handleClose}
-      width="40%"
+      width="50%"
       footer={null}
       styles={modalStyles}
       title={<span className={styles.modalTitle}>Select</span>}

--- a/client/modules/workspace/src/SelectModal/SelectModal.tsx
+++ b/client/modules/workspace/src/SelectModal/SelectModal.tsx
@@ -218,7 +218,7 @@ function getFilesColumns(
                 className={iconClassName}
                 style={{ color: '#333333', marginRight: '8px' }}
               ></i>
-              <Tooltip title={data}>{truncateMiddle(data, 35)}</Tooltip>
+              <Tooltip title={data}>{truncateMiddle(data, 45)}</Tooltip>
             </Button>
           );
         }
@@ -230,7 +230,7 @@ function getFilesColumns(
               className={iconClassName}
               style={{ color: '#333333', marginRight: '8px' }}
             ></i>
-            <Tooltip title={data}>{truncateMiddle(data, 35)}</Tooltip>
+            <Tooltip title={data}>{truncateMiddle(data, 45)}</Tooltip>
           </span>
         );
       },


### PR DESCRIPTION
## Overview: ##
Updating the Select File/Folder modal in the applications area to handle long filenames

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-987](https://tacc-main.atlassian.net/browse/WP-987)

## Summary of Changes: ##
Added middle truncating to long filenames
Added tooltips to filenames
Increased width of filename column
Minor increase to modal size

## Testing Steps: ##
1. Pick an app that selects a file/folder
2. Open the modal, and make sure that any long file/folder names are middle truncated and tooltips show up with the full name.

## UI Photos:

## Notes: ##
