### PR TITLE
Using system label instead of id

### DIFF
--- a/client/modules/workspace/src/AppsWizard/FormField.tsx
+++ b/client/modules/workspace/src/AppsWizard/FormField.tsx
@@ -7,7 +7,7 @@ import {
   tapisInputFileRegex,
   TAppFileSettings,
 } from '../AppsWizard/AppsFormSchema';
-import { getExecSystemFromId } from '../utils';
+import { getExecSystemFromId, getSystemName } from '../utils';
 import { SecondaryButton } from '@client/common-components';
 import { SelectModal } from '../SelectModal/SelectModal';
 import { SystemsDocumentation } from './SystemsDocumentation';
@@ -60,7 +60,9 @@ const SystemStatus: React.FC<{
   return (
     <div style={{ display: 'flex', alignItems: 'center', marginLeft: 12 }}>
       <span style={{ marginRight: -5, marginLeft: 8 }}>
-        {value.charAt(0).toUpperCase() + value.slice(1)} status:
+        {currentExecSystem?.notes?.label ||
+          getSystemName(currentExecSystem?.host || '')}{' '}
+        status:
       </span>
       <div
         className={`${systemStatusStyles.statusBadge} ${


### PR DESCRIPTION
## Overview: ##
Using system label instead of ID on formfield

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-1081](https://tacc-main.atlassian.net/jira/software/c/projects/WP/boards/46?assignee=712020%3Aa66df098-eece-4aae-a1c3-6b226867069f&selectedIssue=WP-1081)

## Summary of Changes: ##
Old
<img width="994" height="226" alt="Screenshot 2025-09-25 at 11 22 48 AM" src="https://github.com/user-attachments/assets/da043ba3-4497-4196-b62b-88cca2c69514" />

New
<img width="505" height="122" alt="Screenshot 2025-09-26 at 2 34 17 PM" src="https://github.com/user-attachments/assets/12f21707-6496-43f9-b18a-eff2fd3b8d99" />

## Testing Steps: ##
1. Open up DS and go to Tools & Applications
2. Open Hydro-UQ Download and verify system name has changed 

## UI Photos:

## Notes: ##
