### PR TITLE
Fix CSS on 'add/remove files' button group

### DIFF
--- a/client/modules/datafiles/src/AddFileFolder/AddFileFolder.module.css
+++ b/client/modules/datafiles/src/AddFileFolder/AddFileFolder.module.css
@@ -48,4 +48,6 @@ a.navLink:not(:global(.active)):hover > div {
   height: 100%;
   display: flex;
   align-items: center;
+  justify-content: flex-start;
+  margin: 0.25rem 0px;
 }


### PR DESCRIPTION
## Overview: ##
Fix CSS on Add/Remove file buttons- need to overwrite CSS coming in from an updated dependency.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## UI Photos:
Before:
<img width="282" height="258" alt="image" src="https://github.com/user-attachments/assets/792b2be6-9d7e-4273-84a7-6b07ce3dd2ae" />

After:
<img width="275" height="272" alt="image" src="https://github.com/user-attachments/assets/0512b1bb-4727-4364-9b4b-1afc50193237" />


## Notes: ##
