### PR TITLE
task/WC-292: Add projectId to tapis system notes and enable retry for project system tasks

### DIFF
--- a/designsafe/apps/api/projects_v2/views.py
+++ b/designsafe/apps/api/projects_v2/views.py
@@ -168,7 +168,11 @@ class ProjectsView(BaseApiView):
         initialize_project_graph(project_meta.project_id)
         project_users = [user.username for user in project_meta.users.all()]
         # create project system
-        setup_project_file_system(project_uuid=project_meta.uuid, users=project_users)
+        setup_project_file_system(
+            project_uuid=project_meta.uuid,
+            users=project_users,
+            project_id=f"PRJ-{prj_number}",
+        )
         # add users to system
 
         return JsonResponse({"projectId": project_meta.project_id})


### PR DESCRIPTION
## Overview: ##
- Add projectId to Tapis system notes when a project is created
- Add retry for adding/removing project users in case of a Tapis timeout/hiccup

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-292](https://tacc-main.atlassian.net/browse/WC-292)

