### PR TITLE
fix: RT #112250 youtube videos not loading

### DIFF
--- a/designsafe/apps/cms_plugins/templates/cms_plugins/responsive_embed_plugin.html
+++ b/designsafe/apps/cms_plugins/templates/cms_plugins/responsive_embed_plugin.html
@@ -2,5 +2,7 @@
   <iframe class="embed-responsive-item"
           src="{{instance.url}}"
           frameborder="0"
-          {% if instance.allowfullscreen %}allowfullscreen{% endif %}></iframe>
+          {% if instance.allowfullscreen %}allowfullscreen{% endif %}
+          referrerpolicy="strict-origin-when-cross-origin"
+  ></iframe>
 </div>


### PR DESCRIPTION
## Overview

Add `Referrer Policy` to embeds (as [Google requires](https://developers.google.com/youtube/terms/required-minimum-functionality#embedded-player-api-client-identity)).

This would fix YouTube video embeds not loading —

> Error 153
> Video player configuration error

— on https://pprd.designsafe-ci.org/learning-center/training/ without a snippet.

> [!IMPORTANT]
> **After** deploy, **then** delete [snippet #30](https://www.designsafe-ci.org/admin/djangocms_snippet/snippet/30/change/).
> 
> <details><summary>Snippet #30 Code</summary>
> 
> ```html
> {# TODO: After DesignSafe-CI/portal#1666, delete this snippet #}
> <script type="module">
> const videoEmbeds = document.querySelectorAll('iframe[src*="youtube"]');
> videoEmbeds.forEach(function fixVideoEmbed(videoEmbed, index) {
>     const videoSource = videoEmbed.getAttribute('src');
> 
>     videoEmbed.setAttribute('referrerpolicy', 'strict-origin-when-cross-origin');
>     setTimeout(() => {
>         videoEmbed.setAttribute('src', videoSource);
>     }, index * 50); // staggered delay for each video, so browser can keep up
> });
> </script>
> ```
> 
> </details>

## PR Status

* [X] Ready
* [ ] Work in Progress
* [ ] Hold

## Related

* [RT #112250](https://consult.tacc.utexas.edu/Ticket/Display.html?id=112250)
* review requested via [WP-1125](https://tacc-main.atlassian.net/browse/WP-1125)

## Summary of Changes

Added `referrerpolicy="strict-origin-when-cross-origin"` to Embed Responsive template's `<iframe>`.

## Testing Steps

1. Load this code onto a server.
2. Create/Find a "Responsive Embed" plugin instance with YouTube video.
3. Verify video embed loads in place, no error.

> [!IMPORTANT]
> For testing on public server:
> - pre-prod:
>     1. https://pprd.designsafe-ci.org/learning-center/training/
> - prod:
>    1. delete [snippet #30](https://www.designsafe-ci.org/admin/djangocms_snippet/snippet/30/change/)
>    2. https://www.designsafe-ci.org/learning-center/training/

## UI Photos

https://github.com/user-attachments/assets/440b2028-9794-4cf1-9e5e-71c048628c7c

https://github.com/user-attachments/assets/cdd54eaa-32d1-4058-8432-06a0962eef05

## Notes

[An alternative that I tested, `referrerpolicy="no-referrer"`](https://michaelnordmeyer.com/embedding-youtube-videos-without-sending-the-sites-url-to-youtube) **failed**.