### PR TITLE
App not found for 404 errors

### DIFF
--- a/client/src/workspace/layouts/WorkspaceBaseLayout.tsx
+++ b/client/src/workspace/layouts/WorkspaceBaseLayout.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Outlet } from 'react-router-dom';
 import { Flex, Layout } from 'antd';
 import {
@@ -88,7 +89,16 @@ const WorkspaceRoot: React.FC = () => {
             />
             <AppsSideNav categories={data.categories} />
           </Sider>
-          <Outlet />
+          <ErrorBoundary
+            fallbackRender={() => (
+              <div style={{ padding: 20 }}>
+                <div>App not found</div>
+              </div>
+            )}
+          >
+            <Outlet />
+          </ErrorBoundary>
+
         </Layout>
       </Flex>
       <Toast />


### PR DESCRIPTION
## Overview: ##
If app returns 404 in the workbench, "App not found" is shown
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-916](https://tacc-main.atlassian.net/jira/software/c/projects/WP/boards/46?assignee=712020%3Aa66df098-eece-4aae-a1c3-6b226867069f&selectedIssue=WP-916)

## Summary of Changes: ##

## Testing Steps: ##
1. Go to https://designsafe.dev/workspace/invalidapp and confirm correct message shows

## UI Photos:
<img width="854" height="747" alt="Screenshot 2025-10-06 at 11 34 44 AM" src="https://github.com/user-attachments/assets/3c47d01f-c013-45d4-a960-3bfd5e6d6264" />

## Notes: ##
