### PR TITLE
WC-467: Integrate ORCID ID into the curation and publication pipeline

### DIFF
--- a/client/modules/_hooks/src/datafiles/projects/types.ts
+++ b/client/modules/_hooks/src/datafiles/projects/types.ts
@@ -5,6 +5,7 @@ export type TProjectUser = {
   inst: string;
   role: 'pi' | 'co_pi' | 'team_member' | 'guest';
   username?: string;
+  orcidId?: string;
   authorship?: boolean;
 };
 

--- a/client/modules/_hooks/src/useAuthenticatedUser.ts
+++ b/client/modules/_hooks/src/useAuthenticatedUser.ts
@@ -6,6 +6,7 @@ export type TUser = {
   institution: string;
   homedir: string;
   isStaff: boolean;
+  orcidId?: string;
   setupComplete: boolean;
 };
 

--- a/client/modules/datafiles/src/projects/ProjectPipeline/PipelineOrderAuthors.tsx
+++ b/client/modules/datafiles/src/projects/ProjectPipeline/PipelineOrderAuthors.tsx
@@ -1,7 +1,73 @@
 import { TProjectUser, useProjectDetail } from '@client/hooks';
-import { Button } from 'antd';
+import { Button, Form, Input, Modal } from 'antd';
 import { useSearchParams } from 'react-router-dom';
 import { usePatchEntityMetadata } from '@client/hooks';
+import React, { useState } from 'react';
+import { customRequiredMark } from '../forms/_common';
+
+const AddOrcidModal: React.FC<
+  React.PropsWithChildren<{
+    entityUuid: string;
+    authorList: TProjectUser[];
+    index: number;
+  }>
+> = ({ children, entityUuid, authorList, index }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { mutate } = usePatchEntityMetadata();
+  const [form] = Form.useForm();
+
+  function addOrcidId(orcidId: string) {
+    authorList[index] = { ...authorList[index], orcidId: orcidId };
+    mutate({ entityUuid, patchMetadata: { authors: authorList } });
+  }
+
+  function onFinish(orcidId: string) {
+    addOrcidId(orcidId);
+    setIsModalOpen(false);
+  }
+
+  return (
+    <>
+      <Button type="link" onClick={() => setIsModalOpen(!isModalOpen)}>
+        {children}
+      </Button>
+      <Modal
+        open={isModalOpen}
+        title={`Add ORCID ID for ${authorList[index].fname} ${authorList[index].lname}`}
+        onOk={form.submit}
+        onCancel={() => setIsModalOpen(false)}
+      >
+        <div>
+          Learn more about ORCID and look up IDs:{' '}
+          <a
+            href="https://orcid.org/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            https://orcid.org/
+          </a>
+          <Form
+            form={form}
+            initialValues={{ orcidId: authorList[index].orcidId }}
+            onFinish={(formData) => onFinish(formData.orcidId)} //addOrcidId(formData.orcidId)}
+            requiredMark={customRequiredMark}
+            layout="vertical"
+            style={{ marginTop: '1rem' }}
+          >
+            <Form.Item
+              required
+              rules={[{ required: true }]}
+              name="orcidId"
+              label="ORCID ID"
+            >
+              <Input></Input>
+            </Form.Item>
+          </Form>
+        </div>
+      </Modal>
+    </>
+  );
+};
 
 export const PipelineOrderAuthors: React.FC<{
   projectId: string;
@@ -134,7 +200,28 @@ export const PipelineOrderAuthors: React.FC<{
                   {(entity.value.authors ?? []).map((author, idx, arr) => (
                     <tr key={`${author.email}-${author.fname}-${author.lname}`}>
                       <td style={{ verticalAlign: 'middle' }}>
-                        {author.lname}, {author.fname}
+                        {author.lname}, {author.fname}{' '}
+                        {author.orcidId ? (
+                          <span>
+                            (ORCID: {author.orcidId}{' '}
+                            <AddOrcidModal
+                              authorList={arr}
+                              entityUuid={entity.uuid}
+                              index={idx}
+                            >
+                              Edit
+                            </AddOrcidModal>
+                            )
+                          </span>
+                        ) : (
+                          <AddOrcidModal
+                            authorList={arr}
+                            entityUuid={entity.uuid}
+                            index={idx}
+                          >
+                            Add ORCID ID
+                          </AddOrcidModal>
+                        )}
                       </td>
                       <td>
                         <span> &nbsp;</span>

--- a/client/modules/datafiles/src/projects/forms/CreateProjectForm.tsx
+++ b/client/modules/datafiles/src/projects/forms/CreateProjectForm.tsx
@@ -29,6 +29,7 @@ export const BaseProjectCreateForm: React.FC<{
         username: user?.username,
         email: user?.email,
         inst: user?.institution,
+        orcidId: user?.orcidId,
         role: 'pi',
       },
     ]);

--- a/client/modules/datafiles/src/projects/forms/_fields/GuestMembersInput.tsx
+++ b/client/modules/datafiles/src/projects/forms/_fields/GuestMembersInput.tsx
@@ -12,56 +12,74 @@ export const GuestMembersInput: React.FC<{ name: string }> = ({ name }) => {
           ].map(({ key, name }) => {
             const disabled = fields.length === 0;
             return (
-              <div style={{ display: 'flex', gap: '1rem' }} key={key}>
-                <Form.Item
-                  rules={[{ required: !disabled }]}
-                  label="First Name"
-                  name={disabled ? undefined : [name, 'fname']}
-                  className="flex-1"
+              <div
+                style={{ display: 'flex', flexDirection: 'column' }}
+                key={key}
+              >
+                <div
+                  style={{ display: 'flex', flexDirection: 'row', gap: '1rem' }}
                 >
-                  <Input disabled={disabled} />
-                </Form.Item>
-                <Form.Item
-                  rules={[{ required: !disabled }]}
-                  label="Last Name"
-                  name={disabled ? undefined : [name, 'lname']}
-                  className="flex-1"
-                >
-                  <Input disabled={disabled} />
-                </Form.Item>
-                <Form.Item
-                  rules={disabled ? undefined : [{ required: !disabled }]}
-                  label="Email"
-                  name={[name, 'email']}
-                  className="flex-1"
-                >
-                  <Input disabled={disabled} />
-                </Form.Item>
-                <Form.Item
-                  rules={[{ required: !disabled }]}
-                  label="Institution"
-                  name={disabled ? undefined : [name, 'inst']}
-                  className="flex-2"
-                >
-                  <Input disabled={disabled} />
-                </Form.Item>
-                <Form.Item
-                  hidden
-                  name={disabled ? undefined : [name, 'role']}
-                  initialValue="guest"
-                >
-                  <Input hidden />
-                </Form.Item>
-                <Form.Item label="&nbsp;" hidden={disabled}>
-                  <Button
-                    type="primary"
-                    danger
-                    onClick={() => remove(name)}
-                    aria-label="Remove Guest Member"
+                  <Form.Item
+                    rules={[{ required: !disabled }]}
+                    label="First Name"
+                    name={disabled ? undefined : [name, 'fname']}
+                    className="flex-1"
                   >
-                    <i role="none" className="fa fa-times"></i>
-                  </Button>
-                </Form.Item>
+                    <Input disabled={disabled} />
+                  </Form.Item>
+                  <Form.Item
+                    rules={[{ required: !disabled }]}
+                    label="Last Name"
+                    name={disabled ? undefined : [name, 'lname']}
+                    className="flex-1"
+                  >
+                    <Input disabled={disabled} />
+                  </Form.Item>
+                  <Form.Item
+                    rules={disabled ? undefined : [{ required: !disabled }]}
+                    label="Email"
+                    name={[name, 'email']}
+                    className="flex-1"
+                  >
+                    <Input disabled={disabled} />
+                  </Form.Item>
+                </div>
+                <div
+                  style={{ display: 'flex', flexDirection: 'row', gap: '1rem' }}
+                >
+                  <Form.Item
+                    rules={[{ required: !disabled }]}
+                    label="Institution"
+                    name={disabled ? undefined : [name, 'inst']}
+                    className="flex-2"
+                  >
+                    <Input disabled={disabled} />
+                  </Form.Item>
+                  <Form.Item
+                    label="ORCID ID"
+                    name={disabled ? undefined : [name, 'orcidId']}
+                    className="flex-2"
+                  >
+                    <Input disabled={disabled} />
+                  </Form.Item>
+                  <Form.Item
+                    hidden
+                    name={disabled ? undefined : [name, 'role']}
+                    initialValue="guest"
+                  >
+                    <Input hidden />
+                  </Form.Item>
+                  <Form.Item label="&nbsp;" hidden={disabled}>
+                    <Button
+                      type="primary"
+                      danger
+                      onClick={() => remove(name)}
+                      aria-label="Remove Guest Member"
+                    >
+                      <i role="none" className="fa fa-times"></i>
+                    </Button>
+                  </Form.Item>
+                </div>
               </div>
             );
           })}

--- a/designsafe/apps/api/projects_v2/operations/datacite_operations.py
+++ b/designsafe/apps/api/projects_v2/operations/datacite_operations.py
@@ -58,21 +58,28 @@ def get_datacite_json(
         author for author in authors if not author.get("authorship") is False
     ]
     for author in datacite_authors:
-        author_attr.append(
-            {
-                "name": f"{author.get('lname', '')}, {author.get('fname', '')}",
-                "givenName": author.get("fname", ""),
-                "familyName": author.get("lname", ""),
-                "affiliation": [
-                    {
-                        "name": author.get("inst", ""),
-                        "schemeUri": None,
-                        "affiliationIdentifier": None,
-                        "affiliationIdentifierScheme": None,
-                    }
-                ],
-            }
-        )
+        author_meta = {
+            "name": f"{author.get('lname', '')}, {author.get('fname', '')}",
+            "givenName": author.get("fname", ""),
+            "familyName": author.get("lname", ""),
+            "affiliation": [
+                {
+                    "name": author.get("inst", ""),
+                    "schemeUri": None,
+                    "affiliationIdentifier": None,
+                    "affiliationIdentifierScheme": None,
+                }
+            ],
+        }
+        if author.get("orcidId"):
+            author_meta["nameIdentifiers"] = [
+                {
+                    "schemeUri": "https://orcid.org",
+                    "nameIdentifier": f"https://orcid.org/{author.get("orcidId")}",
+                    "nameIdentifierScheme": "ORCID",
+                }
+            ]
+        author_attr.append(author_meta)
         if inst := author.get("inst", ""):
             institutions.append(inst)
 

--- a/designsafe/apps/api/projects_v2/schema_models/_field_models.py
+++ b/designsafe/apps/api/projects_v2/schema_models/_field_models.py
@@ -43,6 +43,7 @@ class ProjectUser(MetadataModel):
     inst: Optional[str] = None
     user: Optional[str] = None
     username: Optional[str] = None
+    orcid_id: Optional[str] = None
     role: Optional[Literal["pi", "co_pi", "team_member", "guest"]] = None
 
     authorship: Optional[bool] = None

--- a/designsafe/apps/api/users/views.py
+++ b/designsafe/apps/api/users/views.py
@@ -150,6 +150,7 @@ class ProjectUserView(BaseApiView):
                 "fname": u.first_name,
                 "lname": u.last_name,
                 "inst": u.profile.institution,
+                "orcidId": getattr(u.profile, "orcid_id", None),
                 "email": u.email,
                 "username": u.username,
             }

--- a/designsafe/templates/base.j2
+++ b/designsafe/templates/base.j2
@@ -150,6 +150,7 @@
             lastName: "{{ request.user.last_name }}",
             email: "{{ request.user.email }}",
             institution: "{{ request.user.profile.institution }}",
+            orcidId: "{{ request.user.profile.orcid_id }}"
             homedir: "{{tas_homedir}}",
             isStaff: {{ request.user.is_staff|yesno:"true,false" }},
             setupComplete: {{ request.user.profile.setup_complete|yesno:"true,false" }},


### PR DESCRIPTION
## Overview
If the user has an ORCID ID associated with their user profile via TAM, that ID will be added to the project metadata along with the rest of their profile information. If a team members haven't set their ORCID ID, it can be added during the "Order Authors" step in the pipeline. The ORCID ID is passed through the pipeline and added to the DataCite metadata.

## PR Status

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Links

* [WC-467](https://tacc-main.atlassian.net/browse/WC-467)

## Summary of Changes
- Automatically grab the user's ORCID ID when they are added to a project, if it is saved in their profile.
- Add an ORCID ID field for guest members
- Update DataCite with any ORCID IDs stored in the published metadata at the end of the pipeline
- Add a form to update authors' ORCID IDs from the "Order Authors step in the pipeline

## Testing Steps

1. Add a user to a 

## UI

<img width="537" height="235" alt="image" src="https://github.com/user-attachments/assets/af417708-91bd-4b8e-ac20-67c03a3bec7c" />
<img width="885" height="281" alt="image" src="https://github.com/user-attachments/assets/c99885fe-06ac-4286-9cba-c3d78a1df5a5" />


## Notes

<!--
Optional: gotchas, known limitations, further context, etc.
-->
