### PR TITLE
bug/WC-521: Fix listings/previews for paths with special characters

### DIFF
--- a/client/modules/_hooks/src/datafiles/useFileDetail.ts
+++ b/client/modules/_hooks/src/datafiles/useFileDetail.ts
@@ -10,7 +10,9 @@ async function getFileDetail(
   { signal }: { signal: AbortSignal }
 ) {
   const res = await apiClient.get<TFileListing>(
-    `/api/datafiles/${api}/${scheme}/detail/${system}/${encodeURIComponent(path)}`,
+    `/api/datafiles/${api}/${scheme}/detail/${system}/${encodeURIComponent(
+      path
+    )}`,
     { signal }
   );
   return res.data;

--- a/client/modules/_hooks/src/datafiles/useFileDetail.ts
+++ b/client/modules/_hooks/src/datafiles/useFileDetail.ts
@@ -10,7 +10,7 @@ async function getFileDetail(
   { signal }: { signal: AbortSignal }
 ) {
   const res = await apiClient.get<TFileListing>(
-    `/api/datafiles/${api}/${scheme}/detail/${system}/${path}`,
+    `/api/datafiles/${api}/${scheme}/detail/${system}/${encodeURIComponent(path)}`,
     { signal }
   );
   return res.data;

--- a/client/modules/_hooks/src/datafiles/useFilePreview.ts
+++ b/client/modules/_hooks/src/datafiles/useFilePreview.ts
@@ -37,7 +37,7 @@ async function getFilePreview({
   signal,
 }: TPreviewParams & { signal: AbortSignal }) {
   const res = await apiClient.get<TFilePreviewResponse>(
-    `/api/datafiles/${api}/${scheme}/preview/${system}/${path}`,
+    `/api/datafiles/${api}/${scheme}/preview/${system}/${encodeURIComponent(path)}`,
     { params: { doi }, signal }
   );
   return res.data;

--- a/client/modules/_hooks/src/datafiles/useFilePreview.ts
+++ b/client/modules/_hooks/src/datafiles/useFilePreview.ts
@@ -37,7 +37,9 @@ async function getFilePreview({
   signal,
 }: TPreviewParams & { signal: AbortSignal }) {
   const res = await apiClient.get<TFilePreviewResponse>(
-    `/api/datafiles/${api}/${scheme}/preview/${system}/${encodeURIComponent(path)}`,
+    `/api/datafiles/${api}/${scheme}/preview/${system}/${encodeURIComponent(
+      path
+    )}`,
     { params: { doi }, signal }
   );
   return res.data;

--- a/client/modules/datafiles/src/DatafilesModal/CopyModal/CopyModal.tsx
+++ b/client/modules/datafiles/src/DatafilesModal/CopyModal/CopyModal.tsx
@@ -129,7 +129,7 @@ export const CopyModal: React.FC<{
     () => ({
       destApi: 'tapis',
       destSystem: USER_MYDATA_SYSTEM,
-      destPath: encodeURIComponent('/' + user?.username),
+      destPath: `/${user?.username}`,
     }),
     [user]
   );
@@ -157,7 +157,7 @@ export const CopyModal: React.FC<{
         setDest({
           destApi: 'tapis',
           destSystem: USER_WORK_SYSTEM,
-          destPath: encodeURIComponent('/work/' + user?.homedir),
+          destPath: `/work/${user?.homedir}`,
         });
         break;
       case 'myprojects':
@@ -187,7 +187,7 @@ export const CopyModal: React.FC<{
         return;
       }
       const newPath = path.split('/').slice(-1)[0];
-      setDest({ ...dest, destPath: newPath });
+      setDest({ ...dest, destPath: decodeURIComponent(newPath) });
     },
     [dest]
   );
@@ -266,7 +266,7 @@ export const CopyModal: React.FC<{
                   <BaseFileListingBreadcrumb
                     api={destApi}
                     system={destSystem}
-                    path={decodeURIComponent(destPath)}
+                    path={destPath}
                     systemRootAlias={dest.destProjectId}
                     initialBreadcrumbs={
                       destSystem.startsWith('project-')

--- a/client/src/datafiles/layouts/published/PublishedEntityListingLayout.tsx
+++ b/client/src/datafiles/layouts/published/PublishedEntityListingLayout.tsx
@@ -30,7 +30,7 @@ export const PublishedEntityListingLayout: React.FC = () => {
               api="tapis"
               system="designsafe.storage.published"
               scheme="public"
-              path={encodeURIComponent(`${selectedBasePath}/data`)}
+              path={`${selectedBasePath}/data`}
               emptyListingDisplay={
                 data.baseProject.projectType === 'software'
                   ? 'File Unavailable'

--- a/designsafe/apps/api/datafiles/operations/tapis_operations.py
+++ b/designsafe/apps/api/datafiles/operations/tapis_operations.py
@@ -53,7 +53,7 @@ def listing(client, system, path, offset=0, limit=100, q=None, *args, **kwargs):
         return search(client, system, path, offset=0, limit=100, query_string=q, **kwargs)
     raw_listing = client.files.listFiles(
         systemId=system,
-        path=(path or '/'),
+        path=urllib.parse.quote((path or '/')),
         offset=int(offset),
         limit=int(limit),
         headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")}
@@ -597,7 +597,7 @@ def preview(client, system, path, href="", max_uses=3, lifetime=600, *args, **kw
     except FileMetaModel.DoesNotExist:
         meta = {}
 
-    postit_result = client.files.createPostIt(systemId=system, path=path, allowedUses=max_uses, validSeconds=lifetime, headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
+    postit_result = client.files.createPostIt(systemId=system, path=urllib.parse.quote(path), allowedUses=max_uses, validSeconds=lifetime, headers={"X-Tapis-Tracking-ID": kwargs.get("tapis_tracking_id", "")})
     url = postit_result.redeemUrl
 
     if file_ext in settings.SUPPORTED_TEXT_PREVIEW_EXTS:


### PR DESCRIPTION
## Overview
Fix listings/previews for paths with special characters by ensuring paths are properly URL-encoded before being passed to Tapis.

## PR Status

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Links

* [WC-521](https://tacc-main.atlassian.net/browse/WC-521)

## Summary of Changes
- URL-encode paths on the client-side before passing them to the backend, and on the server side before passing them to Tapis. 
- Unify URL encoding behavior across the Move and Copy modals.
- Remove redundant URL encoding in published file listings. 

## Testing Steps

1. Perform listing/preview operations on projects/publications with special characters (PRJ-5808, PRJ-6312).
