### PR TITLE
fix: update internal URLs for moved content

### DIFF
--- a/designsafe/templates/base.j2
+++ b/designsafe/templates/base.j2
@@ -165,10 +165,10 @@
         '/rw/simcenter-research-tools/',
         '/learning-center/simcenter-learning-tools/',
         '/community/mechs/',
-        '/rw/user-guides/',
         '/help/user-guides/',
         '/help/getting-started/',
-        '/rw/use-cases/',
+        '/user-guide/',
+        '/use-cases/'
         '/faq/',
     ];
     const pathsToPDFs = [


### PR DESCRIPTION
## Overview

Update some JavaScript for URLs that have changed.

<details>
<summary>How were the redirects working without this?</summary>

[Snippet #9](https://www.designsafe-ci.org/admin/djangocms_snippet/snippet/9/) adds them as `pathsToForceSetTarget` in its own (possibly now redundant) JavaScript.

</details>

## PR Status

* In Progress

## Related Links

* snippet saved in #1717

## Summary of Changes

- **changed** two outdated paths

## Testing Steps

0. Temporarily disable [snippet #9](https://www.designsafe-ci.org/admin/djangocms_snippet/snippet/9/change/).
1. Find in CMS nav menu this link:
    - Use DesignSafe
        - User Guide
2. Click link.
3. Ensure new window/tab opens.

## UI

> [!WARNING]
> Untested.
