### PR TITLE
task/WG-543: default terrain basemap

### DIFF
--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
@@ -37,6 +37,8 @@ export const mapConfig = {
   minZoom: 2, // 2 typically prevents zooming out too far to see multiple earths
   maxZoom: 24, // Maximum possible detail
   maxFitBoundsSelectedFeatureZoom: 18,
+  selectedEventZoomToLevel: 11, // Zoom level to use when an event is selected
+  minZoomForOpenTopo: 9,        // Minimum zoom level for displaying OpenTopo datasets
   maxBounds: [
     [-90, -180], // Southwest coordinates
     [90, 180], // Northeast coordinates
@@ -174,11 +176,11 @@ export const LeafletMap: React.FC = () => {
         </LayersControl>
 
         {/* Open Topo features, only visible when zoomed in and DS event selected*/}
-        <ZoomConditionalLayerGroup minZoom={9}>
+        <ZoomConditionalLayerGroup minZoom={mapConfig.minZoomForOpenTopo}>
           <OpenTopoLayer />
         </ZoomConditionalLayerGroup>
         {/* Recon Portal features, only zoomed in when DS event selected*/}
-        <ZoomOnEventSelection zoomLevel={11}></ZoomOnEventSelection>
+        <ZoomOnEventSelection zoomLevel={mapConfig.selectedEventZoomToLevel}></ZoomOnEventSelection>
         {/* Marker Features with Clustering (also includes point cloud markers) */}
         <MarkerClusterGroup
           zIndexOffset={1}
@@ -186,7 +188,7 @@ export const LeafletMap: React.FC = () => {
           chunkedLoading={true}
           showCoverageOnHover={false}
           animate={true}
-          maxFitBoundsSelectedFeatureZoom={15}
+          maxFitBoundsSelectedFeatureZoom={mapConfig.maxFitBoundsSelectedFeatureZoom}
           spiderifyOnHover={true}
           spiderfyOnMaxZoom={true}
           spiderfyOnZoom={15}

--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
@@ -155,20 +155,20 @@ export const LeafletMap: React.FC = () => {
       >
         {/* Base layers */}
         <LayersControl position="topright" collapsed={false}>
-          <LayersControl.BaseLayer checked name="View Borders">
-            <TileLayer
-              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-              maxNativeZoom={19}
-            />
-          </LayersControl.BaseLayer>
-          <LayersControl.BaseLayer name="View Terrain">
+          <LayersControl.BaseLayer checked name="View Terrain">
             <TileLayer
               attribution='Map data: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
               url="https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png"
               maxNativeZoom={
                 14
               } /* Available zoom level should be higher but seems to be errors */
+            />
+          </LayersControl.BaseLayer>
+          <LayersControl.BaseLayer name="View Borders">
+            <TileLayer
+              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+              maxNativeZoom={19}
             />
           </LayersControl.BaseLayer>
         </LayersControl>


### PR DESCRIPTION
## Overview: ##

Set the OpenTopo terrain as the the default basemap

This PR also adds two more zoom levels (`selectedEventZoomToLevel`, `minZoomForOpenTopo`) to `mapConfig` and uses another one that was arleady there (`maxFitBoundsSelectedFeatureZoom`)

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-543](https://tacc-main.atlassian.net/browse/WG-543)

## UI Photos:
<img width="613" height="512" alt="Screenshot 2025-08-20 at 10 18 40 AM" src="https://github.com/user-attachments/assets/33970ecb-60f3-40b1-bf8d-57c5a9c8916a" />

