### PR TITLE
fix(css): DSAPP-115 Tools & Apps Styles Affect Job Status Menu

### DIFF
--- a/designsafe/static/styles/app-page.css
+++ b/designsafe/static/styles/app-page.css
@@ -9,29 +9,29 @@
   margin: 0 50px;
 }
 
-.s-app-page h1 {
+.s-app-page main h1 {
     color: var(--ds-accent-color, #47a59d);
 }
-.s-app-page h2 {
+.s-app-page main h2 {
     font-size: 2.5rem;
     font-weight: 500; /* e.g. "medium" */
     text-transform: none;
 
     margin-bottom: 30px;
 }
-.s-app-page h2:not(.s-app-version-list *) {
+.s-app-page main h2:not(.s-app-version-list *) {
     color: var(--ds-accent-color, #47a59d);
 
     margin-top: 40px;
     padding-bottom: 16px;
     border-bottom: 2px solid var(--ds-accent-color, #47a59d);
 }
-.s-app-page h3:not(.s-app-version-list *):not(.c-app-card__title) {
+.s-app-page main h3:not(.s-app-version-list *):not(.c-app-card__title) {
     font-size: 1.8rem;
     margin-top: 40px; /* double Bootstrap h3 margin-top */
 }
 
-.s-app-page p {
+.s-app-page main p {
     --line-height: 1.8; /* variable so app-card.css can use */
 
     line-height: var(--line-height);
@@ -39,11 +39,11 @@
 
 /* Add more space between Bootstrap columns */
 /* HACK: Overwrite Bootstrap grid */
-.s-app-page [class*="col-"] {
+.s-app-page main [class*="col-"] {
     padding-left: 30px;
     padding-right: 30px;
 }
-.s-app-page .row {
+.s-app-page main .row {
     margin-left: -30px;
     margin-right: -30px;
 }


### PR DESCRIPTION
## Overview: ##

Do not add extra space around `<h3>`'s in the Job Status menu.

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [DSAPP-115](https://tacc-main.atlassian.net/browse/DSAPP-115)

## Summary of Changes: ##

Limit `.s-app-page` element styles to `<main>` content.

## Testing Steps: ##
1. Be logged in.
2. Open [Tools & Applications webpage](https://designsafe-ci.org/use-designsafe/tools-applications/) (not workspace).
3. Verify these links look as they do on other pages.
    - "Job Status" (near top-right of page)
    - "View All Jobs" (inside "Job Status" menu)

## UI Photos: ##

…