### PR TITLE
task/WG-534 - Recon Portal Event Scroll Changes

### DIFF
--- a/client/modules/reconportal/src/ReconSidePanel/ReconSidePanel.module.css
+++ b/client/modules/reconportal/src/ReconSidePanel/ReconSidePanel.module.css
@@ -18,14 +18,27 @@
 
 .scrollableList {
   flex: 1;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
   min-height: 0;
-  padding-bottom: 48px;
+  overflow: hidden;
 }
 
-.eventContainer:first-child {
-  margin-top: 24px;
-  border-top: 1px solid var(--global-color-primary--light);
+.filtersSection {
+  position: sticky;
+  top: 0;
+  background: var(--global-color-primary--xx-light);
+  z-index: 1;
+  padding: 16px;
+  border-bottom: 1px solid var(--global-color-primary--light);
+  flex-shrink: 0;
+}
+
+.eventsScrollableArea {
+  flex: 1;
+  overflow-y: auto;
+  padding-bottom: 48px;
+  overscroll-behavior: contain;
 }
 
 .eventContainer {

--- a/client/modules/reconportal/src/ReconSidePanel/ReconSidePanel.tsx
+++ b/client/modules/reconportal/src/ReconSidePanel/ReconSidePanel.tsx
@@ -337,7 +337,9 @@ export const ReconSidePanel: React.FC<LayoutProps> = ({
                 <List
                   dataSource={filteredReconPortalEvents}
                   renderItem={renderEventCard}
-                  locale={{ emptyText: 'No events match your selected filters' }}
+                  locale={{
+                    emptyText: 'No events match your selected filters',
+                  }}
                   className={styles.eventList}
                   itemLayout="vertical"
                   split={false}
@@ -346,7 +348,9 @@ export const ReconSidePanel: React.FC<LayoutProps> = ({
               </div>
             </>
           ) : (
-            <div className={styles.eventsScrollableArea}>{renderEventDetail(selectedEvent)}</div>
+            <div className={styles.eventsScrollableArea}>
+              {renderEventDetail(selectedEvent)}
+            </div>
           )}
         </div>
       </Flex>

--- a/client/modules/reconportal/src/ReconSidePanel/ReconSidePanel.tsx
+++ b/client/modules/reconportal/src/ReconSidePanel/ReconSidePanel.tsx
@@ -259,7 +259,7 @@ export const ReconSidePanel: React.FC<LayoutProps> = ({
         <div className={styles.scrollableList}>
           {!selectedEvent ? (
             <>
-              <div style={{ padding: '16px' }}>
+              <div className={styles.filtersSection}>
                 <Flex vertical gap={8}>
                   <Text
                     style={{
@@ -284,67 +284,69 @@ export const ReconSidePanel: React.FC<LayoutProps> = ({
                     </Link>
                   </Text>
                 </Flex>
+
+                <div style={{ marginTop: '16px', width: '100%' }}>
+                  <Search
+                    placeholder="Search by keyword"
+                    allowClear
+                    enterButton="Search"
+                    size="large"
+                    onSearch={onSearch}
+                  />
+
+                  <Flex
+                    gap={16}
+                    justify="space-between"
+                    style={{ width: '100%', marginTop: '16px' }}
+                  >
+                    <Select
+                      placeholder="Select Event Type"
+                      style={{ flex: 1 }}
+                      onChange={handleEventTypeChange}
+                      value={selectedEventType}
+                      allowClear
+                    >
+                      {eventTypes.map((eventType: EventTypeResponse) => (
+                        <Select.Option
+                          key={eventType.name}
+                          value={eventType.name}
+                        >
+                          {eventType.display_name}
+                        </Select.Option>
+                      ))}
+                    </Select>
+
+                    <Select
+                      placeholder="Select Year"
+                      style={{ flex: 1 }}
+                      onChange={handleYearChange}
+                      value={selectedYear}
+                      allowClear
+                    >
+                      {availableYears.map((year) => (
+                        <Select.Option key={year} value={year}>
+                          {year}
+                        </Select.Option>
+                      ))}
+                    </Select>
+                  </Flex>
+                </div>
               </div>
 
-              <div style={{ padding: '0 16px', width: '100%' }}>
-                <Search
-                  placeholder="Search by keyword"
-                  allowClear
-                  enterButton="Search"
-                  size="large"
-                  onSearch={onSearch}
+              <div className={styles.eventsScrollableArea}>
+                <List
+                  dataSource={filteredReconPortalEvents}
+                  renderItem={renderEventCard}
+                  locale={{ emptyText: 'No events match your selected filters' }}
+                  className={styles.eventList}
+                  itemLayout="vertical"
+                  split={false}
+                  style={{ width: '100%' }}
                 />
-
-                <Flex
-                  gap={16}
-                  justify="space-between"
-                  style={{ width: '100%', marginTop: '16px' }}
-                >
-                  <Select
-                    placeholder="Select Event Type"
-                    style={{ flex: 1 }}
-                    onChange={handleEventTypeChange}
-                    value={selectedEventType}
-                    allowClear
-                  >
-                    {eventTypes.map((eventType: EventTypeResponse) => (
-                      <Select.Option
-                        key={eventType.name}
-                        value={eventType.name}
-                      >
-                        {eventType.display_name}
-                      </Select.Option>
-                    ))}
-                  </Select>
-
-                  <Select
-                    placeholder="Select Year"
-                    style={{ flex: 1 }}
-                    onChange={handleYearChange}
-                    value={selectedYear}
-                    allowClear
-                  >
-                    {availableYears.map((year) => (
-                      <Select.Option key={year} value={year}>
-                        {year}
-                      </Select.Option>
-                    ))}
-                  </Select>
-                </Flex>
               </div>
-
-              <List
-                dataSource={filteredReconPortalEvents}
-                renderItem={renderEventCard}
-                locale={{ emptyText: 'No events match your selected filters' }}
-                className={styles.eventList}
-                itemLayout="vertical"
-                split={false}
-                style={{ width: '100%' }}
-              />
             </>
           ) : (
-            <div style={{}}>{renderEventDetail(selectedEvent)}</div>
+            <div className={styles.eventsScrollableArea}>{renderEventDetail(selectedEvent)}</div>
           )}
         </div>
       </Flex>


### PR DESCRIPTION
## Overview: ##

This changes the side panel scrolling so that the filters stay stickied to the top and only the event list scrolls

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-534](https://tacc-main.atlassian.net/browse/WG-534)

## Summary of Changes: ##

- Added CSS sticky filters and restructured HTML element hierarchy to separate scrollable event list from fixed filter controls

## Testing Steps: ##
1. Open recon portal and scroll in the side panel

## UI Photos:

## Notes: ##
