### PR TITLE
docs(settings): clarify DEFAULT_FILE_STORAGE comment

### DIFF
--- a/designsafe/settings/common_settings.py
+++ b/designsafe/settings/common_settings.py
@@ -292,8 +292,11 @@ STORAGES = {
     },
 }
 
-# djangocms-forms-maintained still reads the legacy setting while using the
-# Django 5 storage registry. Keep it sourced from the canonical configuration.
+# djangocms-forms-maintained (TACC/djangocms-forms fork) predates Django's
+# STORAGES registry (added in 4.2) and only reads the legacy
+# DEFAULT_FILE_STORAGE setting via its AppConf. Derive it from
+# STORAGES["default"]["BACKEND"] above so the two settings can't drift apart
+# if the storage backend ever changes.
 DEFAULT_FILE_STORAGE = STORAGES["default"]["BACKEND"]
 
 STATICFILES_FINDERS = (


### PR DESCRIPTION
## Overview

Clarifies the `DEFAULT_FILE_STORAGE` comment in `common_settings.py` that a reviewer on PR #1716 found confusing.

## PR Status

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Links

https://github.com/DesignSafe-CI/portal/pull/1716#discussion_r3668680193

## Summary of Changes

* **reworded** the comment above `DEFAULT_FILE_STORAGE` to name djangocms-forms-maintained and explain why it needs the setting derived from `STORAGES`

## Testing Steps

1. N/A — comment-only change, no behavior affected.

## UI

N/A

## Notes

No functional change; the derivation `DEFAULT_FILE_STORAGE = STORAGES["default"]["BACKEND"]` is unchanged.