### PR TITLE
bug/WC-290: Tombstone disables file listings and entity trees

### DIFF
--- a/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPreview/ProjectPreview.tsx
@@ -332,21 +332,25 @@ export const PublishedEntityDisplay: React.FC<{
                   license={license}
                   publicationDate={treeData.publicationDate}
                 />
-                {(treeData.value.fileObjs?.length ?? 0) > 0 && (
-                  <EntityFileListingTable
-                    treeData={treeData}
-                    preview={preview}
-                  />
+                {!treeData.value.tombstone && (
+                  <>
+                    {(treeData.value.fileObjs?.length ?? 0) > 0 && (
+                      <EntityFileListingTable
+                        treeData={treeData}
+                        preview={preview}
+                      />
+                    )}
+                    {(sortedChildren ?? []).map((child) => (
+                      <RecursiveTree
+                        preview={preview}
+                        treeData={child}
+                        key={child.id}
+                        defaultOpen={defaultOpenChildren}
+                        showEditCategories={showEditCategories}
+                      />
+                    ))}
+                  </>
                 )}
-                {(sortedChildren ?? []).map((child) => (
-                  <RecursiveTree
-                    preview={preview}
-                    treeData={child}
-                    key={child.id}
-                    defaultOpen={defaultOpenChildren}
-                    showEditCategories={showEditCategories}
-                  />
-                ))}
               </>
             ),
           },

--- a/client/src/datafiles/layouts/published/PublishedEntityListingLayout.tsx
+++ b/client/src/datafiles/layouts/published/PublishedEntityListingLayout.tsx
@@ -20,19 +20,21 @@ export const PublishedEntityListingLayout: React.FC = () => {
         data.baseProject.projectType
       ) && (
         <DoiContextProvider value={data.baseProject.dois?.[0]}>
-          <FileListing
-            scroll={{ y: 500, x: 500 }}
-            api="tapis"
-            system="designsafe.storage.published"
-            path={encodeURIComponent(
-              `${
-                data.tree.children.find((c) => c.version === selectedVersion)
-                  ?.basePath ?? ''
-              }/data`
-            )}
-            baseRoute="."
-            fileTags={data.fileTags}
-          />
+          {!data.baseProject.tombstone && (
+            <FileListing
+              scroll={{ y: 500, x: 500 }}
+              api="tapis"
+              system="designsafe.storage.published"
+              path={encodeURIComponent(
+                `${
+                  data.tree.children.find((c) => c.version === selectedVersion)
+                    ?.basePath ?? ''
+                }/data`
+              )}
+              baseRoute="."
+              fileTags={data.fileTags}
+            />
+          )}
         </DoiContextProvider>
       )}
     </div>


### PR DESCRIPTION
## Overview: ##
Added flags to disable file listings and entity trees on tombstoned publications

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-290](https://tacc-main.atlassian.net/browse/WC-290)

## Summary of Changes: ##
Added flags to disable file listings and entity trees on tombstoned publications

## Testing Steps: ##
1. Open a type other tombstoned publication (eg  2227) and make sure there are no file listings.
2. Open a non-other type tombstoned publication (eg 4151) and make sure the tree isn't showing
3. Open a not tombstoned publication and make sure the file listings and trees show up correctly.

## UI Photos:

## Notes: ##
