### PR TITLE
task/WC-461: disable data download button on tombstoned pubs

### DIFF
--- a/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
+++ b/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
@@ -133,7 +133,7 @@ export const PublishedDetailLayout: React.FC = () => {
 
   let entitiesTombstoned = true;
   const entities = data.tree.children;
-  for (let entity of entities) {
+  for (const entity of entities) {
     if (entity.value.tombstone === undefined) {
       entitiesTombstoned = entitiesTombstoned && false;
     } else {

--- a/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
+++ b/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
@@ -131,15 +131,8 @@ export const PublishedDetailLayout: React.FC = () => {
     (c) => c.value.projectId === projectId
   )?.publicationDate;
 
-  let entitiesTombstoned = true;
   const entities = data.tree.children;
-  for (const entity of entities) {
-    if (entity.value.tombstone === undefined) {
-      entitiesTombstoned = entitiesTombstoned && false;
-    } else {
-      entitiesTombstoned = entitiesTombstoned && entity.value.tombstone;
-    }
-  }
+  const entitiesTombstoned = entities.some((e) => !!e.value.tombstone);
 
   return (
     <Layout style={{ paddingBottom: '100px' }}>

--- a/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
+++ b/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
@@ -131,6 +131,17 @@ export const PublishedDetailLayout: React.FC = () => {
     (c) => c.value.projectId === projectId
   )?.publicationDate;
 
+  let entitiesTombstoned = true;
+  const entities = data.tree.children;
+  for (let entity of entities) {
+    if (entity.value.tombstone === undefined) {
+      entitiesTombstoned = entitiesTombstoned && false;
+    }
+    else {
+      entitiesTombstoned = entitiesTombstoned && entity.value.tombstone;
+    }
+  }
+
   return (
     <Layout style={{ paddingBottom: '100px' }}>
       <div style={{ position: 'sticky', top: 0, zIndex: 1 }}>
@@ -152,10 +163,12 @@ export const PublishedDetailLayout: React.FC = () => {
           <strong>{data.baseProject.projectId}</strong> |{' '}
           {data.baseProject.title}
         </span>
-        <DownloadDatasetModal
-          projectId={projectId}
-          license={data.baseProject.license}
-        />
+        {(!data.baseProject.tombstone && !entitiesTombstoned) &&
+          <DownloadDatasetModal
+            projectId={projectId}
+            license={data.baseProject.license}
+          />
+        }
       </div>
 
       {['other', 'software'].includes(data.baseProject.projectType) && (

--- a/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
+++ b/client/src/datafiles/layouts/published/PublishedDetailLayout.tsx
@@ -136,8 +136,7 @@ export const PublishedDetailLayout: React.FC = () => {
   for (let entity of entities) {
     if (entity.value.tombstone === undefined) {
       entitiesTombstoned = entitiesTombstoned && false;
-    }
-    else {
+    } else {
       entitiesTombstoned = entitiesTombstoned && entity.value.tombstone;
     }
   }
@@ -163,12 +162,12 @@ export const PublishedDetailLayout: React.FC = () => {
           <strong>{data.baseProject.projectId}</strong> |{' '}
           {data.baseProject.title}
         </span>
-        {(!data.baseProject.tombstone && !entitiesTombstoned) &&
+        {!data.baseProject.tombstone && !entitiesTombstoned && (
           <DownloadDatasetModal
             projectId={projectId}
             license={data.baseProject.license}
           />
-        }
+        )}
       </div>
 
       {['other', 'software'].includes(data.baseProject.projectType) && (


### PR DESCRIPTION
## Overview
Disables the data download button if a type other publication is tombstoned, or if **all** entities of a not-type other are tombstoned.

## PR Status

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Links

* [WC-461](https://tacc-main.atlassian.net/browse/WC-461)
* [WC-482](https://tacc-main.atlassian.net/browse/WC-482)

## Summary of Changes
Adds a check to determine if the data download button should be disabled when tombstones are in place

## Testing Steps
1. Go to any publication that is not tombstoned and make sure the data download button is there.
2. Go to any tombstoned publication (type other) and make sure the data download button is not there.
3. Go to PRJ-5755 (you may need to load a more recent db into your local if the mission is not tombstoned) and make sure the data download button is there.

## UI


## Notes
Only PRJ-5755 as of this PR has two entities and only one is tombstoned, hence why we're keeping the data download button if not all entities are tombstoned.  We will be restricting access to the tombstoned entity's files via filesystem permissions changes.
