### PR TITLE
bug/WA-529: Fix to Vista version of Jupyter HPC Native

### DIFF
--- a/client/modules/workspace/src/utils/apps.ts
+++ b/client/modules/workspace/src/utils/apps.ts
@@ -544,7 +544,6 @@ export const findAppById = (
     for (const app of category.apps) {
       if (app.app_id === appId && app.version === version) {
         return app;
-        }
       }
     }
   }

--- a/client/modules/workspace/src/utils/apps.ts
+++ b/client/modules/workspace/src/utils/apps.ts
@@ -531,17 +531,21 @@ export const useGetAppParams = () => {
  * Find app in app tray categories and get the icon info.
  * @param data TAppCategories or undefined
  * @param appId string - id of an app.
+ * @param version string - version of an app.
  * @returns icon name if available, otherwise null
  */
 export const findAppById = (
   data: TAppCategories | undefined,
-  appId: string
+  appId: string,
+  version: string
 ) => {
   if (!data) return null;
   for (const category of data.categories) {
     for (const app of category.apps) {
       if (app.app_id === appId) {
-        return app;
+        if (app.version === version) {
+          return app;
+        }
       }
     }
   }

--- a/client/modules/workspace/src/utils/apps.ts
+++ b/client/modules/workspace/src/utils/apps.ts
@@ -542,7 +542,7 @@ export const findAppById = (
   if (!data) return null;
   for (const category of data.categories) {
     for (const app of category.apps) {
-      if (app.app_id === appId && app.version === version) {
+      if (app.app_id === appId && (!version || app.version === version)) {
         return app;
       }
     }

--- a/client/modules/workspace/src/utils/apps.ts
+++ b/client/modules/workspace/src/utils/apps.ts
@@ -542,9 +542,8 @@ export const findAppById = (
   if (!data) return null;
   for (const category of data.categories) {
     for (const app of category.apps) {
-      if (app.app_id === appId) {
-        if (app.version === version) {
-          return app;
+      if (app.app_id === appId && app.version === version) {
+        return app;
         }
       }
     }

--- a/client/src/workspace/layouts/AppsViewLayout.tsx
+++ b/client/src/workspace/layouts/AppsViewLayout.tsx
@@ -17,7 +17,11 @@ export const AppsViewLayout: React.FC = () => {
   const { data: app } = useGetAppsSuspense({ appId, appVersion });
   const { data } = useAppsListing();
 
-  const portalApp = findAppById(data, app.definition.id);
+  const portalApp = findAppById(
+    data,
+    app.definition.id,
+    app.definition.version
+  );
 
   const icon = portalApp?.icon || app.definition.notes.icon || 'Generic-App';
   const userGuideLink =


### PR DESCRIPTION
## Overview: ##
The Vista version of Jupyter HPC Native had Stampede3 in the title (see screenshot)

## PR Status: ##

* [x] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WA-529](https://tacc-main.atlassian.net/browse/WA-529)

## Summary of Changes: ##
Added version check to findAppById because we are starting to use apps with the same id, but different versions for simplicity and it is causing the wrong apps to be pulled for layout purposes.

## Testing Steps: ##
1. Go to https://designsafe.dev/workspace/jupyter-hpc-native?appVersion=vista
2. You might need to add the app to the [app tray locally](https://designsafe.dev/admin/workspace/applistingentry/)
3. Verify the title is no longer incorrect.

## UI Photos:
<img width="1407" height="798" alt="Screenshot 2026-05-07 at 10 33 16 AM" src="https://github.com/user-attachments/assets/327e17db-3d5c-4d78-b391-a2ed159963bb" />

## Notes: ##
