### PR TITLE
Bug/WP-1288: Fix bug where refresh_tokens would not update the TapisOauthToken model

### DIFF
--- a/designsafe/apps/auth/models.py
+++ b/designsafe/apps/auth/models.py
@@ -96,12 +96,13 @@ class TapisOAuthToken(models.Model):
 
     def refresh_tokens(self):
         """Refresh and update Tapis OAuth Tokens"""
-        self.client.refresh_tokens()
+        client = self.client
+        client.refresh_tokens()
         self.update(
             created=int(time.time()),
-            access_token=self.client.access_token.access_token,
-            refresh_token=self.client.refresh_token.refresh_token,
-            expires_in=self.client.access_token.expires_in().total_seconds(),
+            access_token=client.access_token.access_token,
+            refresh_token=client.refresh_token.refresh_token,
+            expires_in=client.access_token.expires_in().total_seconds(),
         )
 
     def __str__(self):


### PR DESCRIPTION
## Overview: ##
Fixes a subtle bug where the `refresh_tokens()` method on `TapisOauthToken` would not update the user's access token.

Explanation of the bug:
1. `self.client.refresh_tokens()` is called, which instantiates a client object using the `self.client` property method, then updates its tokens in-memory
2. When `self.update` is called, the client is instantiated **again**, using the access token saved in the database instead of the access token set on the client object in (1).
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WP-1288](https://tacc-main.atlassian.net/browse/WP-1288)

