### PR TITLE
task/WG-561: shift event popup

### DIFF
--- a/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LeafletMap.tsx
@@ -165,74 +165,72 @@ export const LeafletMap: React.FC = () => {
   }, [filteredReconPortalEvents, selectedReconPortalEventIdentifier]);
 
   return (
-    <>
-      <MapContainer
-        center={mapConfig.startingCenter}
-        zoom={3}
-        className={styles.root}
-        zoomControl={false}
-        minZoom={mapConfig.minZoom}
-        maxZoom={mapConfig.maxZoom}
-        maxBounds={mapConfig.maxBounds}
-        preferCanvas={true}
+    <MapContainer
+      center={mapConfig.startingCenter}
+      zoom={3}
+      className={styles.root}
+      zoomControl={false}
+      minZoom={mapConfig.minZoom}
+      maxZoom={mapConfig.maxZoom}
+      maxBounds={mapConfig.maxBounds}
+      preferCanvas={true}
+    >
+      {/* Base layers */}
+      <LayersControl position="topright" collapsed={false}>
+        <LayersControl.BaseLayer checked name="View Satellite">
+          <TileLayer
+            attribution="Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
+            url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+            maxNativeZoom={
+              14
+            } /* Available zoom level should be higher but seems to be errors */
+          />
+        </LayersControl.BaseLayer>
+        <LayersControl.BaseLayer name="View Borders">
+          <TileLayer
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            maxNativeZoom={19}
+          />
+        </LayersControl.BaseLayer>
+      </LayersControl>
+
+      {/* Open Topo features, only visible when zoomed in and DS event selected*/}
+      <ZoomConditionalLayerGroup minZoom={mapConfig.minZoomForOpenTopo}>
+        <OpenTopoLayer />
+      </ZoomConditionalLayerGroup>
+      {/* Recon Portal features, only zoomed in when DS event selected*/}
+      <ZoomOnEventSelection
+        zoomLevel={mapConfig.selectedEventZoomToLevel}
+      ></ZoomOnEventSelection>
+      {/* Marker Features with Clustering (also includes point cloud markers) */}
+      <MarkerClusterGroup
+        zIndexOffset={1}
+        iconCreateFunction={createClusterIcon}
+        chunkedLoading={true}
+        showCoverageOnHover={false}
+        animate={true}
+        maxFitBoundsSelectedFeatureZoom={
+          mapConfig.maxFitBoundsSelectedFeatureZoom
+        }
+        spiderifyOnHover={true}
+        spiderfyOnMaxZoom={true}
+        spiderfyOnZoom={15}
+        zoomToBoundsOnClick={true}
       >
-        {/* Base layers */}
-        <LayersControl position="topright" collapsed={false}>
-          <LayersControl.BaseLayer checked name="View Satellite">
-            <TileLayer
-              attribution="Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
-              url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
-              maxNativeZoom={
-                14
-              } /* Available zoom level should be higher but seems to be errors */
-            />
-          </LayersControl.BaseLayer>
-          <LayersControl.BaseLayer name="View Borders">
-            <TileLayer
-              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-              maxNativeZoom={19}
-            />
-          </LayersControl.BaseLayer>
-        </LayersControl>
+        {ReconPortalEvents}
+      </MarkerClusterGroup>
 
-        {/* Open Topo features, only visible when zoomed in and DS event selected*/}
-        <ZoomConditionalLayerGroup minZoom={mapConfig.minZoomForOpenTopo}>
-          <OpenTopoLayer />
-        </ZoomConditionalLayerGroup>
-        {/* Recon Portal features, only zoomed in when DS event selected*/}
-        <ZoomOnEventSelection
-          zoomLevel={mapConfig.selectedEventZoomToLevel}
-        ></ZoomOnEventSelection>
-        {/* Marker Features with Clustering (also includes point cloud markers) */}
-        <MarkerClusterGroup
-          zIndexOffset={1}
-          iconCreateFunction={createClusterIcon}
-          chunkedLoading={true}
-          showCoverageOnHover={false}
-          animate={true}
-          maxFitBoundsSelectedFeatureZoom={
-            mapConfig.maxFitBoundsSelectedFeatureZoom
-          }
-          spiderifyOnHover={true}
-          spiderfyOnMaxZoom={true}
-          spiderfyOnZoom={15}
-          zoomToBoundsOnClick={true}
-        >
-          {ReconPortalEvents}
-        </MarkerClusterGroup>
+      {/* Legend - only visible when open topo features viewable*/}
+      <LegendControl minZoom={mapConfig.minZoomForOpenTopo} />
 
-        {/* Legend - only visible when open topo features viewable*/}
-        <LegendControl minZoom={mapConfig.minZoomForOpenTopo} />
+      {/* Zoom control */}
+      <ZoomControl position="topright" />
 
-        {/* Zoom control */}
-        <ZoomControl position="topright" />
-
-        {/* Selected event banner popup */}
-        {selectedEvent && (
-          <ReconPortalSelectedPopup selectedEvent={selectedEvent} />
-        )}
-      </MapContainer>
-    </>
+      {/* Selected event banner popup */}
+      {selectedEvent && (
+        <ReconPortalSelectedPopup selectedEvent={selectedEvent} />
+      )}
+    </MapContainer>
   );
 };


### PR DESCRIPTION
## Overview: ##

This PR works on the event popups:
* shifts the hovered popup above a bit so not covering marker
* makes the popup clickable to select the event

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-561](https://tacc-main.atlassian.net/browse/WG-561)
* [WG-561](https://tacc-main.atlassian.net/browse/WG-559)

## Summary of Changes: ##

## Testing Steps: ##
1. See that the hover has an offset from marker
2. See that you can click on the poup (in addition to the marker)

## UI Photos:

**OLD**  that shows how it covers marker
<img width="430" height="231" alt="Screenshot 2025-09-11 at 4 52 47 PM" src="https://github.com/user-attachments/assets/d52ddeb9-81e0-41e8-878e-f8fc8fe70c9a" />



**NEW ** :
 
<img width="483" height="298" alt="Screenshot 2025-09-11 at 4 52 29 PM" src="https://github.com/user-attachments/assets/64a5b1f8-f7a0-491a-a695-5d3455b09a15" />


