### PR TITLE
task/WG-563 - Recon Portal OpenTopo Color Update 

### DIFF
--- a/client/modules/reconportal/src/LeafletMap/LegendControl.tsx
+++ b/client/modules/reconportal/src/LeafletMap/LegendControl.tsx
@@ -8,12 +8,18 @@ import {
   getReconPortalEventIdentifier,
 } from '@client/hooks';
 import { createSvgMarkerIcon } from './leafletUtil';
-import { getReconEventColor, getOpenTopoColor } from '../utils/colors';
+import {
+  getReconEventColor,
+  getOpenTopoColor,
+  getOpenTopoFillColor,
+} from '../utils/colors';
 import styles from './LegendControl.module.css';
 
 function LegendContent({ selectedIconHtml }: { selectedIconHtml: string }) {
   const openTopoColor = getOpenTopoColor();
+  const openTopoFillColor = getOpenTopoFillColor();
   const selectedOpenTopoColor = getOpenTopoColor(true);
+  const selectedOpenTopoFillColor = getOpenTopoFillColor(true);
   return (
     <div className={styles.container}>
       <div className={styles.legendRow}>
@@ -32,8 +38,8 @@ function LegendContent({ selectedIconHtml }: { selectedIconHtml: string }) {
           >
             <span
               style={{
-                background: openTopoColor,
-                opacity: 0.3,
+                background: openTopoFillColor,
+                opacity: 0.4,
                 width: '100%',
                 height: '100%',
                 display: 'block',
@@ -51,8 +57,8 @@ function LegendContent({ selectedIconHtml }: { selectedIconHtml: string }) {
           >
             <span
               style={{
-                background: selectedOpenTopoColor,
-                opacity: 0.3,
+                background: selectedOpenTopoFillColor,
+                opacity: 0.4,
                 width: '100%',
                 height: '100%',
                 display: 'block',

--- a/client/modules/reconportal/src/LeafletMap/OpenTopoLayer.tsx
+++ b/client/modules/reconportal/src/LeafletMap/OpenTopoLayer.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import { GeoJSON } from 'react-leaflet';
 import { OpenTopoPopupContent } from './OpenTopoPopupContent';
-import { getOpenTopoColor } from '../utils/colors';
+import { getOpenTopoColor, getOpenTopoFillColor } from '../utils/colors';
 import { useGetOpenTopo } from '@client/hooks';
 
 import { LeafletMouseEvent } from 'leaflet';
@@ -42,8 +42,9 @@ export const OpenTopoLayer: React.FC = () => {
               selectedOpenTopoDataset === dataset.identifier.value;
             return {
               color: getOpenTopoColor(isSelected),
+              fillColor: getOpenTopoFillColor(isSelected),
               weight: isSelected ? 4 : 2,
-              fillOpacity: isSelected ? 0.6 : 0.3,
+              fillOpacity: isSelected ? 0.6 : 0.4,
               dashArray: isSelected ? '5, 10' : undefined,
             };
           }}

--- a/client/modules/reconportal/src/utils/colors.tsx
+++ b/client/modules/reconportal/src/utils/colors.tsx
@@ -7,6 +7,16 @@ export function getOpenTopoColor(isSelected?: boolean): string {
   if (isSelected) {
     return '#FFD230';
   }
+  return '#D6D3D1';
+}
+
+/**
+ * Get fill color for OpenTopo dataset
+ */
+export function getOpenTopoFillColor(isSelected?: boolean): string {
+  if (isSelected) {
+    return '#FFD230';
+  }
   return 'black';
 }
 


### PR DESCRIPTION
## Overview: ##

Update the border and fill color for OpenTopo datasets to improve visibility

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WG-563](https://tacc-main.atlassian.net/browse/WG-563)

## Summary of Changes: ##

- Added darker fill color for OpenTopo datasets to improve visibility

## Testing Steps: ##
1. Go to Recon Portal and look at OpenTopo datasets in satellite view and border view

## UI Photos:

<img width="1918" height="933" alt="Screenshot 2025-09-12 at 12 07 42 PM" src="https://github.com/user-attachments/assets/7c6e74fb-fe98-4c99-8494-74b4bca439f8" />

<img width="1918" height="933" alt="Screenshot 2025-09-12 at 12 07 51 PM" src="https://github.com/user-attachments/assets/a7630392-c409-4034-99a6-9454ec5a5bf1" />
