### PR TITLE
task/WC-439: Obtain ORCID ID from TAS upon login

### DIFF
--- a/designsafe/apps/auth/tasks.py
+++ b/designsafe/apps/auth/tasks.py
@@ -60,4 +60,5 @@ def update_institution_from_tas(self, username):
     except Exception as exc:
         raise self.retry(exc=exc)
     user_model.profile.institution = tas_model.get("institution", None)
+    user_model.profile.orcid_id = tas_model.get("orcidId", None)
     user_model.profile.save()


### PR DESCRIPTION
## Overview: ##
Updates the login flow to add/refresh the ORCID ID linked to the user's TAS profile.
## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WC-439](https://tacc-main.atlassian.net/browse/WC-439)

## Summary of Changes: ##

## Testing Steps: ##
1. Link your ORCID ID to your account using TAM/TRAM
1. Authenticate to DesignSafe and check the `DesignSafeProfile` associated with your user model contains the ORCID ID from TAS.

