### PR TITLE
WC-289: Path for published on data download modal

### DIFF
--- a/client/modules/datafiles/src/DatafilesModal/DownloadModal/DownloadModal.tsx
+++ b/client/modules/datafiles/src/DatafilesModal/DownloadModal/DownloadModal.tsx
@@ -100,7 +100,7 @@ export const DownloadModal: React.FC<{
           </a>
           ).
         </p>
-        <div hidden={!(system == 'designsafe.storage.published')}>
+        <div hidden={!(system === 'designsafe.storage.published')}>
           <p>
             This data directory is accessible on{' '}
             <strong>data.tacc.utexas.edu</strong> at the following path:

--- a/client/modules/datafiles/src/DatafilesModal/DownloadModal/DownloadModal.tsx
+++ b/client/modules/datafiles/src/DatafilesModal/DownloadModal/DownloadModal.tsx
@@ -100,6 +100,15 @@ export const DownloadModal: React.FC<{
           </a>
           ).
         </p>
+        <div hidden={!(system == 'designsafe.storage.published')}>
+          <p>
+            This data directory is accessible on{' '}
+            <strong>data.tacc.utexas.edu</strong> at the following path:
+          </p>
+          <p>
+            <code>{`/corral/projects/NHERI/published/published-data/${selectedFiles[0]?.name}`}</code>
+          </p>
+        </div>
       </Modal>
       <MicrosurveyModal
         isModalOpen={isMicrosurveyOpen}


### PR DESCRIPTION
## Overview: ##
Adding section to download modal for specifically large publications with the path to the published data folder

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-289](https://tacc-main.atlassian.net/browse/WC-289)

## Summary of Changes: ##

## Testing Steps: ##
1. Pull up a publication with large dataset (PRJ-4040 is one) and make sure the download dataset modal with the large size warning shows the path for downloading.
2. Pull up another location in the portal with a large folder to try to download, and make sure the modal pops up but doesn't have a download path.

## UI Photos:

## Notes: ##
