### PR TITLE
docs: comment instructions for PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@
 ## Summary of Changes: ##
 
 <!--
-Any important details excluded from the overview, but mayeb not clear when viewing the diff.
+Details (perhaps excluded from the simpler overview) that may be clearer as text than reading the diff.
 -->
 
 ## Testing Steps: ##

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,20 +26,11 @@ Details (perhaps excluded from the simpler overview) that may be clearer as text
 
 1. …
 
-## UI Photos:
+## UI
 
 <!--
-Any screenshots or videos to illustrate the change.
-
+Any screenshots or videos to illustrate the change:
 https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/attaching-files
-
-You're welcome to organize screenshots e.g. —
-
-| Before | After |
-| - | - |
-| <img width="900" alt="before" src="..." /> | <img width="900" alt="after" src="..." /> |
-
-— or (outside a table) drag-n-drop videos with a filename that GitHub will render as the video's title.
 -->
 
 ## Notes: ##

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## Overview: ##
+## Overview
 
 <!--
 1–3 sentences stating what problem this solves and what you changed at a high level. Example:
@@ -6,23 +6,23 @@
 "Adds/Fixes X, when Y, via Z."
 -->
 
-## PR Status: ##
+## PR Status
 
 * [X] Ready.
 * [ ] Work in Progress.
 * [ ] Hold.
 
-## Related Jira tickets: ##
+## Related Links
 
 * [DES-XXXX](https://tacc-main.atlassian.net/browse/DES-XXXX)
 
-## Summary of Changes: ##
+## Summary of Changes
 
 <!--
 Details (perhaps excluded from the simpler overview) that may be clearer as text than reading the diff.
 -->
 
-## Testing Steps: ##
+## Testing Steps
 
 1. …
 
@@ -33,7 +33,7 @@ Any screenshots or videos to illustrate the change:
 https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/attaching-files
 -->
 
-## Notes: ##
+## Notes
 
 <!--
 Optional: gotchas, known limitations, further context, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,11 @@
 ## Overview: ##
 
+<!--
+1–3 sentences stating what problem this solves and what you changed at a high level. Example:
+
+"Adds/Fixes X, when Y, via Z."
+-->
+
 ## PR Status: ##
 
 * [X] Ready.
@@ -12,9 +18,32 @@
 
 ## Summary of Changes: ##
 
+<!--
+Any important details excluded from the overview, but mayeb not clear when viewing the diff.
+-->
+
 ## Testing Steps: ##
-1. 
+
+1. …
 
 ## UI Photos:
 
+<!--
+Any screenshots or videos to illustrate the change.
+
+https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/attaching-files
+
+You're welcome to organize screenshots e.g. —
+
+| Before | After |
+| - | - |
+| <img width="900" alt="before" src="..." /> | <img width="900" alt="after" src="..." /> |
+
+— or (outside a table) drag-n-drop videos with a filename that GitHub will render as the video's title.
+-->
+
 ## Notes: ##
+
+<!--
+Optional: gotchas, known limitations, further context, etc.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,7 @@
 ## Overview
 
 <!--
-1–3 sentences stating what problem this solves and what you changed at a high level. Example:
-
-"Adds/Fixes X, when Y, via Z."
+1–3 sentences stating what problem this solves and what you changed at a high level. Example: "Adds/Fixes X, when Y, via Z."
 -->
 
 ## PR Status
@@ -29,8 +27,7 @@ Details (perhaps excluded from the simpler overview) that may be clearer as text
 ## UI
 
 <!--
-Any screenshots or videos to illustrate the change:
-https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/attaching-files
+Any screenshots or videos to illustrate the change: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/attaching-files
 -->
 
 ## Notes


### PR DESCRIPTION
## Overview: ##

Updated the pull request template to include comment descriptions for each section.

> [!NOTE]
> 💡 Consider deleting "Summary of Changes" (seems redundant given "Overview").

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* mimicked by https://github.com/TACC/Core-Portal/pull/1308

## Summary of Changes: ##

- **added** comments to `.github/pull_request_template.md`

## Testing Steps: ##

1. Verify comments are not rendered:
    https://github.com/DesignSafe-CI/portal/blob/docs/pr-template-comments/.github/pull_request_template.md

## UI Photos:

See [raw content](https://raw.githubusercontent.com/DesignSafe-CI/portal/docs/pr-template-comments/.github/pull_request_template.md) or just [the diff](https://github.com/DesignSafe-CI/portal/pull/1710/changes).

## Notes: ##

I've added different PR template comments in [TACC/Core-CMS](https://raw.githubusercontent.com/TACC/Core-CMS/refs/heads/main/.github/PULL_REQUEST_TEMPLATE.md) and [TACC/Core-Styles](https://raw.githubusercontent.com/TACC/Core-Styles/refs/heads/main/.github/PULL_REQUEST_TEMPLATE.md). This PR adds comments that respect what I have seen in DesignSafe PRs.

