### PR TITLE
Fixed making calls to systems that don't exist

### DIFF
--- a/client/modules/_hooks/src/useSystemQueue.ts
+++ b/client/modules/_hooks/src/useSystemQueue.ts
@@ -40,5 +40,6 @@ export function useSystemQueue(hostname: string) {
   return useQuery<QueueItem[], Error>({
     queryKey: ['systemQueue', hostname],
     queryFn: () => fetchSystemQueue(hostname),
+    enabled: !!hostname,
   });
 }

--- a/client/modules/workspace/src/AppsWizard/FormField.tsx
+++ b/client/modules/workspace/src/AppsWizard/FormField.tsx
@@ -75,10 +75,14 @@ const QueueStatus: React.FC<{
   const { getValues } = useFormContext();
   const selectedSystemId = getValues('configuration.execSystemId');
   const displayName = getSystemDisplayName(selectedSystemId);
-  const { data: queueData } = useSystemQueue(displayName);
+  const { data: systems } = useSystemOverview();
+  const selectedSystem = systems?.find(
+    (sys) => sys.display_name === displayName
+  );
+  const { data: queueData } = useSystemQueue(selectedSystem?.hostname || '');
   const selectedQueue = queueData?.find((q) => q.name === value);
 
-  if (!value) return null;
+  if (!value || !selectedSystem) return null;
 
   return (
     <div style={{ display: 'flex', alignItems: 'center', marginLeft: 12 }}>


### PR DESCRIPTION
## Overview: ##
Fixed errors popping up when app with non-TAP system was selected. Issue was caused by system status components trying to fetch queue data for systems that are not valid. 

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-1027](https://tacc-main.atlassian.net/jira/software/c/projects/WP/boards/46?assignee=712020%3Aa66df098-eece-4aae-a1c3-6b226867069f&selectedIssue=WP-1027)

## Summary of Changes: ##
- Modified useSystemQueue to prevent API calls when hostname is empty, prevents 404/500 errors when system is invalid to TAP
- Modified FormField - Updated QueueStatus component to use hostname of the selected system rather than displayName, only renders if system exists from systems returned in useSystemOverview

## Testing Steps: ##
1. Navigate to app Hydro-UQ App (Web-Portal)
2. Ensure no errors pop up and queue status component dosen't render

## UI Photos:
<img width="672" height="319" alt="Screenshot 2025-08-06 at 4 50 02 PM" src="https://github.com/user-attachments/assets/945cc3bd-20ab-4bb0-91c7-92605312cd8e" />

## Notes: ##
